### PR TITLE
feat(data): add native SQLite adapter (#11)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/app.json
+++ b/app.json
@@ -49,7 +49,8 @@
           "sounds": ["./assets/notification-sound.wav"],
           "mode": "development"
         }
-      ]
+      ],
+      "expo-sqlite"
     ],
     "extra": {
       "eas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-print": "~14.1.4",
         "expo-sharing": "~13.1.5",
         "expo-splash-screen": "~0.30.10",
+        "expo-sqlite": "~15.2.14",
         "expo-status-bar": "~2.2.3",
         "nativewind": "^2.0.11",
         "react": "19.0.0",
@@ -6208,6 +6209,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -9301,6 +9308,20 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "15.2.14",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-15.2.14.tgz",
+      "integrity": "sha512-6tWnEE0fcir30/e7eVwjeC7eKdncfVnIgo2JvnKpRndedyiFMXLMyOQWNVGnuhnSrPV2BHvGGjLByS/j5VgH4w==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expo-print": "~14.1.4",
     "expo-sharing": "~13.1.5",
     "expo-splash-screen": "~0.30.10",
+    "expo-sqlite": "~15.2.14",
     "expo-status-bar": "~2.2.3",
     "nativewind": "^2.0.11",
     "react": "19.0.0",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,1 +1,2 @@
 export * from './contracts';
+export * from './sqlite';

--- a/src/data/sqlite/__tests__/sqliteLocalDatabase.test.ts
+++ b/src/data/sqlite/__tests__/sqliteLocalDatabase.test.ts
@@ -1,0 +1,46 @@
+import { defineLocalDatabaseContract } from '../../testing/localDatabaseContract';
+import { NodeSqliteDriver } from '../../testing/nodeSqliteDriver';
+import { migrateSqliteDatabase, sqliteMigrations } from '../migrations';
+import { SqliteLocalDatabase } from '../sqliteLocalDatabase';
+
+defineLocalDatabaseContract('SQLite', () => SqliteLocalDatabase.open(new NodeSqliteDriver()));
+
+describe('SQLite migrations', () => {
+  it('applies each migration once when initialization is repeated', async () => {
+    const driver = new NodeSqliteDriver();
+
+    await migrateSqliteDatabase(driver);
+    await migrateSqliteDatabase(driver);
+
+    const applied = await driver.getAll<{ version: number; name: string }>(
+      `SELECT version, name
+       FROM schema_migrations
+       ORDER BY version`,
+    );
+    expect(applied).toEqual(sqliteMigrations.map(({ version, name }) => ({ version, name })));
+
+    await driver.close();
+  });
+});
+
+describe('SQLite lifecycle', () => {
+  it('lets an accepted transaction finish before closing the connection', async () => {
+    const database = await SqliteLocalDatabase.open(new NodeSqliteDriver());
+    let continueTransaction!: () => void;
+    const transactionGate = new Promise<void>((resolve) => {
+      continueTransaction = resolve;
+    });
+
+    const transaction = database.transaction(async () => {
+      await transactionGate;
+      return 'committed';
+    });
+    const close = database.close();
+
+    continueTransaction();
+
+    await expect(transaction).resolves.toBe('committed');
+    await expect(close).resolves.toBeUndefined();
+    expect(() => database.repository('halls')).toThrow(/closed/);
+  });
+});

--- a/src/data/sqlite/expoSqliteDriver.ts
+++ b/src/data/sqlite/expoSqliteDriver.ts
@@ -1,0 +1,53 @@
+import { openDatabaseAsync, SQLiteDatabase } from 'expo-sqlite';
+import { SqliteDriver, SqliteRow, SqliteRunResult, SqliteValue } from './sqliteDriver';
+
+export async function openExpoSqliteDriver(databaseName = 'orderia-v2.db'): Promise<SqliteDriver> {
+  const database = await openDatabaseAsync(databaseName);
+  return new ExpoSqliteDriver(database);
+}
+
+class ExpoSqliteDriver implements SqliteDriver {
+  constructor(private readonly database: SQLiteDatabase) {}
+
+  async exec(sql: string): Promise<void> {
+    await this.database.execAsync(sql);
+  }
+
+  async run(sql: string, parameters: readonly SqliteValue[] = []): Promise<SqliteRunResult> {
+    const result = await this.database.runAsync(sql, [...parameters]);
+    return {
+      changes: result.changes,
+      lastInsertRowId: result.lastInsertRowId,
+    };
+  }
+
+  async getFirst<Row extends SqliteRow>(
+    sql: string,
+    parameters: readonly SqliteValue[] = [],
+  ): Promise<Row | null> {
+    return this.database.getFirstAsync<Row>(sql, [...parameters]);
+  }
+
+  async getAll<Row extends SqliteRow>(
+    sql: string,
+    parameters: readonly SqliteValue[] = [],
+  ): Promise<readonly Row[]> {
+    return this.database.getAllAsync<Row>(sql, [...parameters]);
+  }
+
+  async exclusiveTransaction<Result>(
+    work: (transaction: SqliteDriver) => Promise<Result>,
+  ): Promise<Result> {
+    let result!: Result;
+
+    await this.database.withExclusiveTransactionAsync(async (transaction) => {
+      result = await work(new ExpoSqliteDriver(transaction));
+    });
+
+    return result;
+  }
+
+  async close(): Promise<void> {
+    await this.database.closeAsync();
+  }
+}

--- a/src/data/sqlite/index.ts
+++ b/src/data/sqlite/index.ts
@@ -1,0 +1,4 @@
+export * from './migrations';
+export * from './openNativeLocalDatabase';
+export * from './sqliteDriver';
+export * from './sqliteLocalDatabase';

--- a/src/data/sqlite/migrations.ts
+++ b/src/data/sqlite/migrations.ts
@@ -1,0 +1,123 @@
+import { SqliteDriver } from './sqliteDriver';
+
+export interface SqliteMigration {
+  readonly version: number;
+  readonly name: string;
+  readonly sql: string;
+}
+
+export const sqliteMigrations: readonly SqliteMigration[] = [
+  {
+    version: 1,
+    name: 'local_first_foundation',
+    sql: `
+      CREATE TABLE IF NOT EXISTS domain_records (
+        collection TEXT NOT NULL,
+        organization_id TEXT NOT NULL,
+        branch_id TEXT NOT NULL DEFAULT '',
+        entity_id TEXT NOT NULL,
+        version INTEGER NOT NULL,
+        deleted_at TEXT,
+        entity_json TEXT NOT NULL,
+        PRIMARY KEY (collection, organization_id, branch_id, entity_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_domain_records_scope
+        ON domain_records (organization_id, branch_id, collection, entity_id);
+
+      CREATE INDEX IF NOT EXISTS idx_domain_records_active
+        ON domain_records (organization_id, branch_id, collection, entity_id)
+        WHERE deleted_at IS NULL;
+
+      CREATE TABLE IF NOT EXISTS outbox_mutations (
+        id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        branch_id TEXT NOT NULL,
+        device_id TEXT NOT NULL,
+        client_mutation_id TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        repository TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        operation TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        base_version INTEGER,
+        status TEXT NOT NULL,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        last_attempt_at TEXT,
+        next_attempt_at TEXT,
+        applied_at TEXT,
+        error_code TEXT,
+        error_message TEXT,
+        UNIQUE (device_id, client_mutation_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_outbox_claim
+        ON outbox_mutations (
+          organization_id,
+          branch_id,
+          status,
+          next_attempt_at,
+          created_at
+        );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        organization_id TEXT NOT NULL,
+        branch_id TEXT NOT NULL,
+        cursor_value TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (organization_id, branch_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_conflicts (
+        id TEXT PRIMARY KEY,
+        organization_id TEXT NOT NULL,
+        branch_id TEXT NOT NULL,
+        mutation_id TEXT NOT NULL,
+        repository TEXT NOT NULL,
+        entity_id TEXT NOT NULL,
+        base_version INTEGER,
+        server_version INTEGER NOT NULL,
+        local_payload_json TEXT NOT NULL,
+        server_payload_json TEXT NOT NULL,
+        status TEXT NOT NULL,
+        detected_at TEXT NOT NULL,
+        resolved_at TEXT,
+        resolution_payload_json TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sync_conflicts_scope
+        ON sync_conflicts (organization_id, branch_id, status, detected_at);
+    `,
+  },
+];
+
+export async function migrateSqliteDatabase(driver: SqliteDriver): Promise<void> {
+  await driver.exec(`
+    PRAGMA foreign_keys = ON;
+    PRAGMA journal_mode = WAL;
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      applied_at TEXT NOT NULL
+    );
+  `);
+
+  const appliedRows = await driver.getAll<{ version: number }>(
+    'SELECT version FROM schema_migrations ORDER BY version',
+  );
+  const appliedVersions = new Set(appliedRows.map((row) => Number(row.version)));
+
+  for (const migration of sqliteMigrations) {
+    if (appliedVersions.has(migration.version)) continue;
+
+    await driver.exclusiveTransaction(async (transaction) => {
+      await transaction.exec(migration.sql);
+      await transaction.run(
+        `INSERT INTO schema_migrations (version, name, applied_at)
+         VALUES (?, ?, ?)`,
+        [migration.version, migration.name, new Date().toISOString()],
+      );
+    });
+  }
+}

--- a/src/data/sqlite/openNativeLocalDatabase.ts
+++ b/src/data/sqlite/openNativeLocalDatabase.ts
@@ -1,0 +1,9 @@
+import { openExpoSqliteDriver } from './expoSqliteDriver';
+import { SqliteLocalDatabase } from './sqliteLocalDatabase';
+
+export async function openNativeLocalDatabase(
+  databaseName = 'orderia-v2.db',
+): Promise<SqliteLocalDatabase> {
+  const driver = await openExpoSqliteDriver(databaseName);
+  return SqliteLocalDatabase.open(driver);
+}

--- a/src/data/sqlite/sqliteDriver.ts
+++ b/src/data/sqlite/sqliteDriver.ts
@@ -1,0 +1,24 @@
+export type SqliteValue = null | number | string;
+export type SqliteRow = Record<string, null | number | string>;
+
+export interface SqliteRunResult {
+  readonly changes: number;
+  readonly lastInsertRowId?: number;
+}
+
+export interface SqliteDriver {
+  exec(sql: string): Promise<void>;
+  run(sql: string, parameters?: readonly SqliteValue[]): Promise<SqliteRunResult>;
+  getFirst<Row extends SqliteRow>(
+    sql: string,
+    parameters?: readonly SqliteValue[],
+  ): Promise<Row | null>;
+  getAll<Row extends SqliteRow>(
+    sql: string,
+    parameters?: readonly SqliteValue[],
+  ): Promise<readonly Row[]>;
+  exclusiveTransaction<Result>(
+    work: (transaction: SqliteDriver) => Promise<Result>,
+  ): Promise<Result>;
+  close(): Promise<void>;
+}

--- a/src/data/sqlite/sqliteLocalDatabase.ts
+++ b/src/data/sqlite/sqliteLocalDatabase.ts
@@ -1,0 +1,177 @@
+import {
+  DomainEntityMap,
+  LocalDatabase,
+  LocalTransaction,
+  OutboxRepository,
+  ReadRepository,
+  RepositoryName,
+  SyncStateRepository,
+} from '../contracts';
+import { migrateSqliteDatabase } from './migrations';
+import { SqliteDriver } from './sqliteDriver';
+import { SqliteOutboxRepository } from './sqliteOutboxRepository';
+import { SqliteRepository } from './sqliteRepository';
+import { SqliteSyncStateRepository } from './sqliteSyncStateRepository';
+
+type DatabaseState = 'open' | 'closing' | 'closed';
+
+export class SqliteLocalDatabase implements LocalDatabase {
+  readonly engine = 'sqlite' as const;
+
+  private transactionTail: Promise<void> = Promise.resolve();
+  private state: DatabaseState = 'open';
+  private readonly readDriver: SqliteDriver;
+
+  private constructor(private readonly driver: SqliteDriver) {
+    this.readDriver = new QueuedReadSqliteDriver(
+      driver,
+      async () => this.transactionTail,
+      () => this.assertOpen(),
+    );
+  }
+
+  static async open(driver: SqliteDriver): Promise<SqliteLocalDatabase> {
+    try {
+      await migrateSqliteDatabase(driver);
+      return new SqliteLocalDatabase(driver);
+    } catch (error) {
+      await driver.close();
+      throw error;
+    }
+  }
+
+  get outbox(): Pick<OutboxRepository, 'getById' | 'list'> {
+    this.assertOpen();
+    return new SqliteOutboxRepository(() => {
+      this.assertOpen();
+      return this.readDriver;
+    });
+  }
+
+  get syncState(): Pick<SyncStateRepository, 'getCursor' | 'getConflict' | 'listConflicts'> {
+    this.assertOpen();
+    return new SqliteSyncStateRepository(() => {
+      this.assertOpen();
+      return this.readDriver;
+    });
+  }
+
+  repository<Name extends RepositoryName>(name: Name): ReadRepository<DomainEntityMap[Name]> {
+    this.assertOpen();
+    return new SqliteRepository(name, () => {
+      this.assertOpen();
+      return this.readDriver;
+    });
+  }
+
+  async transaction<Result>(
+    work: (transaction: LocalTransaction) => Promise<Result>,
+  ): Promise<Result> {
+    this.assertOpen();
+
+    const previousTransaction = this.transactionTail;
+    let releaseTransaction!: () => void;
+    this.transactionTail = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    await previousTransaction;
+    let transactionActive = true;
+
+    try {
+      return await this.driver.exclusiveTransaction(async (transactionDriver) => {
+        const getTransactionDriver = () => {
+          if (!transactionActive) {
+            throw new Error('Local transaction is no longer active');
+          }
+
+          return transactionDriver;
+        };
+        return work(createTransaction(getTransactionDriver));
+      });
+    } finally {
+      transactionActive = false;
+      releaseTransaction();
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.state === 'closed') return;
+    if (this.state === 'closing') {
+      await this.transactionTail;
+      return;
+    }
+
+    this.state = 'closing';
+    await this.transactionTail;
+    await this.driver.close();
+    this.state = 'closed';
+  }
+
+  private assertOpen(): void {
+    if (this.state !== 'open') {
+      throw new Error('Local database is closed');
+    }
+  }
+}
+
+function createTransaction(getDriver: () => SqliteDriver): LocalTransaction {
+  return {
+    repository: <Name extends RepositoryName>(name: Name) => new SqliteRepository(name, getDriver),
+    outbox: new SqliteOutboxRepository(getDriver),
+    syncState: new SqliteSyncStateRepository(getDriver),
+  };
+}
+
+class QueuedReadSqliteDriver implements SqliteDriver {
+  constructor(
+    private readonly driver: SqliteDriver,
+    private readonly waitForTransactions: () => Promise<void>,
+    private readonly assertOpen: () => void,
+  ) {}
+
+  async exec(sql: string): Promise<void> {
+    await this.wait();
+    return this.driver.exec(sql);
+  }
+
+  async run(
+    sql: string,
+    parameters?: Parameters<SqliteDriver['run']>[1],
+  ): ReturnType<SqliteDriver['run']> {
+    await this.wait();
+    return this.driver.run(sql, parameters);
+  }
+
+  async getFirst<Row extends Record<string, null | number | string>>(
+    sql: string,
+    parameters?: Parameters<SqliteDriver['getFirst']>[1],
+  ): Promise<Row | null> {
+    await this.wait();
+    return this.driver.getFirst<Row>(sql, parameters);
+  }
+
+  async getAll<Row extends Record<string, null | number | string>>(
+    sql: string,
+    parameters?: Parameters<SqliteDriver['getAll']>[1],
+  ): Promise<readonly Row[]> {
+    await this.wait();
+    return this.driver.getAll<Row>(sql, parameters);
+  }
+
+  async exclusiveTransaction<Result>(
+    _work: (transaction: SqliteDriver) => Promise<Result>,
+  ): Promise<Result> {
+    throw new Error('Read-only SQLite driver cannot start a transaction');
+  }
+
+  async close(): Promise<void> {
+    throw new Error('Read-only SQLite driver cannot close the database');
+  }
+
+  private async wait(): Promise<void> {
+    this.assertOpen();
+    await this.waitForTransactions();
+    this.assertOpen();
+  }
+}

--- a/src/data/sqlite/sqliteOutboxRepository.ts
+++ b/src/data/sqlite/sqliteOutboxRepository.ts
@@ -1,0 +1,276 @@
+import {
+  OutboxMutation,
+  OutboxRepository,
+  OutboxStatus,
+  OutboxTransitionPatch,
+  RepositoryScope,
+  assertOutboxTransition,
+} from '../contracts';
+import { MutationId } from '../../domain/ids';
+import { SqliteDriver, SqliteRow, SqliteValue } from './sqliteDriver';
+import { parseJson, serializeJson, stableSerialize } from './sqliteSerialization';
+
+interface OutboxRow extends SqliteRow {
+  id: string;
+  organization_id: string;
+  branch_id: string;
+  device_id: string;
+  client_mutation_id: string;
+  idempotency_key: string;
+  repository: string;
+  entity_id: string;
+  operation: string;
+  payload_json: string;
+  base_version: number | null;
+  status: string;
+  attempt_count: number;
+  created_at: string;
+  last_attempt_at: string | null;
+  next_attempt_at: string | null;
+  applied_at: string | null;
+  error_code: string | null;
+  error_message: string | null;
+}
+
+const outboxColumns = `
+  id,
+  organization_id,
+  branch_id,
+  device_id,
+  client_mutation_id,
+  idempotency_key,
+  repository,
+  entity_id,
+  operation,
+  payload_json,
+  base_version,
+  status,
+  attempt_count,
+  created_at,
+  last_attempt_at,
+  next_attempt_at,
+  applied_at,
+  error_code,
+  error_message
+`;
+
+export class SqliteOutboxRepository implements OutboxRepository {
+  constructor(private readonly getDriver: () => SqliteDriver) {}
+
+  async enqueue(mutation: OutboxMutation): Promise<OutboxMutation> {
+    if (mutation.status !== 'pending' || mutation.attemptCount !== 0) {
+      throw new Error('New outbox mutations must start pending with zero attempts');
+    }
+
+    if (!mutation.idempotencyKey.trim()) {
+      throw new Error('Outbox mutation requires an idempotency key');
+    }
+
+    const existingClientMutation = await this.getDriver().getFirst<OutboxRow>(
+      `SELECT ${outboxColumns}
+       FROM outbox_mutations
+       WHERE device_id = ? AND client_mutation_id = ?
+       LIMIT 1`,
+      [mutation.deviceId, mutation.clientMutationId],
+    );
+
+    if (existingClientMutation) {
+      const existing = mapOutboxRow(existingClientMutation);
+      if (stableSerialize(existing) !== stableSerialize(mutation)) {
+        throw new Error('Client mutation ID was reused with different content');
+      }
+
+      return existing;
+    }
+
+    const existingId = await this.getById(mutation.id);
+    if (existingId) {
+      throw new Error(`Outbox mutation ID already exists: ${mutation.id}`);
+    }
+
+    await this.getDriver().run(
+      `INSERT INTO outbox_mutations (
+         ${outboxColumns}
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      outboxParameters(mutation),
+    );
+    return cloneMutation(mutation);
+  }
+
+  async getById(id: MutationId): Promise<OutboxMutation | null> {
+    const row = await this.getDriver().getFirst<OutboxRow>(
+      `SELECT ${outboxColumns}
+       FROM outbox_mutations
+       WHERE id = ?
+       LIMIT 1`,
+      [id],
+    );
+    return row ? mapOutboxRow(row) : null;
+  }
+
+  async list(
+    scope: RepositoryScope,
+    statuses?: readonly OutboxStatus[],
+  ): Promise<readonly OutboxMutation[]> {
+    if (statuses?.length === 0) return [];
+
+    const parameters: SqliteValue[] = [scope.organizationId];
+    const branchClause = scope.branchId === undefined ? '' : 'AND branch_id = ?';
+    if (scope.branchId !== undefined) {
+      parameters.push(scope.branchId);
+    }
+
+    const statusClause =
+      statuses === undefined ? '' : `AND status IN (${statuses.map(() => '?').join(', ')})`;
+    if (statuses !== undefined) {
+      parameters.push(...statuses);
+    }
+
+    const rows = await this.getDriver().getAll<OutboxRow>(
+      `SELECT ${outboxColumns}
+       FROM outbox_mutations
+       WHERE organization_id = ?
+         ${branchClause}
+         ${statusClause}
+       ORDER BY created_at, id`,
+      parameters,
+    );
+    return rows.map(mapOutboxRow);
+  }
+
+  async claimNext(
+    scope: RepositoryScope,
+    limit: number,
+    now: string,
+  ): Promise<readonly OutboxMutation[]> {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error('Outbox claim limit must be a positive safe integer');
+    }
+
+    const candidates = (await this.list(scope, ['pending', 'retry_wait']))
+      .filter(
+        (mutation) =>
+          mutation.status === 'pending' ||
+          mutation.nextAttemptAt === undefined ||
+          mutation.nextAttemptAt <= now,
+      )
+      .slice(0, limit);
+
+    const claimed: OutboxMutation[] = [];
+    for (const mutation of candidates) {
+      claimed.push(
+        await this.transition(mutation.id, mutation.status, 'processing', {
+          lastAttemptAt: now,
+        }),
+      );
+    }
+    return claimed;
+  }
+
+  async transition(
+    id: MutationId,
+    expectedStatus: OutboxStatus,
+    nextStatus: OutboxStatus,
+    patch: OutboxTransitionPatch = {},
+  ): Promise<OutboxMutation> {
+    const current = await this.getById(id);
+    if (!current) {
+      throw new Error(`Unknown outbox mutation ${id}`);
+    }
+
+    if (current.status !== expectedStatus) {
+      throw new Error(`Outbox mutation ${id} expected ${expectedStatus}, got ${current.status}`);
+    }
+
+    assertOutboxTransition(current.status, nextStatus);
+
+    if (nextStatus === 'applied' && patch.appliedAt === undefined) {
+      throw new Error('Applied outbox mutation requires appliedAt');
+    }
+
+    if (nextStatus === 'retry_wait' && patch.nextAttemptAt === undefined) {
+      throw new Error('Retrying outbox mutation requires nextAttemptAt');
+    }
+
+    const next: OutboxMutation = {
+      ...current,
+      ...patch,
+      status: nextStatus,
+      attemptCount: nextStatus === 'processing' ? current.attemptCount + 1 : current.attemptCount,
+    };
+    await this.getDriver().run(
+      `UPDATE outbox_mutations
+       SET status = ?,
+           attempt_count = ?,
+           last_attempt_at = ?,
+           next_attempt_at = ?,
+           applied_at = ?,
+           error_code = ?,
+           error_message = ?
+       WHERE id = ?`,
+      [
+        next.status,
+        next.attemptCount,
+        next.lastAttemptAt ?? null,
+        next.nextAttemptAt ?? null,
+        next.appliedAt ?? null,
+        next.errorCode ?? null,
+        next.errorMessage ?? null,
+        next.id,
+      ],
+    );
+    return next;
+  }
+}
+
+function outboxParameters(mutation: OutboxMutation): readonly SqliteValue[] {
+  return [
+    mutation.id,
+    mutation.organizationId,
+    mutation.branchId,
+    mutation.deviceId,
+    mutation.clientMutationId,
+    mutation.idempotencyKey,
+    mutation.repository,
+    mutation.entityId,
+    mutation.operation,
+    serializeJson(mutation.payload),
+    mutation.baseVersion ?? null,
+    mutation.status,
+    mutation.attemptCount,
+    mutation.createdAt,
+    mutation.lastAttemptAt ?? null,
+    mutation.nextAttemptAt ?? null,
+    mutation.appliedAt ?? null,
+    mutation.errorCode ?? null,
+    mutation.errorMessage ?? null,
+  ];
+}
+
+function mapOutboxRow(row: OutboxRow): OutboxMutation {
+  return {
+    id: row.id as OutboxMutation['id'],
+    organizationId: row.organization_id as OutboxMutation['organizationId'],
+    branchId: row.branch_id as OutboxMutation['branchId'],
+    deviceId: row.device_id as OutboxMutation['deviceId'],
+    clientMutationId: row.client_mutation_id as OutboxMutation['clientMutationId'],
+    idempotencyKey: row.idempotency_key,
+    repository: row.repository as OutboxMutation['repository'],
+    entityId: row.entity_id,
+    operation: row.operation as OutboxMutation['operation'],
+    payload: parseJson<OutboxMutation['payload']>(row.payload_json),
+    ...(row.base_version === null ? {} : { baseVersion: row.base_version }),
+    status: row.status as OutboxStatus,
+    attemptCount: row.attempt_count,
+    createdAt: row.created_at,
+    ...(row.last_attempt_at === null ? {} : { lastAttemptAt: row.last_attempt_at }),
+    ...(row.next_attempt_at === null ? {} : { nextAttemptAt: row.next_attempt_at }),
+    ...(row.applied_at === null ? {} : { appliedAt: row.applied_at }),
+    ...(row.error_code === null ? {} : { errorCode: row.error_code }),
+    ...(row.error_message === null ? {} : { errorMessage: row.error_message }),
+  };
+}
+
+function cloneMutation(mutation: OutboxMutation): OutboxMutation {
+  return parseJson<OutboxMutation>(serializeJson(mutation));
+}

--- a/src/data/sqlite/sqliteRepository.ts
+++ b/src/data/sqlite/sqliteRepository.ts
@@ -1,0 +1,209 @@
+import {
+  DomainEntityMap,
+  PutOptions,
+  RepositoryName,
+  RepositoryPage,
+  RepositoryQuery,
+  RepositoryScope,
+  TombstoneOptions,
+  TransactionRepository,
+} from '../contracts';
+import { SqliteDriver, SqliteRow, SqliteValue } from './sqliteDriver';
+import {
+  assertEntityMatchesScope,
+  assertExpectedVersion,
+  branchKey,
+  parseJson,
+  readDeletedAt,
+  readEntityVersion,
+  serializeJson,
+} from './sqliteSerialization';
+
+interface DomainRecordRow extends SqliteRow {
+  entity_json: string;
+  version: number;
+  deleted_at: string | null;
+}
+
+export class SqliteRepository<Name extends RepositoryName> implements TransactionRepository<
+  DomainEntityMap[Name]
+> {
+  constructor(
+    private readonly name: Name,
+    private readonly getDriver: () => SqliteDriver,
+  ) {}
+
+  async getById(
+    scope: RepositoryScope,
+    id: DomainEntityMap[Name]['id'],
+  ): Promise<DomainEntityMap[Name] | null> {
+    const { sql, parameters } = this.recordSelector(scope, id);
+    const row = await this.getDriver().getFirst<DomainRecordRow>(
+      `SELECT entity_json, version, deleted_at
+       FROM domain_records
+       WHERE ${sql} AND deleted_at IS NULL
+       ORDER BY branch_id
+       LIMIT 1`,
+      parameters,
+    );
+    return row ? parseJson<DomainEntityMap[Name]>(row.entity_json) : null;
+  }
+
+  async list(
+    scope: RepositoryScope,
+    query: RepositoryQuery = {},
+  ): Promise<RepositoryPage<DomainEntityMap[Name]>> {
+    const limit = query.limit ?? 100;
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error('Repository query limit must be a positive safe integer');
+    }
+
+    const offset = query.after ? Number(query.after) : 0;
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error('Repository cursor is invalid');
+    }
+
+    const parameters: SqliteValue[] = [this.name, scope.organizationId];
+    const branchClause = scope.branchId === undefined ? '' : ' AND branch_id = ?';
+    if (scope.branchId !== undefined) {
+      parameters.push(scope.branchId);
+    }
+
+    parameters.push(limit + 1, offset);
+    const rows = await this.getDriver().getAll<DomainRecordRow>(
+      `SELECT entity_json, version, deleted_at
+       FROM domain_records
+       WHERE collection = ?
+         AND organization_id = ?
+         ${branchClause}
+         ${query.includeDeleted === true ? '' : 'AND deleted_at IS NULL'}
+       ORDER BY entity_id
+       LIMIT ? OFFSET ?`,
+      parameters,
+    );
+    const hasNextPage = rows.length > limit;
+    const pageRows = rows.slice(0, limit);
+
+    return {
+      items: pageRows.map((row) => parseJson<DomainEntityMap[Name]>(row.entity_json)),
+      nextCursor: hasNextPage ? String(offset + pageRows.length) : undefined,
+    };
+  }
+
+  async put(
+    scope: RepositoryScope,
+    entity: DomainEntityMap[Name],
+    options: PutOptions = {},
+  ): Promise<DomainEntityMap[Name]> {
+    assertEntityMatchesScope(this.name, entity, scope);
+    const existing = await this.findStoredRecord(scope, entity.id);
+    const actualVersion = existing ? Number(existing.version) : null;
+    assertExpectedVersion(this.name, entity.id, options.expectedVersion, actualVersion);
+
+    const version = readEntityVersion(entity) ?? (actualVersion ?? 0) + 1;
+    await this.getDriver().run(
+      `INSERT INTO domain_records (
+         collection,
+         organization_id,
+         branch_id,
+         entity_id,
+         version,
+         deleted_at,
+         entity_json
+       ) VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (collection, organization_id, branch_id, entity_id)
+       DO UPDATE SET
+         version = excluded.version,
+         deleted_at = excluded.deleted_at,
+         entity_json = excluded.entity_json`,
+      [
+        this.name,
+        scope.organizationId,
+        branchKey(scope),
+        entity.id,
+        version,
+        readDeletedAt(entity) ?? null,
+        serializeJson(entity),
+      ],
+    );
+    return parseJson<DomainEntityMap[Name]>(serializeJson(entity));
+  }
+
+  async tombstone(
+    scope: RepositoryScope,
+    id: DomainEntityMap[Name]['id'],
+    options: TombstoneOptions,
+  ): Promise<DomainEntityMap[Name]> {
+    const existing = await this.findStoredRecord(scope, id);
+    if (!existing) {
+      throw new Error(`Cannot tombstone missing ${this.name}/${id}`);
+    }
+
+    const actualVersion = Number(existing.version);
+    assertExpectedVersion(this.name, id, options.expectedVersion, actualVersion);
+
+    const current = parseJson<DomainEntityMap[Name]>(existing.entity_json);
+    const nextVersion = actualVersion + 1;
+    const tombstoned = {
+      ...current,
+      deletedAt: options.deletedAt,
+      ...('version' in current ? { version: nextVersion } : {}),
+    } as DomainEntityMap[Name];
+
+    await this.getDriver().run(
+      `UPDATE domain_records
+       SET version = ?, deleted_at = ?, entity_json = ?
+       WHERE collection = ?
+         AND organization_id = ?
+         AND branch_id = ?
+         AND entity_id = ?`,
+      [
+        nextVersion,
+        options.deletedAt,
+        serializeJson(tombstoned),
+        this.name,
+        scope.organizationId,
+        branchKey(scope),
+        id,
+      ],
+    );
+    return tombstoned;
+  }
+
+  private async findStoredRecord(
+    scope: RepositoryScope,
+    id: string,
+  ): Promise<DomainRecordRow | null> {
+    const { sql, parameters } = this.recordSelector(scope, id, true);
+    return this.getDriver().getFirst<DomainRecordRow>(
+      `SELECT entity_json, version, deleted_at
+       FROM domain_records
+       WHERE ${sql}
+       LIMIT 1`,
+      parameters,
+    );
+  }
+
+  private recordSelector(
+    scope: RepositoryScope,
+    id: string,
+    exactBranch = false,
+  ): { readonly sql: string; readonly parameters: readonly SqliteValue[] } {
+    const parameters: SqliteValue[] = [this.name, scope.organizationId];
+    const shouldFilterBranch = exactBranch || scope.branchId !== undefined;
+    const branchClause = shouldFilterBranch ? ' AND branch_id = ?' : '';
+
+    if (shouldFilterBranch) {
+      parameters.push(branchKey(scope));
+    }
+
+    parameters.push(id);
+    return {
+      sql: `collection = ?
+            AND organization_id = ?
+            ${branchClause}
+            AND entity_id = ?`,
+      parameters,
+    };
+  }
+}

--- a/src/data/sqlite/sqliteSerialization.ts
+++ b/src/data/sqlite/sqliteSerialization.ts
@@ -1,0 +1,83 @@
+import { OptimisticConcurrencyError, RepositoryName, RepositoryScope } from '../contracts';
+import { JsonValue } from '../../domain/entities';
+
+export function branchKey(scope: RepositoryScope): string {
+  return scope.branchId ?? '';
+}
+
+export function parseJson<Value>(value: string): Value {
+  return JSON.parse(value) as Value;
+}
+
+export function serializeJson(value: JsonValue | object): string {
+  return JSON.stringify(value);
+}
+
+export function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+export function assertEntityMatchesScope(
+  repository: RepositoryName,
+  entity: object & { readonly id: string },
+  scope: RepositoryScope,
+): void {
+  const organizationId =
+    'organizationId' in entity && typeof entity.organizationId === 'string'
+      ? entity.organizationId
+      : undefined;
+  const entityBranchId =
+    'branchId' in entity && typeof entity.branchId === 'string' ? entity.branchId : undefined;
+
+  if (organizationId !== undefined && organizationId !== scope.organizationId) {
+    throw new Error('Entity organization does not match repository scope');
+  }
+
+  if (entityBranchId !== undefined && entityBranchId !== scope.branchId) {
+    throw new Error('Entity branch does not match repository scope');
+  }
+
+  if (repository === 'organizations' && entity.id !== scope.organizationId) {
+    throw new Error('Organization entity ID does not match repository scope');
+  }
+}
+
+export function assertExpectedVersion(
+  repository: RepositoryName,
+  entityId: string,
+  expectedVersion: number | null | undefined,
+  actualVersion: number | null,
+): void {
+  if (expectedVersion === undefined) return;
+
+  if (expectedVersion !== actualVersion) {
+    throw new OptimisticConcurrencyError(repository, entityId, expectedVersion, actualVersion);
+  }
+}
+
+export function readEntityVersion(entity: object): number | undefined {
+  if ('version' in entity && typeof entity.version === 'number') {
+    return entity.version;
+  }
+
+  return undefined;
+}
+
+export function readDeletedAt(entity: object): string | undefined {
+  if ('deletedAt' in entity && typeof entity.deletedAt === 'string') {
+    return entity.deletedAt;
+  }
+
+  return undefined;
+}

--- a/src/data/sqlite/sqliteSyncStateRepository.ts
+++ b/src/data/sqlite/sqliteSyncStateRepository.ts
@@ -1,0 +1,241 @@
+import {
+  RepositoryScope,
+  SyncConflict,
+  SyncConflictStatus,
+  SyncCursor,
+  SyncStateRepository,
+} from '../contracts';
+import { JsonValue } from '../../domain/entities';
+import { SyncConflictId } from '../../domain/ids';
+import { SqliteDriver, SqliteRow, SqliteValue } from './sqliteDriver';
+import { parseJson, serializeJson } from './sqliteSerialization';
+
+interface CursorRow extends SqliteRow {
+  organization_id: string;
+  branch_id: string;
+  cursor_value: string;
+  updated_at: string;
+}
+
+interface ConflictRow extends SqliteRow {
+  id: string;
+  organization_id: string;
+  branch_id: string;
+  mutation_id: string;
+  repository: string;
+  entity_id: string;
+  base_version: number | null;
+  server_version: number;
+  local_payload_json: string;
+  server_payload_json: string;
+  status: string;
+  detected_at: string;
+  resolved_at: string | null;
+  resolution_payload_json: string | null;
+}
+
+const conflictColumns = `
+  id,
+  organization_id,
+  branch_id,
+  mutation_id,
+  repository,
+  entity_id,
+  base_version,
+  server_version,
+  local_payload_json,
+  server_payload_json,
+  status,
+  detected_at,
+  resolved_at,
+  resolution_payload_json
+`;
+
+export class SqliteSyncStateRepository implements SyncStateRepository {
+  constructor(private readonly getDriver: () => SqliteDriver) {}
+
+  async getCursor(scope: RepositoryScope): Promise<SyncCursor | null> {
+    if (scope.branchId === undefined) {
+      throw new Error('Sync cursor access requires a branch scope');
+    }
+
+    const row = await this.getDriver().getFirst<CursorRow>(
+      `SELECT organization_id, branch_id, cursor_value, updated_at
+       FROM sync_cursors
+       WHERE organization_id = ? AND branch_id = ?
+       LIMIT 1`,
+      [scope.organizationId, scope.branchId],
+    );
+    return row ? mapCursorRow(row) : null;
+  }
+
+  async setCursor(cursor: SyncCursor): Promise<SyncCursor> {
+    await this.getDriver().run(
+      `INSERT INTO sync_cursors (
+         organization_id,
+         branch_id,
+         cursor_value,
+         updated_at
+       ) VALUES (?, ?, ?, ?)
+       ON CONFLICT (organization_id, branch_id)
+       DO UPDATE SET
+         cursor_value = excluded.cursor_value,
+         updated_at = excluded.updated_at`,
+      [cursor.organizationId, cursor.branchId, cursor.value, cursor.updatedAt],
+    );
+    return cloneCursor(cursor);
+  }
+
+  async addConflict(conflict: SyncConflict): Promise<SyncConflict> {
+    if (conflict.status !== 'unresolved') {
+      throw new Error('New sync conflicts must start unresolved');
+    }
+
+    if (await this.getConflict(conflict.id)) {
+      throw new Error(`Sync conflict already exists: ${conflict.id}`);
+    }
+
+    await this.getDriver().run(
+      `INSERT INTO sync_conflicts (
+         ${conflictColumns}
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      conflictParameters(conflict),
+    );
+    return cloneConflict(conflict);
+  }
+
+  async getConflict(id: SyncConflictId): Promise<SyncConflict | null> {
+    const row = await this.getDriver().getFirst<ConflictRow>(
+      `SELECT ${conflictColumns}
+       FROM sync_conflicts
+       WHERE id = ?
+       LIMIT 1`,
+      [id],
+    );
+    return row ? mapConflictRow(row) : null;
+  }
+
+  async listConflicts(
+    scope: RepositoryScope,
+    statuses?: readonly SyncConflictStatus[],
+  ): Promise<readonly SyncConflict[]> {
+    if (statuses?.length === 0) return [];
+
+    const parameters: SqliteValue[] = [scope.organizationId];
+    const branchClause = scope.branchId === undefined ? '' : 'AND branch_id = ?';
+    if (scope.branchId !== undefined) {
+      parameters.push(scope.branchId);
+    }
+
+    const statusClause =
+      statuses === undefined ? '' : `AND status IN (${statuses.map(() => '?').join(', ')})`;
+    if (statuses !== undefined) {
+      parameters.push(...statuses);
+    }
+
+    const rows = await this.getDriver().getAll<ConflictRow>(
+      `SELECT ${conflictColumns}
+       FROM sync_conflicts
+       WHERE organization_id = ?
+         ${branchClause}
+         ${statusClause}
+       ORDER BY detected_at, id`,
+      parameters,
+    );
+    return rows.map(mapConflictRow);
+  }
+
+  async resolveConflict(
+    id: SyncConflictId,
+    status: Exclude<SyncConflictStatus, 'unresolved'>,
+    resolvedAt: string,
+    resolutionPayload?: JsonValue,
+  ): Promise<SyncConflict> {
+    const current = await this.getConflict(id);
+    if (!current) {
+      throw new Error(`Unknown sync conflict ${id}`);
+    }
+
+    if (current.status !== 'unresolved') {
+      throw new Error(`Sync conflict ${id} is already resolved`);
+    }
+
+    const next: SyncConflict = {
+      ...current,
+      status,
+      resolvedAt,
+      resolutionPayload,
+    };
+    await this.getDriver().run(
+      `UPDATE sync_conflicts
+       SET status = ?, resolved_at = ?, resolution_payload_json = ?
+       WHERE id = ?`,
+      [
+        status,
+        resolvedAt,
+        resolutionPayload === undefined ? null : serializeJson(resolutionPayload),
+        id,
+      ],
+    );
+    return next;
+  }
+}
+
+function conflictParameters(conflict: SyncConflict): readonly SqliteValue[] {
+  return [
+    conflict.id,
+    conflict.organizationId,
+    conflict.branchId,
+    conflict.mutationId,
+    conflict.repository,
+    conflict.entityId,
+    conflict.baseVersion ?? null,
+    conflict.serverVersion,
+    serializeJson(conflict.localPayload),
+    serializeJson(conflict.serverPayload),
+    conflict.status,
+    conflict.detectedAt,
+    conflict.resolvedAt ?? null,
+    conflict.resolutionPayload === undefined ? null : serializeJson(conflict.resolutionPayload),
+  ];
+}
+
+function mapCursorRow(row: CursorRow): SyncCursor {
+  return {
+    organizationId: row.organization_id as SyncCursor['organizationId'],
+    branchId: row.branch_id as SyncCursor['branchId'],
+    value: row.cursor_value,
+    updatedAt: row.updated_at,
+  };
+}
+
+function mapConflictRow(row: ConflictRow): SyncConflict {
+  return {
+    id: row.id as SyncConflict['id'],
+    organizationId: row.organization_id as SyncConflict['organizationId'],
+    branchId: row.branch_id as SyncConflict['branchId'],
+    mutationId: row.mutation_id as SyncConflict['mutationId'],
+    repository: row.repository as SyncConflict['repository'],
+    entityId: row.entity_id,
+    ...(row.base_version === null ? {} : { baseVersion: row.base_version }),
+    serverVersion: row.server_version,
+    localPayload: parseJson<JsonValue>(row.local_payload_json),
+    serverPayload: parseJson<JsonValue>(row.server_payload_json),
+    status: row.status as SyncConflictStatus,
+    detectedAt: row.detected_at,
+    ...(row.resolved_at === null ? {} : { resolvedAt: row.resolved_at }),
+    ...(row.resolution_payload_json === null
+      ? {}
+      : {
+          resolutionPayload: parseJson<JsonValue>(row.resolution_payload_json),
+        }),
+  };
+}
+
+function cloneCursor(cursor: SyncCursor): SyncCursor {
+  return parseJson<SyncCursor>(serializeJson(cursor));
+}
+
+function cloneConflict(conflict: SyncConflict): SyncConflict {
+  return parseJson<SyncConflict>(serializeJson(conflict));
+}

--- a/src/data/testing/index.ts
+++ b/src/data/testing/index.ts
@@ -1,2 +1,3 @@
 export * from './inMemoryLocalDatabase';
 export * from './localDatabaseContract';
+export * from './nodeSqliteDriver';

--- a/src/data/testing/nodeSqliteDriver.ts
+++ b/src/data/testing/nodeSqliteDriver.ts
@@ -1,0 +1,72 @@
+import { DatabaseSync, SQLInputValue } from 'node:sqlite';
+import { SqliteDriver, SqliteRow, SqliteRunResult, SqliteValue } from '../sqlite/sqliteDriver';
+
+export class NodeSqliteDriver implements SqliteDriver {
+  private readonly database: DatabaseSync;
+  private closed = false;
+
+  constructor(path = ':memory:') {
+    this.database = new DatabaseSync(path);
+  }
+
+  async exec(sql: string): Promise<void> {
+    this.assertOpen();
+    this.database.exec(sql);
+  }
+
+  async run(sql: string, parameters: readonly SqliteValue[] = []): Promise<SqliteRunResult> {
+    this.assertOpen();
+    const result = this.database.prepare(sql).run(...(parameters as readonly SQLInputValue[]));
+
+    return {
+      changes: Number(result.changes),
+      lastInsertRowId: Number(result.lastInsertRowid),
+    };
+  }
+
+  async getFirst<Row extends SqliteRow>(
+    sql: string,
+    parameters: readonly SqliteValue[] = [],
+  ): Promise<Row | null> {
+    this.assertOpen();
+    const row = this.database.prepare(sql).get(...(parameters as readonly SQLInputValue[]));
+    return row ? (row as Row) : null;
+  }
+
+  async getAll<Row extends SqliteRow>(
+    sql: string,
+    parameters: readonly SqliteValue[] = [],
+  ): Promise<readonly Row[]> {
+    this.assertOpen();
+    return this.database.prepare(sql).all(...(parameters as readonly SQLInputValue[])) as Row[];
+  }
+
+  async exclusiveTransaction<Result>(
+    work: (transaction: SqliteDriver) => Promise<Result>,
+  ): Promise<Result> {
+    this.assertOpen();
+    this.database.exec('BEGIN IMMEDIATE');
+
+    try {
+      const result = await work(this);
+      this.database.exec('COMMIT');
+      return result;
+    } catch (error) {
+      this.database.exec('ROLLBACK');
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+
+    this.database.close();
+    this.closed = true;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('SQLite driver is closed');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add the Expo SQLite native driver and versioned WAL-backed migrations
- persist all v2 domain records, outbox mutations, sync cursors, and conflicts
- serialize writes through crash-safe exclusive transactions with lifecycle guards
- run the shared adapter contract against real SQLite via Node's built-in driver
- move CI to Node 22 for the SQLite-backed contract suite

## Verification
- `npx expo install --check`
- `npm run verify:full`
- 39 Jest tests, web export, and Chromium smoke test pass

Closes #11

Depends on #37