### PR TITLE
test(finance): lock legacy total behavior (#8)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ module.exports = defineConfig([
     },
   },
   {
-    files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
+    files: ['jest.setup.js', '**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
     languageOptions: {
       globals: {
         ...globals.jest,

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '!src/i18n/languages.ts',
   ],
   coverageDirectory: 'coverage',
+  setupFiles: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "export:web": "expo export --platform web",
     "build:web": "expo export --platform web",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --max-warnings=83",
+    "lint": "eslint . --max-warnings=80",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/contexts/AnalyticsContext.tsx
+++ b/src/contexts/AnalyticsContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useMemo } from 'react';
-import { useHistoryStore, useOrderStore, useMenuStore } from '../stores';
-import { DayHistory, MenuItem, TicketLine } from '../types';
+import React, { createContext, useContext } from 'react';
+import { useHistoryStore, useMenuStore } from '../stores';
+import { DayHistory, MenuItem } from '../types';
+import { calculateLinesTotal, isBillableLine } from '../utils/financeUtils';
 
 export interface SalesAnalytics {
   totalRevenue: number;
@@ -108,10 +109,7 @@ export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
   const { menuItems, categories } = useMenuStore();
 
   const calculateTicketTotal = (ticket: any): number => {
-    return ticket.lines.reduce(
-      (sum: number, line: any) => sum + line.quantity * line.priceSnapshot,
-      0,
-    );
+    return calculateLinesTotal(ticket.lines);
   };
 
   const filterDataByDateRange = (data: DayHistory[], dateRange?: DateRange): DayHistory[] => {
@@ -162,6 +160,8 @@ export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
 
         // Item and category analysis
         ticket.lines.forEach((line) => {
+          if (!isBillableLine(line)) return;
+
           const item = menuItems.find((m) => m.id === line.menuItemId);
           if (item) {
             const itemRevenue = line.quantity * line.priceSnapshot;

--- a/src/stores/__tests__/financialBehavior.test.ts
+++ b/src/stores/__tests__/financialBehavior.test.ts
@@ -1,0 +1,144 @@
+import { generateDateKey } from '../../constants/branding';
+import { Ticket, TicketLine } from '../../types';
+import { useHistoryStore } from '../historyStore';
+import { useLayoutStore } from '../layoutStore';
+import { useMenuStore } from '../menuStore';
+import { useOrderStore } from '../orderStore';
+
+jest.mock('../../services/notificationService', () => ({
+  notificationService: {
+    cancelDeliveryNotifications: jest.fn(),
+    scheduleDeliveryNotifications: jest.fn().mockResolvedValue([]),
+  },
+}));
+
+const now = new Date('2026-07-26T13:00:00.000Z');
+
+function createLine(overrides: Partial<TicketLine> = {}): TicketLine {
+  return {
+    id: 'line-1',
+    menuItemId: 'item-1',
+    nameSnapshot: 'Patates Kızartması',
+    priceSnapshot: 400,
+    quantity: 1,
+    status: 'pending',
+    createdAt: now.getTime(),
+    updatedAt: now.getTime(),
+    ...overrides,
+  };
+}
+
+function createTicket(overrides: Partial<Ticket> = {}): Ticket {
+  return {
+    id: 'ticket-1',
+    tableId: 'table-1',
+    status: 'open',
+    createdAt: now.getTime(),
+    lines: [],
+    ...overrides,
+  };
+}
+
+describe('legacy financial behavior', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+
+    useHistoryStore.setState({ dailyHistory: {} });
+    useLayoutStore.setState({ halls: [], tables: [] });
+    useMenuStore.setState({ categories: [], menuItems: [] });
+    useOrderStore.setState({ openTickets: {} });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('excludes cancelled lines from open and paid totals', () => {
+    const ticket = createTicket({
+      lines: [
+        createLine({ id: 'billable', priceSnapshot: 400, quantity: 2 }),
+        createLine({
+          id: 'cancelled',
+          priceSnapshot: 900,
+          quantity: 3,
+          status: 'cancelled',
+        }),
+      ],
+    });
+
+    useOrderStore.setState({ openTickets: { [ticket.id]: ticket } });
+
+    expect(useOrderStore.getState().getTicketTotal(ticket.id)).toBe(800);
+
+    useOrderStore.getState().closeTicket(ticket.id, {
+      total: 800,
+      amountReceived: 800,
+      change: 0,
+      paymentMethod: 'cash',
+    });
+
+    const history = useHistoryStore.getState().getDayHistory(generateDateKey(now));
+    expect(history?.totals.gross).toBe(800);
+  });
+
+  it('keeps open-ticket exposure separate from paid revenue', () => {
+    const ticket = createTicket({
+      lines: [createLine({ priceSnapshot: 1250, quantity: 2 })],
+    });
+
+    useOrderStore.setState({ openTickets: { [ticket.id]: ticket } });
+
+    expect(useOrderStore.getState().getTodayTotal()).toBe(2500);
+    expect(useHistoryStore.getState().getTotalGrossForDate(generateDateKey(now))).toBe(0);
+
+    useOrderStore.getState().closeTicket(ticket.id, {
+      total: 2500,
+      paymentMethod: 'card',
+    });
+
+    expect(useOrderStore.getState().getTodayTotal()).toBe(0);
+    expect(useHistoryStore.getState().getTotalGrossForDate(generateDateKey(now))).toBe(2500);
+  });
+
+  it('preserves historical item name and price snapshots after menu mutations', () => {
+    useMenuStore.setState({
+      categories: [{ id: 'category-1', name: 'Atıştırmalık', order: 0 }],
+      menuItems: [
+        {
+          id: 'item-1',
+          categoryId: 'category-1',
+          name: 'Patates Kızartması',
+          price: 400,
+          isActive: true,
+        },
+      ],
+    });
+
+    const ticket = createTicket();
+    useOrderStore.setState({ openTickets: { [ticket.id]: ticket } });
+
+    useOrderStore.getState().addTicketLine(ticket.id, {
+      menuItemId: 'item-1',
+      quantity: 2,
+    });
+    useMenuStore.getState().updateMenuItem('item-1', {
+      name: 'Büyük Patates',
+      price: 700,
+    });
+    useOrderStore.getState().closeTicket(ticket.id, {
+      total: 800,
+      paymentMethod: 'card',
+    });
+
+    const historicalTicket = useHistoryStore.getState().getDayHistory(generateDateKey(now))
+      ?.tickets[0];
+
+    expect(historicalTicket?.lines[0]).toMatchObject({
+      nameSnapshot: 'Patates Kızartması',
+      priceSnapshot: 400,
+      quantity: 2,
+    });
+    expect(useHistoryStore.getState().getTotalGrossForDate(generateDateKey(now))).toBe(800);
+  });
+});

--- a/src/stores/historyStore.ts
+++ b/src/stores/historyStore.ts
@@ -4,6 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { DayHistory, Ticket } from '../types';
 import { generateDateKey } from '../constants/branding';
 import { useMenuStore } from './menuStore';
+import { isBillableLine } from '../utils/financeUtils';
 
 interface HistoryState {
   dailyHistory: Record<string, DayHistory>; // date -> history
@@ -162,6 +163,8 @@ function calculateDayTotals(tickets: Ticket[]): {
 
   tickets.forEach((ticket) => {
     ticket.lines.forEach((line) => {
+      if (!isBillableLine(line)) return;
+
       const lineTotal = line.priceSnapshot * line.quantity;
       gross += lineTotal;
 

--- a/src/stores/orderStore.ts
+++ b/src/stores/orderStore.ts
@@ -7,6 +7,7 @@ import { useLayoutStore } from './layoutStore';
 import { useMenuStore } from './menuStore';
 import { useHistoryStore } from './historyStore';
 import { notificationService } from '../services/notificationService';
+import { calculateLinesTotal } from '../utils/financeUtils';
 
 interface OrderState {
   openTickets: Record<string, Ticket>; // ticketId -> ticket
@@ -329,11 +330,7 @@ export const useOrderStore = create<OrderState>()(
         const ticket = get().openTickets[ticketId];
         if (!ticket) return 0;
 
-        return ticket.lines.reduce((total, line) => {
-          // Exclude cancelled items from total calculation
-          if (line.status === 'cancelled') return total;
-          return total + line.priceSnapshot * line.quantity;
-        }, 0);
+        return calculateLinesTotal(ticket.lines);
       },
 
       getAllOpenTickets: () => {

--- a/src/utils/financeUtils.ts
+++ b/src/utils/financeUtils.ts
@@ -1,0 +1,14 @@
+import { TicketLine } from '../types';
+
+type BillableLine = Pick<TicketLine, 'priceSnapshot' | 'quantity' | 'status'>;
+
+export function isBillableLine(line: Pick<TicketLine, 'status'>): boolean {
+  return line.status !== 'cancelled';
+}
+
+export function calculateLinesTotal(lines: BillableLine[]): number {
+  return lines.reduce(
+    (total, line) => (isBillableLine(line) ? total + line.priceSnapshot * line.quantity : total),
+    0,
+  );
+}


### PR DESCRIPTION
## Summary
- add regression coverage for cancelled lines, paid-vs-open totals and immutable menu snapshots
- centralize the legacy billable-line rule in `financeUtils`
- fix daily history and analytics so cancelled lines are not counted as revenue or item sales
- add an AsyncStorage Jest setup for deterministic Zustand store tests
- remove three unused imports and lower the pinned lint ceiling from 83 to 80

## Verification
- `npm run verify:full`
  - 2 Jest suites / 7 tests
  - TypeScript, format and lint gates
  - Expo web production export
  - Chromium smoke test

## Stack
This PR is stacked on #34 and targets `chore/7-quality-baseline`. Retarget after the parent PR lands.

Closes #8
