### PR TITLE
feat(data): define local repository contracts (#10)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,13 @@ module.exports = defineConfig([
     },
   },
   {
-    files: ['jest.setup.js', '**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
+    files: [
+      'jest.setup.js',
+      '**/*.test.{ts,tsx}',
+      '**/*.spec.{ts,tsx}',
+      '**/*.contract.{ts,tsx}',
+      '**/*Contract.{ts,tsx}',
+    ],
     languageOptions: {
       globals: {
         ...globals.jest,

--- a/src/data/contracts/index.ts
+++ b/src/data/contracts/index.ts
@@ -1,0 +1,4 @@
+export * from './localDatabase';
+export * from './outbox';
+export * from './repository';
+export * from './syncState';

--- a/src/data/contracts/localDatabase.ts
+++ b/src/data/contracts/localDatabase.ts
@@ -1,0 +1,25 @@
+import { OutboxRepository } from './outbox';
+import {
+  DomainEntityMap,
+  ReadRepository,
+  RepositoryName,
+  TransactionRepository,
+} from './repository';
+import { SyncStateRepository } from './syncState';
+
+export type LocalDatabaseEngine = 'memory' | 'sqlite' | 'indexeddb';
+
+export interface LocalTransaction {
+  repository<Name extends RepositoryName>(name: Name): TransactionRepository<DomainEntityMap[Name]>;
+  readonly outbox: OutboxRepository;
+  readonly syncState: SyncStateRepository;
+}
+
+export interface LocalDatabase {
+  readonly engine: LocalDatabaseEngine;
+  repository<Name extends RepositoryName>(name: Name): ReadRepository<DomainEntityMap[Name]>;
+  readonly outbox: Pick<OutboxRepository, 'getById' | 'list'>;
+  readonly syncState: Pick<SyncStateRepository, 'getCursor' | 'getConflict' | 'listConflicts'>;
+  transaction<Result>(work: (transaction: LocalTransaction) => Promise<Result>): Promise<Result>;
+  close(): Promise<void>;
+}

--- a/src/data/contracts/outbox.ts
+++ b/src/data/contracts/outbox.ts
@@ -1,0 +1,81 @@
+import { BranchId, DeviceId, MutationId, OrganizationId } from '../../domain/ids';
+import { IsoTimestamp, JsonValue } from '../../domain/entities';
+import { RepositoryName, RepositoryScope } from './repository';
+
+export type MutationOperation = 'create' | 'update' | 'delete' | 'command';
+export type OutboxStatus =
+  'pending' | 'processing' | 'retry_wait' | 'applied' | 'conflict' | 'rejected';
+
+export interface OutboxMutation {
+  readonly id: MutationId;
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly deviceId: DeviceId;
+  readonly clientMutationId: MutationId;
+  readonly idempotencyKey: string;
+  readonly repository: RepositoryName;
+  readonly entityId: string;
+  readonly operation: MutationOperation;
+  readonly payload: JsonValue;
+  readonly baseVersion?: number;
+  readonly status: OutboxStatus;
+  readonly attemptCount: number;
+  readonly createdAt: IsoTimestamp;
+  readonly lastAttemptAt?: IsoTimestamp;
+  readonly nextAttemptAt?: IsoTimestamp;
+  readonly appliedAt?: IsoTimestamp;
+  readonly errorCode?: string;
+  readonly errorMessage?: string;
+}
+
+export interface OutboxTransitionPatch {
+  readonly lastAttemptAt?: IsoTimestamp;
+  readonly nextAttemptAt?: IsoTimestamp;
+  readonly appliedAt?: IsoTimestamp;
+  readonly errorCode?: string;
+  readonly errorMessage?: string;
+}
+
+export interface OutboxRepository {
+  enqueue(mutation: OutboxMutation): Promise<OutboxMutation>;
+  getById(id: MutationId): Promise<OutboxMutation | null>;
+  list(
+    scope: RepositoryScope,
+    statuses?: readonly OutboxStatus[],
+  ): Promise<readonly OutboxMutation[]>;
+  claimNext(
+    scope: RepositoryScope,
+    limit: number,
+    now: IsoTimestamp,
+  ): Promise<readonly OutboxMutation[]>;
+  transition(
+    id: MutationId,
+    expectedStatus: OutboxStatus,
+    nextStatus: OutboxStatus,
+    patch?: OutboxTransitionPatch,
+  ): Promise<OutboxMutation>;
+}
+
+const allowedOutboxTransitions: Readonly<Record<OutboxStatus, readonly OutboxStatus[]>> = {
+  pending: ['processing'],
+  processing: ['applied', 'retry_wait', 'conflict', 'rejected'],
+  retry_wait: ['processing'],
+  applied: [],
+  conflict: [],
+  rejected: [],
+};
+
+export function assertOutboxTransition(current: OutboxStatus, next: OutboxStatus): void {
+  if (current === next) return;
+
+  if (!allowedOutboxTransitions[current].includes(next)) {
+    throw new Error(`Invalid outbox transition: ${current} -> ${next}`);
+  }
+}
+
+export function outboxScope(mutation: OutboxMutation): RepositoryScope {
+  return {
+    organizationId: mutation.organizationId,
+    branchId: mutation.branchId,
+  };
+}

--- a/src/data/contracts/repository.ts
+++ b/src/data/contracts/repository.ts
@@ -1,0 +1,88 @@
+import {
+  AuditEvent,
+  Branch,
+  Check,
+  Device,
+  Hall,
+  Membership,
+  OrderBatch,
+  OrderItem,
+  OrderItemModifier,
+  Organization,
+  Payment,
+  PaymentAllocation,
+  Receipt,
+  RestaurantTable,
+  TableSession,
+} from '../../domain';
+import { BranchId, OrganizationId } from '../../domain/ids';
+
+export interface DomainEntityMap {
+  readonly organizations: Organization;
+  readonly branches: Branch;
+  readonly memberships: Membership;
+  readonly devices: Device;
+  readonly halls: Hall;
+  readonly restaurantTables: RestaurantTable;
+  readonly tableSessions: TableSession;
+  readonly checks: Check;
+  readonly orderBatches: OrderBatch;
+  readonly orderItems: OrderItem;
+  readonly orderItemModifiers: OrderItemModifier;
+  readonly payments: Payment;
+  readonly paymentAllocations: PaymentAllocation;
+  readonly receipts: Receipt;
+  readonly auditEvents: AuditEvent;
+}
+
+export type RepositoryName = keyof DomainEntityMap;
+
+export interface RepositoryScope {
+  readonly organizationId: OrganizationId;
+  readonly branchId?: BranchId;
+}
+
+export interface RepositoryQuery {
+  readonly after?: string;
+  readonly includeDeleted?: boolean;
+  readonly limit?: number;
+}
+
+export interface RepositoryPage<Entity> {
+  readonly items: readonly Entity[];
+  readonly nextCursor?: string;
+}
+
+export interface PutOptions {
+  readonly expectedVersion?: number | null;
+}
+
+export interface TombstoneOptions extends PutOptions {
+  readonly deletedAt: string;
+}
+
+export interface ReadRepository<Entity extends { readonly id: string }> {
+  getById(scope: RepositoryScope, id: Entity['id']): Promise<Entity | null>;
+  list(scope: RepositoryScope, query?: RepositoryQuery): Promise<RepositoryPage<Entity>>;
+}
+
+export interface TransactionRepository<
+  Entity extends { readonly id: string },
+> extends ReadRepository<Entity> {
+  put(scope: RepositoryScope, entity: Entity, options?: PutOptions): Promise<Entity>;
+  tombstone(scope: RepositoryScope, id: Entity['id'], options: TombstoneOptions): Promise<Entity>;
+}
+
+export class OptimisticConcurrencyError extends Error {
+  constructor(
+    readonly repository: RepositoryName,
+    readonly entityId: string,
+    readonly expectedVersion: number | null,
+    readonly actualVersion: number | null,
+  ) {
+    super(
+      `Optimistic concurrency failure in ${repository}/${entityId}: expected ${expectedVersion}, got ${actualVersion}`,
+    );
+    this.name = 'OptimisticConcurrencyError';
+  }
+}

--- a/src/data/contracts/syncState.ts
+++ b/src/data/contracts/syncState.ts
@@ -1,0 +1,47 @@
+import { BranchId, MutationId, OrganizationId, SyncConflictId } from '../../domain/ids';
+import { IsoTimestamp, JsonValue } from '../../domain/entities';
+import { RepositoryName, RepositoryScope } from './repository';
+
+export interface SyncCursor {
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly value: string;
+  readonly updatedAt: IsoTimestamp;
+}
+
+export type SyncConflictStatus =
+  'unresolved' | 'resolved_local' | 'resolved_server' | 'resolved_manual';
+
+export interface SyncConflict {
+  readonly id: SyncConflictId;
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly mutationId: MutationId;
+  readonly repository: RepositoryName;
+  readonly entityId: string;
+  readonly baseVersion?: number;
+  readonly serverVersion: number;
+  readonly localPayload: JsonValue;
+  readonly serverPayload: JsonValue;
+  readonly status: SyncConflictStatus;
+  readonly detectedAt: IsoTimestamp;
+  readonly resolvedAt?: IsoTimestamp;
+  readonly resolutionPayload?: JsonValue;
+}
+
+export interface SyncStateRepository {
+  getCursor(scope: RepositoryScope): Promise<SyncCursor | null>;
+  setCursor(cursor: SyncCursor): Promise<SyncCursor>;
+  addConflict(conflict: SyncConflict): Promise<SyncConflict>;
+  getConflict(id: SyncConflictId): Promise<SyncConflict | null>;
+  listConflicts(
+    scope: RepositoryScope,
+    statuses?: readonly SyncConflictStatus[],
+  ): Promise<readonly SyncConflict[]>;
+  resolveConflict(
+    id: SyncConflictId,
+    status: Exclude<SyncConflictStatus, 'unresolved'>,
+    resolvedAt: IsoTimestamp,
+    resolutionPayload?: JsonValue,
+  ): Promise<SyncConflict>;
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,1 @@
+export * from './contracts';

--- a/src/data/testing/__tests__/inMemoryLocalDatabase.test.ts
+++ b/src/data/testing/__tests__/inMemoryLocalDatabase.test.ts
@@ -1,0 +1,4 @@
+import { InMemoryLocalDatabase } from '../inMemoryLocalDatabase';
+import { defineLocalDatabaseContract } from '../localDatabaseContract';
+
+defineLocalDatabaseContract('in-memory', () => new InMemoryLocalDatabase());

--- a/src/data/testing/inMemoryLocalDatabase.ts
+++ b/src/data/testing/inMemoryLocalDatabase.ts
@@ -1,0 +1,591 @@
+import {
+  DomainEntityMap,
+  LocalDatabase,
+  LocalTransaction,
+  OptimisticConcurrencyError,
+  OutboxMutation,
+  OutboxRepository,
+  OutboxStatus,
+  OutboxTransitionPatch,
+  PutOptions,
+  ReadRepository,
+  RepositoryName,
+  RepositoryPage,
+  RepositoryQuery,
+  RepositoryScope,
+  SyncConflict,
+  SyncConflictStatus,
+  SyncCursor,
+  SyncStateRepository,
+  TombstoneOptions,
+  TransactionRepository,
+  assertOutboxTransition,
+} from '../contracts';
+import { MutationId, SyncConflictId } from '../../domain/ids';
+import { JsonValue } from '../../domain/entities';
+
+interface StoredRecord<Entity> {
+  readonly scope: RepositoryScope;
+  readonly entity: Entity;
+  readonly version: number;
+  readonly deletedAt?: string;
+}
+
+type AnyDomainEntity = DomainEntityMap[RepositoryName];
+type RepositoryState = Record<RepositoryName, Map<string, StoredRecord<AnyDomainEntity>>>;
+
+interface MemoryState {
+  readonly repositories: RepositoryState;
+  readonly outbox: Map<string, OutboxMutation>;
+  readonly idempotencyIndex: Map<string, string>;
+  readonly cursors: Map<string, SyncCursor>;
+  readonly conflicts: Map<string, SyncConflict>;
+}
+
+const repositoryNames: readonly RepositoryName[] = [
+  'organizations',
+  'branches',
+  'memberships',
+  'devices',
+  'halls',
+  'restaurantTables',
+  'tableSessions',
+  'checks',
+  'orderBatches',
+  'orderItems',
+  'orderItemModifiers',
+  'payments',
+  'paymentAllocations',
+  'receipts',
+  'auditEvents',
+];
+
+export class InMemoryLocalDatabase implements LocalDatabase {
+  readonly engine = 'memory' as const;
+
+  private state = createEmptyState();
+  private transactionTail: Promise<void> = Promise.resolve();
+  private closed = false;
+
+  get outbox(): Pick<OutboxRepository, 'getById' | 'list'> {
+    this.assertOpen();
+    return new InMemoryOutboxRepository(() => {
+      this.assertOpen();
+      return this.state;
+    });
+  }
+
+  get syncState(): Pick<SyncStateRepository, 'getCursor' | 'getConflict' | 'listConflicts'> {
+    this.assertOpen();
+    return new InMemorySyncStateRepository(() => {
+      this.assertOpen();
+      return this.state;
+    });
+  }
+
+  repository<Name extends RepositoryName>(name: Name): ReadRepository<DomainEntityMap[Name]> {
+    this.assertOpen();
+    return new InMemoryRepository(name, () => {
+      this.assertOpen();
+      return this.state;
+    });
+  }
+
+  async transaction<Result>(
+    work: (transaction: LocalTransaction) => Promise<Result>,
+  ): Promise<Result> {
+    this.assertOpen();
+
+    const previousTransaction = this.transactionTail;
+    let releaseTransaction!: () => void;
+    this.transactionTail = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    await previousTransaction;
+    let transactionActive = true;
+
+    try {
+      this.assertOpen();
+      const workingState = cloneState(this.state);
+      const getWorkingState = () => {
+        if (!transactionActive) {
+          throw new Error('Local transaction is no longer active');
+        }
+
+        return workingState;
+      };
+      const transaction = createTransaction(getWorkingState);
+      const result = await work(transaction);
+      transactionActive = false;
+      this.state = workingState;
+      return result;
+    } finally {
+      transactionActive = false;
+      releaseTransaction();
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.transactionTail;
+    this.closed = true;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('Local database is closed');
+    }
+  }
+}
+
+class InMemoryRepository<Name extends RepositoryName> implements TransactionRepository<
+  DomainEntityMap[Name]
+> {
+  constructor(
+    private readonly name: Name,
+    private readonly getState: () => MemoryState,
+  ) {}
+
+  async getById(
+    scope: RepositoryScope,
+    id: DomainEntityMap[Name]['id'],
+  ): Promise<DomainEntityMap[Name] | null> {
+    const record = this.findRecord(scope, id);
+    return record && !record.deletedAt ? cloneValue(record.entity) : null;
+  }
+
+  async list(
+    scope: RepositoryScope,
+    query: RepositoryQuery = {},
+  ): Promise<RepositoryPage<DomainEntityMap[Name]>> {
+    const limit = query.limit ?? 100;
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error('Repository query limit must be a positive safe integer');
+    }
+
+    const offset = query.after ? Number(query.after) : 0;
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error('Repository cursor is invalid');
+    }
+
+    const matchingRecords = Array.from(this.getRepository().values())
+      .filter(
+        (record) =>
+          matchesScope(record.scope, scope) &&
+          (query.includeDeleted === true || record.deletedAt === undefined),
+      )
+      .sort((left, right) => left.entity.id.localeCompare(right.entity.id));
+    const page = matchingRecords.slice(offset, offset + limit);
+    const nextOffset = offset + page.length;
+
+    return {
+      items: page.map((record) => cloneValue(record.entity)) as readonly DomainEntityMap[Name][],
+      nextCursor: nextOffset < matchingRecords.length ? String(nextOffset) : undefined,
+    };
+  }
+
+  async put(
+    scope: RepositoryScope,
+    entity: DomainEntityMap[Name],
+    options: PutOptions = {},
+  ): Promise<DomainEntityMap[Name]> {
+    assertEntityMatchesScope(entity, scope);
+    if (this.name === 'organizations' && entity.id !== scope.organizationId) {
+      throw new Error('Organization entity ID does not match repository scope');
+    }
+
+    const existing = this.findRecord(scope, entity.id);
+    const actualVersion = existing?.version ?? null;
+    assertExpectedVersion(this.name, entity.id, options.expectedVersion, actualVersion);
+
+    const version = readEntityVersion(entity) ?? (actualVersion ?? 0) + 1;
+    const record: StoredRecord<DomainEntityMap[Name]> = {
+      scope: cloneValue(scope),
+      entity: cloneValue(entity),
+      version,
+      deletedAt: readDeletedAt(entity),
+    };
+    this.getRepository().set(recordKey(scope, entity.id), record);
+    return cloneValue(entity);
+  }
+
+  async tombstone(
+    scope: RepositoryScope,
+    id: DomainEntityMap[Name]['id'],
+    options: TombstoneOptions,
+  ): Promise<DomainEntityMap[Name]> {
+    const existing = this.findRecord(scope, id);
+    if (!existing) {
+      throw new Error(`Cannot tombstone missing ${this.name}/${id}`);
+    }
+
+    assertExpectedVersion(this.name, id, options.expectedVersion, existing.version);
+
+    const nextVersion = existing.version + 1;
+    const entity = {
+      ...cloneValue(existing.entity),
+      deletedAt: options.deletedAt,
+      ...('version' in existing.entity ? { version: nextVersion } : {}),
+    } as DomainEntityMap[Name];
+    this.getRepository().set(recordKey(scope, id), {
+      scope: cloneValue(scope),
+      entity,
+      version: nextVersion,
+      deletedAt: options.deletedAt,
+    });
+    return cloneValue(entity);
+  }
+
+  private getRepository(): Map<string, StoredRecord<DomainEntityMap[Name]>> {
+    return this.getState().repositories[this.name] as unknown as Map<
+      string,
+      StoredRecord<DomainEntityMap[Name]>
+    >;
+  }
+
+  private findRecord(
+    scope: RepositoryScope,
+    id: string,
+  ): StoredRecord<DomainEntityMap[Name]> | undefined {
+    return Array.from(this.getRepository().values()).find(
+      (record) => record.entity.id === id && matchesScope(record.scope, scope),
+    );
+  }
+}
+
+class InMemoryOutboxRepository implements OutboxRepository {
+  constructor(private readonly getState: () => MemoryState) {}
+
+  async enqueue(mutation: OutboxMutation): Promise<OutboxMutation> {
+    if (mutation.status !== 'pending' || mutation.attemptCount !== 0) {
+      throw new Error('New outbox mutations must start pending with zero attempts');
+    }
+
+    if (!mutation.idempotencyKey.trim()) {
+      throw new Error('Outbox mutation requires an idempotency key');
+    }
+
+    const key = mutationIdempotencyKey(mutation);
+    const existingId = this.getState().idempotencyIndex.get(key);
+
+    if (existingId) {
+      const existing = this.getState().outbox.get(existingId)!;
+      if (stableSerialize(existing) !== stableSerialize(mutation)) {
+        throw new Error('Client mutation ID was reused with different content');
+      }
+
+      return cloneValue(existing);
+    }
+
+    if (this.getState().outbox.has(mutation.id)) {
+      throw new Error(`Outbox mutation ID already exists: ${mutation.id}`);
+    }
+
+    this.getState().outbox.set(mutation.id, cloneValue(mutation));
+    this.getState().idempotencyIndex.set(key, mutation.id);
+    return cloneValue(mutation);
+  }
+
+  async getById(id: MutationId): Promise<OutboxMutation | null> {
+    const mutation = this.getState().outbox.get(id);
+    return mutation ? cloneValue(mutation) : null;
+  }
+
+  async list(
+    scope: RepositoryScope,
+    statuses?: readonly OutboxStatus[],
+  ): Promise<readonly OutboxMutation[]> {
+    return Array.from(this.getState().outbox.values())
+      .filter(
+        (mutation) =>
+          matchesScope(
+            {
+              organizationId: mutation.organizationId,
+              branchId: mutation.branchId,
+            },
+            scope,
+          ) &&
+          (statuses === undefined || statuses.includes(mutation.status)),
+      )
+      .sort(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .map(cloneValue);
+  }
+
+  async claimNext(
+    scope: RepositoryScope,
+    limit: number,
+    now: string,
+  ): Promise<readonly OutboxMutation[]> {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error('Outbox claim limit must be a positive safe integer');
+    }
+
+    const candidates = (await this.list(scope, ['pending', 'retry_wait']))
+      .filter(
+        (mutation) =>
+          mutation.status === 'pending' ||
+          mutation.nextAttemptAt === undefined ||
+          mutation.nextAttemptAt <= now,
+      )
+      .slice(0, limit);
+
+    return Promise.all(
+      candidates.map((mutation) =>
+        this.transition(mutation.id, mutation.status, 'processing', {
+          lastAttemptAt: now,
+        }),
+      ),
+    );
+  }
+
+  async transition(
+    id: MutationId,
+    expectedStatus: OutboxStatus,
+    nextStatus: OutboxStatus,
+    patch: OutboxTransitionPatch = {},
+  ): Promise<OutboxMutation> {
+    const current = this.getState().outbox.get(id);
+    if (!current) {
+      throw new Error(`Unknown outbox mutation ${id}`);
+    }
+
+    if (current.status !== expectedStatus) {
+      throw new Error(`Outbox mutation ${id} expected ${expectedStatus}, got ${current.status}`);
+    }
+
+    assertOutboxTransition(current.status, nextStatus);
+
+    if (nextStatus === 'applied' && patch.appliedAt === undefined) {
+      throw new Error('Applied outbox mutation requires appliedAt');
+    }
+
+    if (nextStatus === 'retry_wait' && patch.nextAttemptAt === undefined) {
+      throw new Error('Retrying outbox mutation requires nextAttemptAt');
+    }
+
+    const next: OutboxMutation = {
+      ...current,
+      ...patch,
+      status: nextStatus,
+      attemptCount: nextStatus === 'processing' ? current.attemptCount + 1 : current.attemptCount,
+    };
+    this.getState().outbox.set(id, cloneValue(next));
+    return cloneValue(next);
+  }
+}
+
+class InMemorySyncStateRepository implements SyncStateRepository {
+  constructor(private readonly getState: () => MemoryState) {}
+
+  async getCursor(scope: RepositoryScope): Promise<SyncCursor | null> {
+    const cursor = this.getState().cursors.get(scopeKey(scope));
+    return cursor ? cloneValue(cursor) : null;
+  }
+
+  async setCursor(cursor: SyncCursor): Promise<SyncCursor> {
+    const scope = {
+      organizationId: cursor.organizationId,
+      branchId: cursor.branchId,
+    };
+    this.getState().cursors.set(scopeKey(scope), cloneValue(cursor));
+    return cloneValue(cursor);
+  }
+
+  async addConflict(conflict: SyncConflict): Promise<SyncConflict> {
+    if (conflict.status !== 'unresolved') {
+      throw new Error('New sync conflicts must start unresolved');
+    }
+
+    if (this.getState().conflicts.has(conflict.id)) {
+      throw new Error(`Sync conflict already exists: ${conflict.id}`);
+    }
+
+    this.getState().conflicts.set(conflict.id, cloneValue(conflict));
+    return cloneValue(conflict);
+  }
+
+  async getConflict(id: SyncConflictId): Promise<SyncConflict | null> {
+    const conflict = this.getState().conflicts.get(id);
+    return conflict ? cloneValue(conflict) : null;
+  }
+
+  async listConflicts(
+    scope: RepositoryScope,
+    statuses?: readonly SyncConflictStatus[],
+  ): Promise<readonly SyncConflict[]> {
+    return Array.from(this.getState().conflicts.values())
+      .filter(
+        (conflict) =>
+          matchesScope(
+            {
+              organizationId: conflict.organizationId,
+              branchId: conflict.branchId,
+            },
+            scope,
+          ) &&
+          (statuses === undefined || statuses.includes(conflict.status)),
+      )
+      .sort((left, right) => left.detectedAt.localeCompare(right.detectedAt))
+      .map(cloneValue);
+  }
+
+  async resolveConflict(
+    id: SyncConflictId,
+    status: Exclude<SyncConflictStatus, 'unresolved'>,
+    resolvedAt: string,
+    resolutionPayload?: JsonValue,
+  ): Promise<SyncConflict> {
+    const current = this.getState().conflicts.get(id);
+    if (!current) {
+      throw new Error(`Unknown sync conflict ${id}`);
+    }
+
+    if (current.status !== 'unresolved') {
+      throw new Error(`Sync conflict ${id} is already resolved`);
+    }
+
+    const next: SyncConflict = {
+      ...current,
+      status,
+      resolvedAt,
+      resolutionPayload,
+    };
+    this.getState().conflicts.set(id, cloneValue(next));
+    return cloneValue(next);
+  }
+}
+
+function createTransaction(getState: () => MemoryState): LocalTransaction {
+  return {
+    repository: <Name extends RepositoryName>(name: Name) => new InMemoryRepository(name, getState),
+    outbox: new InMemoryOutboxRepository(getState),
+    syncState: new InMemorySyncStateRepository(getState),
+  };
+}
+
+function createEmptyState(): MemoryState {
+  const repositories = Object.fromEntries(
+    repositoryNames.map((name) => [name, new Map()]),
+  ) as unknown as RepositoryState;
+
+  return {
+    repositories,
+    outbox: new Map(),
+    idempotencyIndex: new Map(),
+    cursors: new Map(),
+    conflicts: new Map(),
+  };
+}
+
+function cloneState(state: MemoryState): MemoryState {
+  const repositories = Object.fromEntries(
+    repositoryNames.map((name) => [
+      name,
+      new Map(
+        Array.from(state.repositories[name].entries()).map(([key, record]) => [
+          key,
+          cloneValue(record),
+        ]),
+      ),
+    ]),
+  ) as unknown as RepositoryState;
+
+  return {
+    repositories,
+    outbox: cloneMap(state.outbox),
+    idempotencyIndex: new Map(state.idempotencyIndex),
+    cursors: cloneMap(state.cursors),
+    conflicts: cloneMap(state.conflicts),
+  };
+}
+
+function cloneMap<Value>(source: Map<string, Value>): Map<string, Value> {
+  return new Map(Array.from(source.entries()).map(([key, value]) => [key, cloneValue(value)]));
+}
+
+function cloneValue<Value>(value: Value): Value {
+  return JSON.parse(JSON.stringify(value)) as Value;
+}
+
+function recordKey(scope: RepositoryScope, id: string): string {
+  return `${scopeKey(scope)}::${id}`;
+}
+
+function scopeKey(scope: RepositoryScope): string {
+  return `${scope.organizationId}::${scope.branchId ?? '*'}`;
+}
+
+function matchesScope(stored: RepositoryScope, requested: RepositoryScope): boolean {
+  return (
+    stored.organizationId === requested.organizationId &&
+    (requested.branchId === undefined || stored.branchId === requested.branchId)
+  );
+}
+
+function assertEntityMatchesScope(entity: object, scope: RepositoryScope): void {
+  const organizationId =
+    'organizationId' in entity && typeof entity.organizationId === 'string'
+      ? entity.organizationId
+      : undefined;
+  const branchId =
+    'branchId' in entity && typeof entity.branchId === 'string' ? entity.branchId : undefined;
+
+  if (organizationId !== undefined && organizationId !== scope.organizationId) {
+    throw new Error('Entity organization does not match repository scope');
+  }
+
+  if (branchId !== undefined && branchId !== scope.branchId) {
+    throw new Error('Entity branch does not match repository scope');
+  }
+}
+
+function assertExpectedVersion(
+  repository: RepositoryName,
+  entityId: string,
+  expectedVersion: number | null | undefined,
+  actualVersion: number | null,
+): void {
+  if (expectedVersion === undefined) return;
+
+  if (expectedVersion !== actualVersion) {
+    throw new OptimisticConcurrencyError(repository, entityId, expectedVersion, actualVersion);
+  }
+}
+
+function readEntityVersion(entity: object): number | undefined {
+  if ('version' in entity && typeof entity.version === 'number') {
+    return entity.version;
+  }
+
+  return undefined;
+}
+
+function readDeletedAt(entity: object): string | undefined {
+  if ('deletedAt' in entity && typeof entity.deletedAt === 'string') {
+    return entity.deletedAt;
+  }
+
+  return undefined;
+}
+
+function mutationIdempotencyKey(mutation: OutboxMutation): string {
+  return `${mutation.deviceId}::${mutation.clientMutationId}`;
+}
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value);
+}

--- a/src/data/testing/index.ts
+++ b/src/data/testing/index.ts
@@ -1,0 +1,2 @@
+export * from './inMemoryLocalDatabase';
+export * from './localDatabaseContract';

--- a/src/data/testing/localDatabaseContract.ts
+++ b/src/data/testing/localDatabaseContract.ts
@@ -1,0 +1,290 @@
+import {
+  Hall,
+  BranchId,
+  DeviceId,
+  HallId,
+  MutationId,
+  OrganizationId,
+  SyncConflictId,
+  toDomainId,
+} from '../../domain';
+import {
+  LocalDatabase,
+  LocalTransaction,
+  OptimisticConcurrencyError,
+  OutboxMutation,
+  RepositoryScope,
+  SyncConflict,
+} from '../contracts';
+
+const organizationId = toDomainId<OrganizationId>('organization-contract');
+const otherOrganizationId = toDomainId<OrganizationId>('organization-other');
+const branchId = toDomainId<BranchId>('branch-contract');
+const otherBranchId = toDomainId<BranchId>('branch-other');
+const deviceId = toDomainId<DeviceId>('device-contract');
+const mutationId = toDomainId<MutationId>('mutation-contract');
+const timestamp = '2026-07-26T13:00:00.000Z';
+
+const scope: RepositoryScope = { organizationId, branchId };
+const otherBranchScope: RepositoryScope = {
+  organizationId,
+  branchId: otherBranchId,
+};
+const otherOrganizationScope: RepositoryScope = {
+  organizationId: otherOrganizationId,
+  branchId,
+};
+
+export function defineLocalDatabaseContract(
+  adapterName: string,
+  createDatabase: () => LocalDatabase | Promise<LocalDatabase>,
+): void {
+  describe(`${adapterName} local database contract`, () => {
+    let database: LocalDatabase;
+
+    beforeEach(async () => {
+      database = await createDatabase();
+    });
+
+    afterEach(async () => {
+      await database.close();
+    });
+
+    it('isolates organization and branch-scoped records', async () => {
+      const hall = createHall('hall-primary', scope);
+      const otherHall = createHall('hall-other', otherBranchScope);
+
+      await database.transaction(async (transaction) => {
+        await transaction.repository('halls').put(scope, hall, {
+          expectedVersion: null,
+        });
+        await transaction
+          .repository('halls')
+          .put(otherBranchScope, otherHall, { expectedVersion: null });
+      });
+
+      await expect(database.repository('halls').getById(scope, hall.id)).resolves.toEqual(hall);
+      await expect(
+        database.repository('halls').getById(otherBranchScope, hall.id),
+      ).resolves.toBeNull();
+      await expect(database.repository('halls').list(otherOrganizationScope)).resolves.toEqual({
+        items: [],
+        nextCursor: undefined,
+      });
+
+      const organizationPage = await database.repository('halls').list({
+        organizationId,
+      });
+      expect(organizationPage.items).toHaveLength(2);
+    });
+
+    it('commits entity and outbox writes atomically', async () => {
+      const hall = createHall('hall-atomic', scope);
+      const mutation = createMutation(hall);
+
+      await database.transaction(async (transaction) => {
+        await transaction.repository('halls').put(scope, hall, {
+          expectedVersion: null,
+        });
+        await transaction.outbox.enqueue(mutation);
+      });
+
+      await expect(database.repository('halls').getById(scope, hall.id)).resolves.toEqual(hall);
+      await expect(database.outbox.getById(mutation.id)).resolves.toEqual(mutation);
+    });
+
+    it('rolls back every write when a transaction fails', async () => {
+      const hall = createHall('hall-rollback', scope);
+      const mutation = createMutation(hall);
+
+      await expect(
+        database.transaction(async (transaction) => {
+          await transaction.repository('halls').put(scope, hall, {
+            expectedVersion: null,
+          });
+          await transaction.outbox.enqueue(mutation);
+          throw new Error('simulated crash');
+        }),
+      ).rejects.toThrow('simulated crash');
+
+      await expect(database.repository('halls').getById(scope, hall.id)).resolves.toBeNull();
+      await expect(database.outbox.getById(mutation.id)).resolves.toBeNull();
+    });
+
+    it('does not allow transaction handles to mutate state after commit', async () => {
+      let leakedTransaction: LocalTransaction | undefined;
+
+      await database.transaction(async (transaction) => {
+        leakedTransaction = transaction;
+      });
+
+      await expect(leakedTransaction!.repository('halls').list(scope)).rejects.toThrow(
+        /no longer active/,
+      );
+    });
+
+    it('enforces optimistic versions and retains tombstones', async () => {
+      const hall = createHall('hall-versioned', scope);
+
+      await database.transaction(async (transaction) => {
+        await transaction.repository('halls').put(scope, hall, {
+          expectedVersion: null,
+        });
+      });
+
+      const updated = { ...hall, name: 'Updated Hall', version: 2 };
+      await database.transaction(async (transaction) => {
+        await transaction.repository('halls').put(scope, updated, {
+          expectedVersion: 1,
+        });
+      });
+
+      await expect(
+        database.transaction(async (transaction) => {
+          await transaction
+            .repository('halls')
+            .put(scope, { ...updated, name: 'Stale Update', version: 3 }, { expectedVersion: 1 });
+        }),
+      ).rejects.toBeInstanceOf(OptimisticConcurrencyError);
+
+      await database.transaction(async (transaction) => {
+        await transaction.repository('halls').tombstone(scope, hall.id, {
+          expectedVersion: 2,
+          deletedAt: timestamp,
+        });
+      });
+
+      await expect(database.repository('halls').getById(scope, hall.id)).resolves.toBeNull();
+      const deletedPage = await database.repository('halls').list(scope, { includeDeleted: true });
+      expect(deletedPage.items[0]).toMatchObject({
+        id: hall.id,
+        deletedAt: timestamp,
+        version: 3,
+      });
+    });
+
+    it('deduplicates client mutations and enforces the outbox lifecycle', async () => {
+      const mutation = createMutation(createHall('hall-outbox', scope));
+
+      await database.transaction(async (transaction) => {
+        await transaction.outbox.enqueue(mutation);
+        await transaction.outbox.enqueue(mutation);
+      });
+
+      await expect(database.outbox.list(scope)).resolves.toHaveLength(1);
+
+      await database.transaction(async (transaction) => {
+        const claimed = await transaction.outbox.claimNext(scope, 10, timestamp);
+        expect(claimed).toHaveLength(1);
+        expect(claimed[0]).toMatchObject({
+          status: 'processing',
+          attemptCount: 1,
+        });
+
+        await transaction.outbox.transition(mutation.id, 'processing', 'applied', {
+          appliedAt: timestamp,
+        });
+      });
+
+      await expect(database.outbox.getById(mutation.id)).resolves.toMatchObject({
+        status: 'applied',
+        appliedAt: timestamp,
+      });
+      await expect(
+        database.transaction(async (transaction) => {
+          await transaction.outbox.transition(mutation.id, 'applied', 'processing');
+        }),
+      ).rejects.toThrow(/Invalid outbox transition/);
+    });
+
+    it('stores pull cursors and resolves sync conflicts per branch', async () => {
+      const conflict = createConflict();
+
+      await database.transaction(async (transaction) => {
+        await transaction.syncState.setCursor({
+          organizationId,
+          branchId,
+          value: 'cursor-42',
+          updatedAt: timestamp,
+        });
+        await transaction.syncState.addConflict(conflict);
+      });
+
+      await expect(database.syncState.getCursor(scope)).resolves.toMatchObject({
+        value: 'cursor-42',
+      });
+      await expect(database.syncState.listConflicts(otherBranchScope)).resolves.toEqual([]);
+
+      await database.transaction(async (transaction) => {
+        await transaction.syncState.resolveConflict(
+          conflict.id,
+          'resolved_server',
+          timestamp,
+          conflict.serverPayload,
+        );
+      });
+
+      await expect(database.syncState.getConflict(conflict.id)).resolves.toMatchObject({
+        status: 'resolved_server',
+        resolvedAt: timestamp,
+      });
+    });
+  });
+}
+
+function createHall(id: string, targetScope: RepositoryScope): Hall {
+  if (!targetScope.branchId) {
+    throw new Error('Hall fixture requires a branch scope');
+  }
+
+  return {
+    id: toDomainId<HallId>(id),
+    organizationId: targetScope.organizationId,
+    branchId: targetScope.branchId,
+    name: id,
+    sortOrder: 0,
+    version: 1,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    syncStatus: 'pending',
+    clientMutationId: mutationId,
+  };
+}
+
+function createMutation(hall: Hall): OutboxMutation {
+  return {
+    id: mutationId,
+    organizationId,
+    branchId,
+    deviceId,
+    clientMutationId: mutationId,
+    idempotencyKey: `${deviceId}:${mutationId}`,
+    repository: 'halls',
+    entityId: hall.id,
+    operation: 'create',
+    payload: {
+      id: hall.id,
+      name: hall.name,
+    },
+    status: 'pending',
+    attemptCount: 0,
+    createdAt: timestamp,
+  };
+}
+
+function createConflict(): SyncConflict {
+  return {
+    id: toDomainId<SyncConflictId>('conflict-contract'),
+    organizationId,
+    branchId,
+    mutationId,
+    repository: 'halls',
+    entityId: 'hall-conflicted',
+    baseVersion: 1,
+    serverVersion: 2,
+    localPayload: { name: 'Local Hall' },
+    serverPayload: { name: 'Server Hall' },
+    status: 'unresolved',
+    detectedAt: timestamp,
+  };
+}

--- a/src/domain/ids.ts
+++ b/src/domain/ids.ts
@@ -24,6 +24,7 @@ export type PaymentAllocationId = DomainId<'PaymentAllocation'>;
 export type ReceiptId = DomainId<'Receipt'>;
 export type AuditEventId = DomainId<'AuditEvent'>;
 export type MutationId = DomainId<'Mutation'>;
+export type SyncConflictId = DomainId<'SyncConflict'>;
 export type CorrelationId = DomainId<'Correlation'>;
 
 export function toDomainId<T extends DomainId<string>>(value: string): T {


### PR DESCRIPTION
## Summary
- define storage-engine-independent repository, transaction, outbox and sync-state contracts
- type repository collections against the v2 domain model
- define optimistic writes, soft-delete tombstones, mutation lifecycle, pull cursors and conflict resolution
- add an atomic in-memory reference adapter with serialized transactions and rollback
- add a reusable adapter contract suite for native SQLite and web IndexedDB implementations
- verify organization/branch isolation, entity+outbox atomicity, crash rollback, stale versions, idempotency and conflict handling

## Verification
- `npm run verify:full`
  - 6 Jest suites / 30 tests
  - TypeScript, format and lint gates
  - Expo web production export
  - Chromium smoke test

## Stack
This PR is stacked on #36 and targets `feat/9-domain-model-v2`. Retarget after the parent PR lands.

Closes #10
