### PR TITLE
feat(domain): introduce Orderia v2 model (#9)

### DIFF
--- a/src/domain/__tests__/financialRules.test.ts
+++ b/src/domain/__tests__/financialRules.test.ts
@@ -1,0 +1,321 @@
+import {
+  assertCheckCanBeMarkedPaid,
+  assertPaymentAllocations,
+  assertPaymentTender,
+  assertSettlementInvariants,
+  assertSessionCanClose,
+  calculateCheckBalance,
+  calculateCheckTotal,
+  calculateOrderItemTotal,
+  deriveCheckStatus,
+  Check,
+  CheckId,
+  DeviceId,
+  MenuItemId,
+  MutationId,
+  OrderBatchId,
+  OrderItem,
+  OrderItemId,
+  OrderItemModifier,
+  OrderItemModifierId,
+  OrganizationId,
+  Payment,
+  PaymentAllocation,
+  PaymentAllocationId,
+  PaymentId,
+  RestaurantTableId,
+  TableSessionId,
+  UserId,
+  BranchId,
+  toCurrencyCode,
+  toDomainId,
+} from '..';
+
+const organizationId = toDomainId<OrganizationId>('organization-1');
+const branchId = toDomainId<BranchId>('branch-1');
+const sessionId = toDomainId<TableSessionId>('session-1');
+const checkId = toDomainId<CheckId>('check-1');
+const userId = toDomainId<UserId>('user-1');
+const deviceId = toDomainId<DeviceId>('device-1');
+const tableId = toDomainId<RestaurantTableId>('table-1');
+const batchId = toDomainId<OrderBatchId>('batch-1');
+const mutationId = toDomainId<MutationId>('mutation-1');
+const euro = toCurrencyCode('EUR');
+const timestamp = '2026-07-26T13:00:00.000Z';
+
+function createCheck(overrides: Partial<Check> = {}): Check {
+  return {
+    id: checkId,
+    organizationId,
+    branchId,
+    tableSessionId: sessionId,
+    name: 'Kişi 1',
+    status: 'open',
+    openedBy: userId,
+    openedAt: timestamp,
+    version: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    syncStatus: 'synced',
+    ...overrides,
+  };
+}
+
+function createItem(id: string, overrides: Partial<OrderItem> = {}): OrderItem {
+  return {
+    id: toDomainId<OrderItemId>(id),
+    organizationId,
+    branchId,
+    tableSessionId: sessionId,
+    checkId,
+    orderBatchId: batchId,
+    menuItemId: toDomainId<MenuItemId>('menu-item-1'),
+    nameSnapshot: 'Patates Kızartması',
+    categoryNameSnapshot: 'Atıştırmalık',
+    unitPriceMinor: 400,
+    currencyCode: euro,
+    taxRateBasisPoints: 2_000,
+    quantity: 2,
+    status: 'ordered',
+    createdBy: userId,
+    updatedBy: userId,
+    originalTableId: tableId,
+    originalTableSessionId: sessionId,
+    version: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    syncStatus: 'synced',
+    ...overrides,
+  };
+}
+
+function createModifier(
+  orderItemId: OrderItemId,
+  overrides: Partial<OrderItemModifier> = {},
+): OrderItemModifier {
+  return {
+    id: toDomainId<OrderItemModifierId>(`modifier-${orderItemId}`),
+    orderItemId,
+    modifierGroupNameSnapshot: 'Peynir',
+    modifierOptionNameSnapshot: 'Peynirli',
+    priceDeltaMinor: 50,
+    quantity: 1,
+    ...overrides,
+  };
+}
+
+function createPayment(id: string, amountMinor: number, overrides: Partial<Payment> = {}): Payment {
+  return {
+    id: toDomainId<PaymentId>(id),
+    organizationId,
+    branchId,
+    tableSessionId: sessionId,
+    method: 'card',
+    status: 'confirmed',
+    amountMinor,
+    currencyCode: euro,
+    createdBy: userId,
+    createdAt: timestamp,
+    confirmedAt: timestamp,
+    idempotencyKey: `key-${id}`,
+    deviceId,
+    syncStatus: 'synced',
+    clientMutationId: mutationId,
+    ...overrides,
+  };
+}
+
+function createAllocation(
+  paymentId: PaymentId,
+  amountMinor: number,
+  overrides: Partial<PaymentAllocation> = {},
+): PaymentAllocation {
+  return {
+    id: toDomainId<PaymentAllocationId>(`allocation-${paymentId}-${amountMinor}`),
+    paymentId,
+    checkId,
+    amountMinor,
+    ...overrides,
+  };
+}
+
+describe('Orderia v2 financial invariants', () => {
+  it('uses order-time modifier snapshots and excludes cancelled items', () => {
+    const ordered = createItem('ordered-item');
+    const cancelled = createItem('cancelled-item', {
+      unitPriceMinor: 9_999,
+      status: 'cancelled',
+    });
+    const modifiers = [createModifier(ordered.id)];
+
+    expect(calculateOrderItemTotal(ordered, modifiers)).toBe(900);
+    expect(calculateOrderItemTotal(cancelled, modifiers)).toBe(0);
+    expect(calculateCheckTotal(checkId, [ordered, cancelled], modifiers)).toBe(900);
+  });
+
+  it('requires allocations to reconcile exactly with the payment amount', () => {
+    const item = createItem('item-1');
+    const payment = createPayment('payment-1', 900);
+
+    expect(() =>
+      assertPaymentAllocations(
+        payment,
+        [
+          createAllocation(payment.id, 900, {
+            orderItemId: item.id,
+            quantity: 2,
+          }),
+        ],
+        [createCheck()],
+        [item],
+        [createModifier(item.id)],
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      assertPaymentAllocations(
+        payment,
+        [createAllocation(payment.id, 899)],
+        [createCheck()],
+        [item],
+        [createModifier(item.id)],
+      ),
+    ).toThrow(/does not equal payment amount/);
+  });
+
+  it('prevents an order item amount or quantity from being over-allocated', () => {
+    const item = createItem('item-1');
+    const payment = createPayment('payment-1', 901);
+
+    expect(() =>
+      assertPaymentAllocations(
+        payment,
+        [
+          createAllocation(payment.id, 901, {
+            orderItemId: item.id,
+            quantity: 2,
+          }),
+        ],
+        [createCheck()],
+        [item],
+        [createModifier(item.id)],
+      ),
+    ).toThrow(/over-allocated/);
+
+    const quantityPayment = createPayment('payment-2', 900);
+    expect(() =>
+      assertPaymentAllocations(
+        quantityPayment,
+        [
+          createAllocation(quantityPayment.id, 900, {
+            orderItemId: item.id,
+            quantity: 3,
+          }),
+        ],
+        [createCheck()],
+        [item],
+        [createModifier(item.id)],
+      ),
+    ).toThrow(/quantity is over-allocated/);
+  });
+
+  it('derives partial and paid states only from confirmed allocations', () => {
+    const item = createItem('item-1');
+    const modifiers = [createModifier(item.id)];
+    const pending = createPayment('pending-payment', 400, { status: 'pending' });
+    const confirmed = createPayment('confirmed-payment', 400);
+    const allocations = [createAllocation(pending.id, 400), createAllocation(confirmed.id, 400)];
+
+    const partialBalance = calculateCheckBalance(
+      createCheck(),
+      [item],
+      modifiers,
+      [pending, confirmed],
+      allocations,
+    );
+
+    expect(partialBalance).toEqual({
+      totalMinor: 900,
+      paidMinor: 400,
+      remainingMinor: 500,
+    });
+    expect(deriveCheckStatus(partialBalance)).toBe('partially_paid');
+    expect(() => assertCheckCanBeMarkedPaid(partialBalance)).toThrow(/remain/);
+
+    const finalPayment = createPayment('final-payment', 500);
+    const paidBalance = calculateCheckBalance(
+      createCheck({ status: 'partially_paid' }),
+      [item],
+      modifiers,
+      [confirmed, finalPayment],
+      [createAllocation(confirmed.id, 400), createAllocation(finalPayment.id, 500)],
+    );
+
+    expect(deriveCheckStatus(paidBalance)).toBe('paid');
+    expect(() => assertCheckCanBeMarkedPaid(paidBalance)).not.toThrow();
+  });
+
+  it('prevents separate confirmed payments from over-allocating the same item', () => {
+    const firstItem = createItem('item-1', { quantity: 1 });
+    const secondItem = createItem('item-2', { quantity: 1 });
+    const firstPayment = createPayment('payment-1', 400);
+    const secondPayment = createPayment('payment-2', 400);
+
+    expect(() =>
+      assertSettlementInvariants(
+        [createCheck()],
+        [firstItem, secondItem],
+        [],
+        [firstPayment, secondPayment],
+        [
+          createAllocation(firstPayment.id, 400, {
+            orderItemId: firstItem.id,
+            quantity: 1,
+          }),
+          createAllocation(secondPayment.id, 400, {
+            orderItemId: firstItem.id,
+            quantity: 1,
+          }),
+        ],
+      ),
+    ).toThrow(/over-allocate order item/);
+  });
+
+  it('does not close a table session with unsettled named checks', () => {
+    expect(() =>
+      assertSessionCanClose([
+        createCheck({ id: toDomainId<CheckId>('check-paid'), status: 'paid' }),
+        createCheck({ id: toDomainId<CheckId>('check-open'), status: 'open' }),
+      ]),
+    ).toThrow(/unsettled/);
+
+    expect(() =>
+      assertSessionCanClose([
+        createCheck({ id: toDomainId<CheckId>('check-paid'), status: 'paid' }),
+        createCheck({ id: toDomainId<CheckId>('check-voided'), status: 'voided' }),
+      ]),
+    ).not.toThrow();
+  });
+
+  it('reconciles cash tender and change in minor units', () => {
+    expect(() =>
+      assertPaymentTender(
+        createPayment('cash-payment', 800, {
+          method: 'cash',
+          tenderedMinor: 1_000,
+          changeMinor: 200,
+        }),
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      assertPaymentTender(
+        createPayment('bad-cash-payment', 800, {
+          method: 'cash',
+          tenderedMinor: 1_000,
+          changeMinor: 199,
+        }),
+      ),
+    ).toThrow(/Cash change/);
+  });
+});

--- a/src/domain/__tests__/moneyAndBusinessDate.test.ts
+++ b/src/domain/__tests__/moneyAndBusinessDate.test.ts
@@ -1,0 +1,49 @@
+import {
+  addMoney,
+  getBusinessDate,
+  money,
+  multiplyMoney,
+  toBusinessDayCutoff,
+  toCurrencyCode,
+} from '..';
+
+describe('money', () => {
+  const euro = toCurrencyCode('eur');
+
+  it('uses integer minor units and preserves currency', () => {
+    expect(addMoney(money(400, euro), multiplyMoney(money(50, euro), 2))).toEqual({
+      amountMinor: 500,
+      currencyCode: 'EUR',
+    });
+  });
+
+  it('rejects floating-point amounts and mixed currencies', () => {
+    expect(() => money(4.2, euro)).toThrow(/safe integer/);
+    expect(() => addMoney(money(400, euro), money(400, toCurrencyCode('BGN')))).toThrow(
+      /Currency mismatch/,
+    );
+  });
+});
+
+describe('branch-aware business dates', () => {
+  const cutoff = toBusinessDayCutoff('05:00');
+
+  it('assigns pre-cutoff activity to the previous Sofia business day', () => {
+    expect(getBusinessDate('2026-07-26T01:30:00.000Z', 'Europe/Sofia', cutoff)).toBe('2026-07-25');
+    expect(getBusinessDate('2026-07-26T02:30:00.000Z', 'Europe/Sofia', cutoff)).toBe('2026-07-26');
+  });
+
+  it('uses the branch timezone instead of the device timezone', () => {
+    const instant = '2026-07-26T07:30:00.000Z';
+
+    expect(getBusinessDate(instant, 'Europe/Sofia', cutoff)).toBe('2026-07-26');
+    expect(getBusinessDate(instant, 'America/New_York', cutoff)).toBe('2026-07-25');
+  });
+
+  it('rejects invalid cutoffs and timezones', () => {
+    expect(() => toBusinessDayCutoff('25:00')).toThrow(/Invalid business-day cutoff/);
+    expect(() => getBusinessDate(Date.now(), 'Sofia/Invalid', cutoff)).toThrow(
+      /Invalid IANA time zone/,
+    );
+  });
+});

--- a/src/domain/__tests__/stateAndReceiptRules.test.ts
+++ b/src/domain/__tests__/stateAndReceiptRules.test.ts
@@ -1,0 +1,131 @@
+import {
+  assertCheckTransition,
+  assertIssuedReceiptUnchanged,
+  assertOrderItemTransition,
+  assertPaymentTransition,
+  assertReceiptStatusTransition,
+  assertTableSessionTransition,
+  assertValidReceipt,
+  BranchId,
+  CheckId,
+  OrganizationId,
+  OrderItemId,
+  PaymentId,
+  Receipt,
+  ReceiptId,
+  TableSessionId,
+  UserId,
+  getBusinessDate,
+  toBusinessDayCutoff,
+  toCurrencyCode,
+  toDomainId,
+} from '..';
+
+const organizationId = toDomainId<OrganizationId>('organization-1');
+const branchId = toDomainId<BranchId>('branch-1');
+const sessionId = toDomainId<TableSessionId>('session-1');
+const checkId = toDomainId<CheckId>('check-1');
+const receiptId = toDomainId<ReceiptId>('receipt-1');
+const userId = toDomainId<UserId>('user-1');
+const issuedAt = '2026-07-26T13:00:00.000Z';
+const euro = toCurrencyCode('EUR');
+
+function createReceipt(overrides: Partial<Receipt> = {}): Receipt {
+  const paymentId = toDomainId<PaymentId>('payment-1');
+  const itemId = toDomainId<OrderItemId>('item-1');
+
+  return {
+    id: receiptId,
+    organizationId,
+    branchId,
+    tableSessionId: sessionId,
+    checkId,
+    receiptNumber: 'SOF-20260726-0001',
+    businessDate: getBusinessDate(issuedAt, 'Europe/Sofia', toBusinessDayCutoff('05:00')),
+    issuedAt,
+    issuedBy: userId,
+    totalMinor: 800,
+    currencyCode: euro,
+    status: 'issued',
+    snapshot: {
+      schemaVersion: 1,
+      organizationName: 'Orderia Demo',
+      branchName: 'Sofia Center',
+      branchTimezone: 'Europe/Sofia',
+      tableLabel: 'Masa 4',
+      openedAt: '2026-07-26T12:00:00.000Z',
+      issuedAt,
+      waiterDisplayNames: ['Ayşe'],
+      checks: [
+        {
+          checkId,
+          name: 'Kişi 1',
+          items: [
+            {
+              orderItemId: itemId,
+              name: 'Patates Kızartması',
+              modifiers: [],
+              unitPriceMinor: 400,
+              quantity: 2,
+              lineTotalMinor: 800,
+            },
+          ],
+          totalMinor: 800,
+        },
+      ],
+      payments: [
+        {
+          paymentId,
+          method: 'card',
+          amountMinor: 800,
+          confirmedAt: issuedAt,
+          createdByDisplayName: 'Ayşe',
+        },
+      ],
+      totalMinor: 800,
+      currencyCode: euro,
+    },
+    ...overrides,
+  };
+}
+
+describe('domain state transitions', () => {
+  it('allows operational forward transitions', () => {
+    expect(() => assertOrderItemTransition('ordered', 'served')).not.toThrow();
+    expect(() => assertCheckTransition('open', 'partially_paid')).not.toThrow();
+    expect(() => assertTableSessionTransition('payment_pending', 'closed')).not.toThrow();
+    expect(() => assertPaymentTransition('pending', 'confirmed')).not.toThrow();
+  });
+
+  it('rejects reopened terminal financial states', () => {
+    expect(() => assertOrderItemTransition('cancelled', 'ordered')).toThrow(/Invalid/);
+    expect(() => assertCheckTransition('paid', 'open')).toThrow(/Invalid/);
+    expect(() => assertPaymentTransition('confirmed', 'voided')).toThrow(/Invalid/);
+    expect(() => assertReceiptStatusTransition('issued', 'voided')).toThrow(/immutable/);
+  });
+});
+
+describe('immutable receipt rules', () => {
+  it('reconciles snapshot, check and receipt totals', () => {
+    expect(() => assertValidReceipt(createReceipt())).not.toThrow();
+    expect(() =>
+      assertValidReceipt(
+        createReceipt({
+          totalMinor: 801,
+        }),
+      ),
+    ).toThrow(/snapshot total/);
+  });
+
+  it('requires corrections to create a separate adjustment receipt', () => {
+    const original = createReceipt();
+
+    expect(() => assertIssuedReceiptUnchanged(original, { ...original })).not.toThrow();
+    expect(() =>
+      assertIssuedReceiptUnchanged(original, {
+        ...original,
+        pdfStoragePath: 'receipts/re-rendered.pdf',
+      }),
+    ).toThrow(/adjustment receipt/);
+  });
+});

--- a/src/domain/businessDate.ts
+++ b/src/domain/businessDate.ts
@@ -1,0 +1,94 @@
+declare const businessDateBrand: unique symbol;
+declare const businessDayCutoffBrand: unique symbol;
+
+export type BusinessDate = string & {
+  readonly [businessDateBrand]: 'BusinessDate';
+};
+
+export type BusinessDayCutoff = string & {
+  readonly [businessDayCutoffBrand]: 'BusinessDayCutoff';
+};
+
+interface LocalDateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+export function toBusinessDayCutoff(value: string): BusinessDayCutoff {
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value);
+
+  if (!match) {
+    throw new Error(`Invalid business-day cutoff: ${value}`);
+  }
+
+  return value as BusinessDayCutoff;
+}
+
+export function getBusinessDate(
+  timestamp: Date | number | string,
+  timeZone: string,
+  cutoff: BusinessDayCutoff,
+): BusinessDate {
+  const instant = timestamp instanceof Date ? timestamp : new Date(timestamp);
+
+  if (Number.isNaN(instant.getTime())) {
+    throw new Error('Business date requires a valid timestamp');
+  }
+
+  const local = getLocalDateTimeParts(instant, timeZone);
+  const [cutoffHour, cutoffMinute] = cutoff.split(':').map(Number);
+  const beforeCutoff =
+    local.hour < cutoffHour || (local.hour === cutoffHour && local.minute < cutoffMinute);
+
+  if (!beforeCutoff) {
+    return formatBusinessDate(local.year, local.month, local.day);
+  }
+
+  const previousDay = new Date(Date.UTC(local.year, local.month - 1, local.day) - 86_400_000);
+  return formatBusinessDate(
+    previousDay.getUTCFullYear(),
+    previousDay.getUTCMonth() + 1,
+    previousDay.getUTCDate(),
+  );
+}
+
+function getLocalDateTimeParts(instant: Date, timeZone: string): LocalDateTimeParts {
+  let parts: Intl.DateTimeFormatPart[];
+
+  try {
+    parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(instant);
+  } catch {
+    throw new Error(`Invalid IANA time zone: ${timeZone}`);
+  }
+
+  const values = Object.fromEntries(
+    parts.filter((part) => part.type !== 'literal').map((part) => [part.type, Number(part.value)]),
+  );
+
+  return {
+    year: values.year,
+    month: values.month,
+    day: values.day,
+    hour: values.hour,
+    minute: values.minute,
+  };
+}
+
+function formatBusinessDate(year: number, month: number, day: number): BusinessDate {
+  return [
+    year.toString().padStart(4, '0'),
+    month.toString().padStart(2, '0'),
+    day.toString().padStart(2, '0'),
+  ].join('-') as BusinessDate;
+}

--- a/src/domain/entities.ts
+++ b/src/domain/entities.ts
@@ -1,0 +1,306 @@
+import { BusinessDate, BusinessDayCutoff } from './businessDate';
+import {
+  AuditEventId,
+  BranchId,
+  CancellationReasonId,
+  CheckId,
+  CorrelationId,
+  DeviceId,
+  HallId,
+  MembershipId,
+  MenuCategoryId,
+  MenuItemId,
+  MutationId,
+  OrderBatchId,
+  OrderItemId,
+  OrderItemModifierId,
+  OrganizationId,
+  PaymentAllocationId,
+  PaymentId,
+  ReceiptId,
+  RestaurantTableId,
+  TableSessionId,
+  UserId,
+} from './ids';
+import { CurrencyCode } from './money';
+
+export type IsoTimestamp = string;
+export type JsonPrimitive = boolean | number | string | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { readonly [key: string]: JsonValue };
+
+export type OrganizationPlan = 'trial' | 'starter' | 'growth' | 'enterprise';
+export type OrganizationStatus = 'active' | 'suspended' | 'closed';
+export type BranchStatus = 'active' | 'suspended' | 'closed';
+export type MembershipRole = 'waiter' | 'manager';
+export type MembershipStatus = 'invited' | 'active' | 'suspended';
+export type DevicePlatform = 'android' | 'ios_web' | 'web';
+export type SyncStatus = 'synced' | 'pending' | 'conflict' | 'rejected';
+export type TableSessionStatus = 'open' | 'payment_pending' | 'closed' | 'voided';
+export type CheckStatus = 'open' | 'partially_paid' | 'paid' | 'voided';
+export type OrderItemStatus = 'draft' | 'ordered' | 'served' | 'cancelled';
+export type PaymentMethod = 'cash' | 'card' | 'mixed_adjustment';
+export type PaymentStatus = 'pending' | 'confirmed' | 'failed' | 'voided';
+export type ReceiptStatus = 'issued' | 'adjusted' | 'voided';
+
+export interface VersionedMetadata {
+  readonly version: number;
+  readonly createdAt: IsoTimestamp;
+  readonly updatedAt: IsoTimestamp;
+  readonly deletedAt?: IsoTimestamp;
+}
+
+export interface SyncMetadata {
+  readonly syncStatus: SyncStatus;
+  readonly clientMutationId?: MutationId;
+  readonly serverVersion?: number;
+  readonly lastSyncedAt?: IsoTimestamp;
+}
+
+export interface TenantScope {
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+}
+
+export interface Organization {
+  readonly id: OrganizationId;
+  readonly name: string;
+  readonly slug: string;
+  readonly plan: OrganizationPlan;
+  readonly status: OrganizationStatus;
+  readonly createdAt: IsoTimestamp;
+}
+
+export interface Branch extends VersionedMetadata {
+  readonly id: BranchId;
+  readonly organizationId: OrganizationId;
+  readonly name: string;
+  readonly timezone: string;
+  readonly currencyCode: CurrencyCode;
+  readonly businessDayCutoff: BusinessDayCutoff;
+  readonly receiptPrefix: string;
+  readonly status: BranchStatus;
+  readonly allowOfflinePayments: boolean;
+}
+
+export interface Profile {
+  readonly id: UserId;
+  readonly displayName: string;
+  readonly email: string;
+  readonly avatarUrl?: string;
+  readonly locale: string;
+  readonly createdAt: IsoTimestamp;
+}
+
+export interface Membership {
+  readonly id: MembershipId;
+  readonly organizationId: OrganizationId;
+  readonly branchId?: BranchId;
+  readonly userId: UserId;
+  readonly role: MembershipRole;
+  readonly status: MembershipStatus;
+  readonly createdAt: IsoTimestamp;
+  readonly deletedAt?: IsoTimestamp;
+}
+
+export interface Device extends TenantScope {
+  readonly id: DeviceId;
+  readonly userId: UserId;
+  readonly platform: DevicePlatform;
+  readonly appVersion: string;
+  readonly lastSeenAt: IsoTimestamp;
+  readonly lastSyncAt?: IsoTimestamp;
+  readonly pushEndpoint?: string;
+  readonly revokedAt?: IsoTimestamp;
+}
+
+export interface Hall extends TenantScope, VersionedMetadata, SyncMetadata {
+  readonly id: HallId;
+  readonly name: string;
+  readonly sortOrder: number;
+}
+
+export interface RestaurantTable extends TenantScope, VersionedMetadata, SyncMetadata {
+  readonly id: RestaurantTableId;
+  readonly hallId: HallId;
+  readonly label: string;
+  readonly sequenceNumber: number;
+  readonly capacity?: number;
+  readonly sortOrder: number;
+}
+
+export interface TableSession extends TenantScope, VersionedMetadata, SyncMetadata {
+  readonly id: TableSessionId;
+  readonly tableId: RestaurantTableId;
+  readonly status: TableSessionStatus;
+  readonly openedBy: UserId;
+  readonly openedAt: IsoTimestamp;
+  readonly closedBy?: UserId;
+  readonly closedAt?: IsoTimestamp;
+  readonly guestCount?: number;
+  readonly note?: string;
+  readonly transferredFromTableId?: RestaurantTableId;
+}
+
+export interface SessionParticipant {
+  readonly tableSessionId: TableSessionId;
+  readonly userId: UserId;
+  readonly firstActionAt: IsoTimestamp;
+  readonly lastActionAt: IsoTimestamp;
+}
+
+export interface Check extends TenantScope, VersionedMetadata, SyncMetadata {
+  readonly id: CheckId;
+  readonly tableSessionId: TableSessionId;
+  readonly name: string;
+  readonly note?: string;
+  readonly status: CheckStatus;
+  readonly openedBy: UserId;
+  readonly openedAt: IsoTimestamp;
+  readonly closedAt?: IsoTimestamp;
+}
+
+export interface OrderBatch extends TenantScope, SyncMetadata {
+  readonly id: OrderBatchId;
+  readonly tableSessionId: TableSessionId;
+  readonly checkId: CheckId;
+  readonly createdBy: UserId;
+  readonly createdAt: IsoTimestamp;
+  readonly clientMutationId: MutationId;
+}
+
+export interface OrderItem extends TenantScope, VersionedMetadata, SyncMetadata {
+  readonly id: OrderItemId;
+  readonly tableSessionId: TableSessionId;
+  readonly checkId: CheckId;
+  readonly orderBatchId: OrderBatchId;
+  readonly menuItemId?: MenuItemId;
+  readonly nameSnapshot: string;
+  readonly categoryIdSnapshot?: MenuCategoryId;
+  readonly categoryNameSnapshot?: string;
+  readonly unitPriceMinor: number;
+  readonly currencyCode: CurrencyCode;
+  readonly taxRateBasisPoints: number;
+  readonly quantity: number;
+  readonly status: OrderItemStatus;
+  readonly note?: string;
+  readonly createdBy: UserId;
+  readonly updatedBy: UserId;
+  readonly cancelledBy?: UserId;
+  readonly cancelledAt?: IsoTimestamp;
+  readonly cancellationReasonId?: CancellationReasonId;
+  readonly originalTableId: RestaurantTableId;
+  readonly originalTableSessionId: TableSessionId;
+}
+
+export interface OrderItemModifier {
+  readonly id: OrderItemModifierId;
+  readonly orderItemId: OrderItemId;
+  readonly modifierGroupNameSnapshot: string;
+  readonly modifierOptionNameSnapshot: string;
+  readonly priceDeltaMinor: number;
+  readonly quantity: number;
+}
+
+export interface Payment extends TenantScope, SyncMetadata {
+  readonly id: PaymentId;
+  readonly tableSessionId: TableSessionId;
+  readonly method: PaymentMethod;
+  readonly status: PaymentStatus;
+  readonly amountMinor: number;
+  readonly tenderedMinor?: number;
+  readonly changeMinor?: number;
+  readonly currencyCode: CurrencyCode;
+  readonly createdBy: UserId;
+  readonly createdAt: IsoTimestamp;
+  readonly confirmedAt?: IsoTimestamp;
+  readonly idempotencyKey: string;
+  readonly deviceId: DeviceId;
+}
+
+export interface PaymentAllocation {
+  readonly id: PaymentAllocationId;
+  readonly paymentId: PaymentId;
+  readonly checkId: CheckId;
+  readonly orderItemId?: OrderItemId;
+  readonly quantity?: number;
+  readonly amountMinor: number;
+}
+
+export interface ReceiptSnapshotItem {
+  readonly orderItemId: OrderItemId;
+  readonly name: string;
+  readonly modifiers: readonly {
+    readonly name: string;
+    readonly priceDeltaMinor: number;
+    readonly quantity: number;
+  }[];
+  readonly unitPriceMinor: number;
+  readonly quantity: number;
+  readonly lineTotalMinor: number;
+}
+
+export interface ReceiptSnapshotCheck {
+  readonly checkId: CheckId;
+  readonly name: string;
+  readonly note?: string;
+  readonly items: readonly ReceiptSnapshotItem[];
+  readonly totalMinor: number;
+}
+
+export interface ReceiptSnapshotPayment {
+  readonly paymentId: PaymentId;
+  readonly method: PaymentMethod;
+  readonly amountMinor: number;
+  readonly confirmedAt: IsoTimestamp;
+  readonly createdByDisplayName: string;
+}
+
+export interface ReceiptSnapshot {
+  readonly schemaVersion: 1;
+  readonly organizationName: string;
+  readonly branchName: string;
+  readonly branchTimezone: string;
+  readonly tableLabel: string;
+  readonly openedAt: IsoTimestamp;
+  readonly issuedAt: IsoTimestamp;
+  readonly waiterDisplayNames: readonly string[];
+  readonly checks: readonly ReceiptSnapshotCheck[];
+  readonly payments: readonly ReceiptSnapshotPayment[];
+  readonly totalMinor: number;
+  readonly currencyCode: CurrencyCode;
+}
+
+export interface Receipt extends TenantScope {
+  readonly id: ReceiptId;
+  readonly tableSessionId: TableSessionId;
+  readonly checkId: CheckId;
+  readonly receiptNumber: string;
+  readonly businessDate: BusinessDate;
+  readonly issuedAt: IsoTimestamp;
+  readonly issuedBy: UserId;
+  readonly totalMinor: number;
+  readonly currencyCode: CurrencyCode;
+  readonly snapshot: ReceiptSnapshot;
+  readonly pdfStoragePath?: string;
+  readonly pdfHash?: string;
+  readonly status: ReceiptStatus;
+  readonly adjustsReceiptId?: ReceiptId;
+}
+
+export interface AuditMetadata {
+  readonly actorUserId: UserId;
+  readonly deviceId: DeviceId;
+  readonly occurredAt: IsoTimestamp;
+  readonly clientMutationId: MutationId;
+  readonly correlationId: CorrelationId;
+}
+
+export interface AuditEvent extends TenantScope, AuditMetadata {
+  readonly id: AuditEventId;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly action: string;
+  readonly before?: JsonValue;
+  readonly after?: JsonValue;
+  readonly reason?: string;
+}

--- a/src/domain/financialRules.ts
+++ b/src/domain/financialRules.ts
@@ -1,0 +1,374 @@
+import {
+  Check,
+  CheckStatus,
+  OrderItem,
+  OrderItemModifier,
+  Payment,
+  PaymentAllocation,
+} from './entities';
+import { CheckId, OrderItemId, PaymentId } from './ids';
+import { assertMinorUnits, assertSameCurrency } from './money';
+
+export interface CheckBalance {
+  readonly totalMinor: number;
+  readonly paidMinor: number;
+  readonly remainingMinor: number;
+}
+
+export function calculateOrderItemTotal(
+  item: OrderItem,
+  modifiers: readonly OrderItemModifier[],
+): number {
+  assertPositiveInteger(item.quantity, 'order item quantity');
+  assertNonNegativeMinor(item.unitPriceMinor, 'unitPriceMinor');
+
+  if (
+    !Number.isSafeInteger(item.taxRateBasisPoints) ||
+    item.taxRateBasisPoints < 0 ||
+    item.taxRateBasisPoints > 10_000
+  ) {
+    throw new Error('taxRateBasisPoints must be an integer from 0 to 10000');
+  }
+
+  if (item.status === 'cancelled') {
+    return 0;
+  }
+
+  const modifierTotalMinor = modifiers
+    .filter((modifier) => modifier.orderItemId === item.id)
+    .reduce((total, modifier) => {
+      assertPositiveInteger(modifier.quantity, 'modifier quantity');
+      assertMinorUnits(modifier.priceDeltaMinor, 'priceDeltaMinor');
+      return assertMinorUnits(total + modifier.priceDeltaMinor * modifier.quantity);
+    }, 0);
+
+  const unitTotalMinor = item.unitPriceMinor + modifierTotalMinor;
+  assertNonNegativeMinor(unitTotalMinor, 'order item unit total');
+
+  return assertMinorUnits(unitTotalMinor * item.quantity);
+}
+
+export function calculateCheckTotal(
+  checkId: CheckId,
+  items: readonly OrderItem[],
+  modifiers: readonly OrderItemModifier[],
+): number {
+  const checkItems = items.filter((item) => item.checkId === checkId);
+
+  if (checkItems.length > 1) {
+    const currency = checkItems[0].currencyCode;
+    checkItems.slice(1).forEach((item) => assertSameCurrency(currency, item.currencyCode));
+  }
+
+  return checkItems.reduce(
+    (total, item) => assertMinorUnits(total + calculateOrderItemTotal(item, modifiers)),
+    0,
+  );
+}
+
+export function calculateCheckBalance(
+  check: Check,
+  items: readonly OrderItem[],
+  modifiers: readonly OrderItemModifier[],
+  payments: readonly Payment[],
+  allocations: readonly PaymentAllocation[],
+): CheckBalance {
+  const totalMinor = calculateCheckTotal(check.id, items, modifiers);
+  const confirmedPaymentIds = new Set(
+    payments.filter((payment) => payment.status === 'confirmed').map((payment) => payment.id),
+  );
+  const paidMinor = allocations
+    .filter(
+      (allocation) =>
+        allocation.checkId === check.id && confirmedPaymentIds.has(allocation.paymentId),
+    )
+    .reduce(
+      (total, allocation) =>
+        assertMinorUnits(total + assertNonNegativeMinor(allocation.amountMinor, 'allocation')),
+      0,
+    );
+
+  if (paidMinor > totalMinor) {
+    throw new Error(`Check ${check.id} is over-allocated by ${paidMinor - totalMinor} minor units`);
+  }
+
+  return {
+    totalMinor,
+    paidMinor,
+    remainingMinor: totalMinor - paidMinor,
+  };
+}
+
+export function deriveCheckStatus(balance: CheckBalance): CheckStatus {
+  if (balance.paidMinor === 0) {
+    return 'open';
+  }
+
+  if (balance.remainingMinor === 0) {
+    return 'paid';
+  }
+
+  return 'partially_paid';
+}
+
+export function assertCheckCanBeMarkedPaid(balance: CheckBalance): void {
+  if (balance.totalMinor <= 0) {
+    throw new Error('A zero-value check must be voided instead of paid');
+  }
+
+  if (balance.remainingMinor !== 0) {
+    throw new Error(`Check cannot be paid while ${balance.remainingMinor} minor units remain`);
+  }
+}
+
+export function assertSessionCanClose(checks: readonly Check[]): void {
+  const unsettled = checks.filter((check) => check.status !== 'paid' && check.status !== 'voided');
+
+  if (unsettled.length > 0) {
+    throw new Error(`Session cannot close with ${unsettled.length} unsettled check(s)`);
+  }
+}
+
+export function assertPaymentAllocations(
+  payment: Payment,
+  allocations: readonly PaymentAllocation[],
+  checks: readonly Check[],
+  items: readonly OrderItem[],
+  modifiers: readonly OrderItemModifier[],
+): void {
+  assertPaymentTender(payment);
+
+  const paymentAllocations = allocations.filter(
+    (allocation) => allocation.paymentId === payment.id,
+  );
+
+  if (paymentAllocations.length !== allocations.length) {
+    throw new Error(`Allocations contain a payment ID other than ${payment.id}`);
+  }
+
+  const allocationTotal = paymentAllocations.reduce(
+    (total, allocation) =>
+      assertMinorUnits(total + assertPositiveMinor(allocation.amountMinor, 'allocation amount')),
+    0,
+  );
+
+  if (allocationTotal !== payment.amountMinor) {
+    throw new Error(
+      `Payment allocation total ${allocationTotal} does not equal payment amount ${payment.amountMinor}`,
+    );
+  }
+
+  const itemAmounts = new Map<OrderItemId, number>();
+  const itemQuantities = new Map<OrderItemId, number>();
+
+  paymentAllocations.forEach((allocation) => {
+    const check = checks.find((candidate) => candidate.id === allocation.checkId);
+    if (!check) {
+      throw new Error(`Allocation references unknown check ${allocation.checkId}`);
+    }
+
+    if (
+      check.tableSessionId !== payment.tableSessionId ||
+      check.organizationId !== payment.organizationId ||
+      check.branchId !== payment.branchId
+    ) {
+      throw new Error('Allocation check is outside the payment tenant or table session');
+    }
+
+    if (allocation.quantity !== undefined && allocation.orderItemId === undefined) {
+      throw new Error('Allocation quantity requires an orderItemId');
+    }
+
+    if (!allocation.orderItemId) return;
+
+    const item = items.find((candidate) => candidate.id === allocation.orderItemId);
+    if (!item) {
+      throw new Error(`Allocation references unknown order item ${allocation.orderItemId}`);
+    }
+
+    if (item.checkId !== allocation.checkId) {
+      throw new Error('Allocation check does not own the referenced order item');
+    }
+
+    if (
+      item.tableSessionId !== payment.tableSessionId ||
+      item.organizationId !== payment.organizationId ||
+      item.branchId !== payment.branchId
+    ) {
+      throw new Error('Allocated order item is outside the payment tenant or table session');
+    }
+
+    assertSameCurrency(payment.currencyCode, item.currencyCode);
+    itemAmounts.set(item.id, (itemAmounts.get(item.id) ?? 0) + allocation.amountMinor);
+
+    if (allocation.quantity !== undefined) {
+      assertPositiveInteger(allocation.quantity, 'allocation quantity');
+      itemQuantities.set(item.id, (itemQuantities.get(item.id) ?? 0) + allocation.quantity);
+    }
+  });
+
+  itemAmounts.forEach((amountMinor, itemId) => {
+    const item = findOrderItem(items, itemId);
+    const billableMinor = calculateOrderItemTotal(item, modifiers);
+
+    if (amountMinor > billableMinor) {
+      throw new Error(`Order item ${itemId} is over-allocated by ${amountMinor - billableMinor}`);
+    }
+  });
+
+  itemQuantities.forEach((quantity, itemId) => {
+    const item = findOrderItem(items, itemId);
+
+    if (quantity > item.quantity) {
+      throw new Error(`Order item ${itemId} quantity is over-allocated`);
+    }
+  });
+}
+
+export function assertPaymentTender(payment: Payment): void {
+  assertPositiveMinor(payment.amountMinor, 'payment amount');
+
+  if (payment.method === 'cash') {
+    if (payment.tenderedMinor === undefined) {
+      throw new Error('Cash payment requires tenderedMinor');
+    }
+
+    const tenderedMinor = assertNonNegativeMinor(payment.tenderedMinor, 'tenderedMinor');
+    if (tenderedMinor < payment.amountMinor) {
+      throw new Error('Cash tender cannot be lower than the payment amount');
+    }
+
+    const expectedChange = tenderedMinor - payment.amountMinor;
+    if (payment.changeMinor !== expectedChange) {
+      throw new Error(`Cash change must equal ${expectedChange} minor units`);
+    }
+
+    return;
+  }
+
+  if (payment.changeMinor !== undefined && payment.changeMinor !== 0) {
+    throw new Error('Non-cash payments cannot return change');
+  }
+
+  if (payment.tenderedMinor !== undefined && payment.tenderedMinor !== payment.amountMinor) {
+    throw new Error('Non-cash tender must equal the payment amount');
+  }
+}
+
+export function assertSettlementInvariants(
+  checks: readonly Check[],
+  items: readonly OrderItem[],
+  modifiers: readonly OrderItemModifier[],
+  payments: readonly Payment[],
+  allocations: readonly PaymentAllocation[],
+): void {
+  const paymentIds = new Set(payments.map((payment) => payment.id));
+  const unknownPaymentAllocation = allocations.find(
+    (allocation) => !paymentIds.has(allocation.paymentId),
+  );
+
+  if (unknownPaymentAllocation) {
+    throw new Error(`Allocation references unknown payment ${unknownPaymentAllocation.paymentId}`);
+  }
+
+  payments.forEach((payment) => {
+    assertPaymentAllocations(
+      payment,
+      allocations.filter((allocation) => allocation.paymentId === payment.id),
+      checks,
+      items,
+      modifiers,
+    );
+  });
+
+  const confirmedPaymentIds = getConfirmedPaymentIds(payments);
+  const confirmedItemAmounts = new Map<OrderItemId, number>();
+  const confirmedItemQuantities = new Map<OrderItemId, number>();
+
+  allocations
+    .filter(
+      (allocation) =>
+        confirmedPaymentIds.has(allocation.paymentId) && allocation.orderItemId !== undefined,
+    )
+    .forEach((allocation) => {
+      const itemId = allocation.orderItemId!;
+      confirmedItemAmounts.set(
+        itemId,
+        (confirmedItemAmounts.get(itemId) ?? 0) + allocation.amountMinor,
+      );
+
+      if (allocation.quantity !== undefined) {
+        confirmedItemQuantities.set(
+          itemId,
+          (confirmedItemQuantities.get(itemId) ?? 0) + allocation.quantity,
+        );
+      }
+    });
+
+  confirmedItemAmounts.forEach((amountMinor, itemId) => {
+    const item = findOrderItem(items, itemId);
+    const billableMinor = calculateOrderItemTotal(item, modifiers);
+
+    if (amountMinor > billableMinor) {
+      throw new Error(
+        `Confirmed payments over-allocate order item ${itemId} by ${amountMinor - billableMinor}`,
+      );
+    }
+  });
+
+  confirmedItemQuantities.forEach((quantity, itemId) => {
+    const item = findOrderItem(items, itemId);
+
+    if (quantity > item.quantity) {
+      throw new Error(`Confirmed payments over-allocate order item ${itemId} quantity`);
+    }
+  });
+
+  checks.forEach((check) => {
+    calculateCheckBalance(check, items, modifiers, payments, allocations);
+  });
+}
+
+export function getConfirmedPaymentIds(payments: readonly Payment[]): ReadonlySet<PaymentId> {
+  return new Set(
+    payments.filter((payment) => payment.status === 'confirmed').map((payment) => payment.id),
+  );
+}
+
+function findOrderItem(items: readonly OrderItem[], itemId: OrderItemId): OrderItem {
+  const item = items.find((candidate) => candidate.id === itemId);
+
+  if (!item) {
+    throw new Error(`Unknown order item ${itemId}`);
+  }
+
+  return item;
+}
+
+function assertPositiveInteger(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive safe integer`);
+  }
+
+  return value;
+}
+
+function assertPositiveMinor(value: number, field: string): number {
+  assertMinorUnits(value, field);
+
+  if (value <= 0) {
+    throw new Error(`${field} must be greater than zero`);
+  }
+
+  return value;
+}
+
+function assertNonNegativeMinor(value: number, field: string): number {
+  assertMinorUnits(value, field);
+
+  if (value < 0) {
+    throw new Error(`${field} cannot be negative`);
+  }
+
+  return value;
+}

--- a/src/domain/ids.ts
+++ b/src/domain/ids.ts
@@ -1,0 +1,41 @@
+declare const domainIdBrand: unique symbol;
+
+export type DomainId<Name extends string> = string & {
+  readonly [domainIdBrand]: Name;
+};
+
+export type OrganizationId = DomainId<'Organization'>;
+export type BranchId = DomainId<'Branch'>;
+export type UserId = DomainId<'User'>;
+export type MembershipId = DomainId<'Membership'>;
+export type DeviceId = DomainId<'Device'>;
+export type HallId = DomainId<'Hall'>;
+export type RestaurantTableId = DomainId<'RestaurantTable'>;
+export type TableSessionId = DomainId<'TableSession'>;
+export type CheckId = DomainId<'Check'>;
+export type OrderBatchId = DomainId<'OrderBatch'>;
+export type OrderItemId = DomainId<'OrderItem'>;
+export type OrderItemModifierId = DomainId<'OrderItemModifier'>;
+export type MenuItemId = DomainId<'MenuItem'>;
+export type MenuCategoryId = DomainId<'MenuCategory'>;
+export type CancellationReasonId = DomainId<'CancellationReason'>;
+export type PaymentId = DomainId<'Payment'>;
+export type PaymentAllocationId = DomainId<'PaymentAllocation'>;
+export type ReceiptId = DomainId<'Receipt'>;
+export type AuditEventId = DomainId<'AuditEvent'>;
+export type MutationId = DomainId<'Mutation'>;
+export type CorrelationId = DomainId<'Correlation'>;
+
+export function toDomainId<T extends DomainId<string>>(value: string): T {
+  const normalized = value.trim();
+
+  if (!normalized) {
+    throw new Error('Domain IDs cannot be blank');
+  }
+
+  if (normalized.length > 128) {
+    throw new Error('Domain IDs cannot exceed 128 characters');
+  }
+
+  return normalized as T;
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,7 @@
+export * from './businessDate';
+export * from './entities';
+export * from './financialRules';
+export * from './ids';
+export * from './money';
+export * from './receiptRules';
+export * from './stateTransitions';

--- a/src/domain/money.ts
+++ b/src/domain/money.ts
@@ -1,0 +1,71 @@
+declare const currencyCodeBrand: unique symbol;
+
+export type CurrencyCode = string & {
+  readonly [currencyCodeBrand]: 'CurrencyCode';
+};
+
+export interface Money {
+  readonly amountMinor: number;
+  readonly currencyCode: CurrencyCode;
+}
+
+export function toCurrencyCode(value: string): CurrencyCode {
+  const normalized = value.trim().toUpperCase();
+
+  if (!/^[A-Z]{3}$/.test(normalized)) {
+    throw new Error(`Invalid ISO 4217 currency code: ${value}`);
+  }
+
+  return normalized as CurrencyCode;
+}
+
+export function assertMinorUnits(value: number, field = 'amountMinor'): number {
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${field} must be a safe integer expressed in minor units`);
+  }
+
+  return value;
+}
+
+export function money(amountMinor: number, currencyCode: CurrencyCode): Money {
+  return {
+    amountMinor: assertMinorUnits(amountMinor),
+    currencyCode,
+  };
+}
+
+export function addMoney(...values: Money[]): Money {
+  if (values.length === 0) {
+    throw new Error('addMoney requires at least one value');
+  }
+
+  const currencyCode = values[0].currencyCode;
+  const amountMinor = values.reduce((sum, value) => {
+    assertSameCurrency(currencyCode, value.currencyCode);
+    return assertMinorUnits(sum + value.amountMinor);
+  }, 0);
+
+  return money(amountMinor, currencyCode);
+}
+
+export function subtractMoney(minuend: Money, subtrahend: Money): Money {
+  assertSameCurrency(minuend.currencyCode, subtrahend.currencyCode);
+  return money(
+    assertMinorUnits(minuend.amountMinor - subtrahend.amountMinor),
+    minuend.currencyCode,
+  );
+}
+
+export function multiplyMoney(value: Money, multiplier: number): Money {
+  if (!Number.isSafeInteger(multiplier) || multiplier < 0) {
+    throw new Error('Money multiplier must be a non-negative safe integer');
+  }
+
+  return money(assertMinorUnits(value.amountMinor * multiplier), value.currencyCode);
+}
+
+export function assertSameCurrency(left: CurrencyCode, right: CurrencyCode): void {
+  if (left !== right) {
+    throw new Error(`Currency mismatch: ${left} cannot be combined with ${right}`);
+  }
+}

--- a/src/domain/receiptRules.ts
+++ b/src/domain/receiptRules.ts
@@ -1,0 +1,46 @@
+import { Receipt } from './entities';
+import { assertMinorUnits, assertSameCurrency } from './money';
+
+export function assertValidReceipt(receipt: Receipt): void {
+  assertMinorUnits(receipt.totalMinor, 'receipt totalMinor');
+  assertMinorUnits(receipt.snapshot.totalMinor, 'receipt snapshot totalMinor');
+  assertSameCurrency(receipt.currencyCode, receipt.snapshot.currencyCode);
+
+  if (receipt.totalMinor !== receipt.snapshot.totalMinor) {
+    throw new Error('Receipt total does not match its immutable snapshot total');
+  }
+
+  const checkTotal = receipt.snapshot.checks.reduce(
+    (total, check) => assertMinorUnits(total + check.totalMinor),
+    0,
+  );
+
+  if (checkTotal !== receipt.totalMinor) {
+    throw new Error('Receipt check totals do not reconcile with the receipt total');
+  }
+}
+
+export function assertIssuedReceiptUnchanged(original: Receipt, candidate: Receipt): void {
+  if (original.status !== 'issued') {
+    throw new Error('Receipt immutability check requires an issued original receipt');
+  }
+
+  if (stableSerialize(original) !== stableSerialize(candidate)) {
+    throw new Error('Issued receipts are immutable; create an adjustment receipt');
+  }
+}
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}

--- a/src/domain/stateTransitions.ts
+++ b/src/domain/stateTransitions.ts
@@ -1,0 +1,78 @@
+import {
+  CheckStatus,
+  OrderItemStatus,
+  PaymentStatus,
+  ReceiptStatus,
+  TableSessionStatus,
+} from './entities';
+
+const tableSessionTransitions: Readonly<Record<TableSessionStatus, readonly TableSessionStatus[]>> =
+  {
+    open: ['payment_pending', 'voided'],
+    payment_pending: ['open', 'closed'],
+    closed: [],
+    voided: [],
+  };
+
+const checkTransitions: Readonly<Record<CheckStatus, readonly CheckStatus[]>> = {
+  open: ['partially_paid', 'paid', 'voided'],
+  partially_paid: ['paid'],
+  paid: [],
+  voided: [],
+};
+
+const orderItemTransitions: Readonly<Record<OrderItemStatus, readonly OrderItemStatus[]>> = {
+  draft: ['ordered', 'cancelled'],
+  ordered: ['served', 'cancelled'],
+  served: ['cancelled'],
+  cancelled: [],
+};
+
+const paymentTransitions: Readonly<Record<PaymentStatus, readonly PaymentStatus[]>> = {
+  pending: ['confirmed', 'failed', 'voided'],
+  confirmed: [],
+  failed: [],
+  voided: [],
+};
+
+export function assertTableSessionTransition(
+  current: TableSessionStatus,
+  next: TableSessionStatus,
+): void {
+  assertTransition('table session', tableSessionTransitions, current, next);
+}
+
+export function assertCheckTransition(current: CheckStatus, next: CheckStatus): void {
+  assertTransition('check', checkTransitions, current, next);
+}
+
+export function assertOrderItemTransition(current: OrderItemStatus, next: OrderItemStatus): void {
+  assertTransition('order item', orderItemTransitions, current, next);
+}
+
+export function assertPaymentTransition(current: PaymentStatus, next: PaymentStatus): void {
+  assertTransition('payment', paymentTransitions, current, next);
+}
+
+export function assertReceiptStatusTransition(current: ReceiptStatus, next: ReceiptStatus): void {
+  if (current !== next) {
+    throw new Error(
+      `Issued receipt status is immutable; create an adjustment receipt instead of ${current} -> ${next}`,
+    );
+  }
+}
+
+function assertTransition<State extends string>(
+  entityName: string,
+  transitions: Readonly<Record<State, readonly State[]>>,
+  current: State,
+  next: State,
+): void {
+  if (current === next) {
+    return;
+  }
+
+  if (!transitions[current].includes(next)) {
+    throw new Error(`Invalid ${entityName} state transition: ${current} -> ${next}`);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce branded tenant/entity IDs and v2 organization, branch, membership and device models
- model halls, tables, table sessions, named checks, order batches/items/modifier snapshots, payments, allocations, receipts and audit metadata
- enforce safe integer minor-unit money and ISO-style currency codes
- compute business dates from branch IANA timezone and cutoff instead of device timezone
- define explicit session/check/item/payment transitions and immutable receipt behavior
- enforce allocation reconciliation, aggregate item over-allocation protection, confirmed-ledger balances, cash change and session-close invariants

## Verification
- `npm run verify:full`
  - 5 Jest suites / 23 tests
  - TypeScript, format and lint gates
  - Expo web production export
  - Chromium smoke test

## Stack
This PR is stacked on #35 and targets `test/8-financial-characterization`. Retarget after the parent PR lands.

Closes #9
