### PR TITLE
feat(data): add IndexedDB adapter (#12)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint-config-expo": "~9.2.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^17.7.0",
         "jest": "~29.7.0",
         "jest-expo": "~53.0.14",
@@ -9349,6 +9350,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-config-expo": "~9.2.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.7.0",
     "jest": "~29.7.0",
     "jest-expo": "~53.0.14",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,2 +1,3 @@
 export * from './contracts';
+export * from './indexeddb';
 export * from './sqlite';

--- a/src/data/indexeddb/__tests__/indexedDbLocalDatabase.test.ts
+++ b/src/data/indexeddb/__tests__/indexedDbLocalDatabase.test.ts
@@ -1,0 +1,150 @@
+import 'fake-indexeddb/auto';
+
+import { BranchId, DeviceId, MutationId, OrganizationId, toDomainId } from '../../../domain';
+import { OutboxMutation } from '../../contracts';
+import { defineLocalDatabaseContract } from '../../testing/localDatabaseContract';
+import { IndexedDbLocalDatabase } from '../indexedDbLocalDatabase';
+import {
+  indexedDbIndexes,
+  indexedDbSchemaVersion,
+  indexedDbStores,
+  openIndexedDbConnection,
+} from '../indexedDbSchema';
+
+const createdDatabaseNames: string[] = [];
+let databaseSequence = 0;
+
+defineLocalDatabaseContract('IndexedDB', () => {
+  const name = uniqueDatabaseName('contract');
+  return IndexedDbLocalDatabase.open(name);
+});
+
+describe('IndexedDB browser persistence', () => {
+  it('retains queued offline mutations after the database is reopened', async () => {
+    const databaseName = uniqueDatabaseName('reload');
+    const mutation = createMutation('mutation-reload');
+    const firstConnection = await IndexedDbLocalDatabase.open(databaseName);
+
+    await firstConnection.transaction(async (transaction) => {
+      await transaction.outbox.enqueue(mutation);
+    });
+    await firstConnection.close();
+
+    const reloadedConnection = await IndexedDbLocalDatabase.open(databaseName);
+    await expect(reloadedConnection.outbox.getById(mutation.id)).resolves.toEqual(mutation);
+    await reloadedConnection.close();
+  });
+
+  it('does not expose aborted writes after the database is reopened', async () => {
+    const databaseName = uniqueDatabaseName('recovery');
+    const mutation = createMutation('mutation-aborted');
+    const firstConnection = await IndexedDbLocalDatabase.open(databaseName);
+
+    await expect(
+      firstConnection.transaction(async (transaction) => {
+        await transaction.outbox.enqueue(mutation);
+        throw new Error('simulated browser termination');
+      }),
+    ).rejects.toThrow('simulated browser termination');
+    await firstConnection.close();
+
+    const recoveredConnection = await IndexedDbLocalDatabase.open(databaseName);
+    await expect(recoveredConnection.outbox.getById(mutation.id)).resolves.toBeNull();
+    await recoveredConnection.close();
+  });
+
+  it('keeps a transaction active across asynchronous application work', async () => {
+    const databaseName = uniqueDatabaseName('async-transaction');
+    const mutation = createMutation('mutation-delayed');
+    const database = await IndexedDbLocalDatabase.open(databaseName);
+
+    await database.transaction(async (transaction) => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1);
+      });
+      await transaction.outbox.enqueue(mutation);
+    });
+
+    await expect(database.outbox.getById(mutation.id)).resolves.toEqual(mutation);
+    await database.close();
+  });
+});
+
+describe('IndexedDB migrations', () => {
+  it('creates the versioned stores and query indexes', async () => {
+    const databaseName = uniqueDatabaseName('migration');
+    const database = await openIndexedDbConnection(indexedDB, databaseName);
+    const transaction = database.transaction(
+      [
+        indexedDbStores.domainRecords,
+        indexedDbStores.outboxMutations,
+        indexedDbStores.syncConflicts,
+      ],
+      'readonly',
+    );
+
+    expect(database.version).toBe(indexedDbSchemaVersion);
+    expect(Array.from(database.objectStoreNames)).toEqual(
+      expect.arrayContaining(Object.values(indexedDbStores)),
+    );
+    expect(Array.from(transaction.objectStore(indexedDbStores.domainRecords).indexNames)).toEqual(
+      expect.arrayContaining([
+        indexedDbIndexes.domainScopeCollectionEntity,
+        indexedDbIndexes.domainOrganizationCollectionEntity,
+      ]),
+    );
+
+    database.close();
+  });
+});
+
+afterAll(async () => {
+  for (const databaseName of createdDatabaseNames) {
+    await deleteDatabase(databaseName);
+  }
+});
+
+function uniqueDatabaseName(label: string): string {
+  const name = `orderia-${label}-${databaseSequence}`;
+  databaseSequence += 1;
+  createdDatabaseNames.push(name);
+  return name;
+}
+
+function createMutation(id: string): OutboxMutation {
+  const mutationId = toDomainId<MutationId>(id);
+  const organizationId = toDomainId<OrganizationId>('organization-pwa');
+  const branchId = toDomainId<BranchId>('branch-pwa');
+  const deviceId = toDomainId<DeviceId>('device-pwa');
+
+  return {
+    id: mutationId,
+    organizationId,
+    branchId,
+    deviceId,
+    clientMutationId: mutationId,
+    idempotencyKey: `${deviceId}:${mutationId}`,
+    repository: 'halls',
+    entityId: 'hall-pwa',
+    operation: 'create',
+    payload: { name: 'Offline Hall' },
+    status: 'pending',
+    attemptCount: 0,
+    createdAt: '2026-07-26T13:00:00.000Z',
+  };
+}
+
+function deleteDatabase(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(name);
+    request.onsuccess = () => {
+      resolve();
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error(`Could not delete ${name}`));
+    };
+    request.onblocked = () => {
+      reject(new Error(`Deleting ${name} was blocked`));
+    };
+  });
+}

--- a/src/data/indexeddb/index.ts
+++ b/src/data/indexeddb/index.ts
@@ -1,0 +1,2 @@
+export * from './indexedDbLocalDatabase';
+export * from './indexedDbSchema';

--- a/src/data/indexeddb/indexedDbLocalDatabase.ts
+++ b/src/data/indexeddb/indexedDbLocalDatabase.ts
@@ -1,0 +1,147 @@
+import {
+  DomainEntityMap,
+  LocalDatabase,
+  LocalTransaction,
+  OutboxRepository,
+  ReadRepository,
+  RepositoryName,
+  SyncStateRepository,
+} from '../contracts';
+import { indexedDbStoreNames, indexedDbStores, openIndexedDbConnection } from './indexedDbSchema';
+import { IndexedDbOutboxRepository } from './indexedDbOutboxRepository';
+import { IndexedDbRepository } from './indexedDbRepository';
+import { IndexedDbSyncStateRepository } from './indexedDbSyncStateRepository';
+import {
+  createStrictReadWriteTransaction,
+  keepTransactionAlive,
+  transactionResult,
+} from './indexedDbUtils';
+
+type DatabaseState = 'open' | 'closing' | 'closed';
+
+export class IndexedDbLocalDatabase implements LocalDatabase {
+  readonly engine = 'indexeddb' as const;
+
+  private state: DatabaseState = 'open';
+  private transactionTail: Promise<void> = Promise.resolve();
+
+  private constructor(private readonly database: IDBDatabase) {
+    database.onversionchange = () => {
+      void this.close();
+    };
+  }
+
+  static async open(
+    databaseName = 'orderia-v2',
+    factory: IDBFactory | undefined = globalThis.indexedDB,
+  ): Promise<IndexedDbLocalDatabase> {
+    if (!factory) {
+      throw new Error('IndexedDB is not available in this environment');
+    }
+
+    const database = await openIndexedDbConnection(factory, databaseName);
+    return new IndexedDbLocalDatabase(database);
+  }
+
+  get outbox(): Pick<OutboxRepository, 'getById' | 'list'> {
+    this.assertOpen();
+    return new IndexedDbOutboxRepository(() => this.readStore(indexedDbStores.outboxMutations));
+  }
+
+  get syncState(): Pick<SyncStateRepository, 'getCursor' | 'getConflict' | 'listConflicts'> {
+    this.assertOpen();
+    return new IndexedDbSyncStateRepository((name) => this.readStore(name));
+  }
+
+  repository<Name extends RepositoryName>(name: Name): ReadRepository<DomainEntityMap[Name]> {
+    this.assertOpen();
+    return new IndexedDbRepository(name, () => this.readStore(indexedDbStores.domainRecords));
+  }
+
+  async transaction<Result>(
+    work: (transaction: LocalTransaction) => Promise<Result>,
+  ): Promise<Result> {
+    this.assertOpen();
+
+    const previousTransaction = this.transactionTail;
+    let releaseTransaction!: () => void;
+    this.transactionTail = new Promise<void>((resolve) => {
+      releaseTransaction = resolve;
+    });
+
+    await previousTransaction;
+    let transactionActive = true;
+
+    try {
+      const indexedDbTransaction = createStrictReadWriteTransaction(
+        this.database,
+        indexedDbStoreNames,
+      );
+      const completion = transactionResult(indexedDbTransaction);
+      const stopKeepAlive = keepTransactionAlive(indexedDbTransaction, indexedDbStores.metadata);
+      const getStore = (name: string) => {
+        if (!transactionActive) {
+          throw new Error('Local transaction is no longer active');
+        }
+
+        return indexedDbTransaction.objectStore(name);
+      };
+
+      try {
+        const result = await work(createTransaction(getStore));
+        stopKeepAlive();
+        await completion;
+        return result;
+      } catch (error) {
+        stopKeepAlive();
+        try {
+          indexedDbTransaction.abort();
+        } catch {
+          // The browser may already have aborted the transaction.
+        }
+        try {
+          await completion;
+        } catch {
+          // Preserve the original application or request error.
+        }
+        throw error;
+      }
+    } finally {
+      transactionActive = false;
+      releaseTransaction();
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.state === 'closed') return;
+    if (this.state === 'closing') {
+      await this.transactionTail;
+      return;
+    }
+
+    this.state = 'closing';
+    await this.transactionTail;
+    this.database.close();
+    this.state = 'closed';
+  }
+
+  private readStore(name: string): IDBObjectStore {
+    this.assertOpen();
+    return this.database.transaction(name, 'readonly').objectStore(name);
+  }
+
+  private assertOpen(): void {
+    if (this.state !== 'open') {
+      throw new Error('Local database is closed');
+    }
+  }
+}
+
+function createTransaction(getStore: (name: string) => IDBObjectStore): LocalTransaction {
+  return {
+    repository: <Name extends RepositoryName>(name: Name) =>
+      new IndexedDbRepository(name, () => getStore(indexedDbStores.domainRecords)),
+    outbox: new IndexedDbOutboxRepository(() => getStore(indexedDbStores.outboxMutations)),
+    syncState: new IndexedDbSyncStateRepository(getStore),
+  };
+}

--- a/src/data/indexeddb/indexedDbOutboxRepository.ts
+++ b/src/data/indexeddb/indexedDbOutboxRepository.ts
@@ -1,0 +1,151 @@
+import {
+  OutboxMutation,
+  OutboxRepository,
+  OutboxStatus,
+  OutboxTransitionPatch,
+  RepositoryScope,
+  assertOutboxTransition,
+} from '../contracts';
+import { MutationId } from '../../domain/ids';
+import { indexedDbIndexes, indexedDbStores } from './indexedDbSchema';
+import { cloneValue, requestResult, scopeRange, stableSerialize } from './indexedDbUtils';
+
+export class IndexedDbOutboxRepository implements OutboxRepository {
+  constructor(private readonly getStore: () => IDBObjectStore) {}
+
+  async enqueue(mutation: OutboxMutation): Promise<OutboxMutation> {
+    if (mutation.status !== 'pending' || mutation.attemptCount !== 0) {
+      throw new Error('New outbox mutations must start pending with zero attempts');
+    }
+
+    if (!mutation.idempotencyKey.trim()) {
+      throw new Error('Outbox mutation requires an idempotency key');
+    }
+
+    const store = this.getStore();
+    assertOutboxStore(store);
+    const existingClientMutation = await requestResult<OutboxMutation | undefined>(
+      store
+        .index(indexedDbIndexes.outboxDeviceClientMutation)
+        .get([mutation.deviceId, mutation.clientMutationId]),
+    );
+
+    if (existingClientMutation) {
+      if (stableSerialize(existingClientMutation) !== stableSerialize(mutation)) {
+        throw new Error('Client mutation ID was reused with different content');
+      }
+
+      return cloneValue(existingClientMutation);
+    }
+
+    if (await requestResult<OutboxMutation | undefined>(store.get(mutation.id))) {
+      throw new Error(`Outbox mutation ID already exists: ${mutation.id}`);
+    }
+
+    await requestResult(store.add(cloneValue(mutation)));
+    return cloneValue(mutation);
+  }
+
+  async getById(id: MutationId): Promise<OutboxMutation | null> {
+    const store = this.getStore();
+    assertOutboxStore(store);
+    const mutation = await requestResult<OutboxMutation | undefined>(store.get(id));
+    return mutation ? cloneValue(mutation) : null;
+  }
+
+  async list(
+    scope: RepositoryScope,
+    statuses?: readonly OutboxStatus[],
+  ): Promise<readonly OutboxMutation[]> {
+    if (statuses?.length === 0) return [];
+
+    const store = this.getStore();
+    assertOutboxStore(store);
+    const indexName =
+      scope.branchId === undefined
+        ? indexedDbIndexes.outboxOrganizationCreated
+        : indexedDbIndexes.outboxScopeCreated;
+    const mutations = await requestResult<OutboxMutation[]>(
+      store.index(indexName).getAll(scopeRange(scope)),
+    );
+    return mutations
+      .filter((mutation) => statuses === undefined || statuses.includes(mutation.status))
+      .sort(
+        (left, right) =>
+          left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+      )
+      .map(cloneValue);
+  }
+
+  async claimNext(
+    scope: RepositoryScope,
+    limit: number,
+    now: string,
+  ): Promise<readonly OutboxMutation[]> {
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error('Outbox claim limit must be a positive safe integer');
+    }
+
+    const candidates = (await this.list(scope, ['pending', 'retry_wait']))
+      .filter(
+        (mutation) =>
+          mutation.status === 'pending' ||
+          mutation.nextAttemptAt === undefined ||
+          mutation.nextAttemptAt <= now,
+      )
+      .slice(0, limit);
+
+    const claimed: OutboxMutation[] = [];
+    for (const mutation of candidates) {
+      claimed.push(
+        await this.transition(mutation.id, mutation.status, 'processing', {
+          lastAttemptAt: now,
+        }),
+      );
+    }
+    return claimed;
+  }
+
+  async transition(
+    id: MutationId,
+    expectedStatus: OutboxStatus,
+    nextStatus: OutboxStatus,
+    patch: OutboxTransitionPatch = {},
+  ): Promise<OutboxMutation> {
+    const current = await this.getById(id);
+    if (!current) {
+      throw new Error(`Unknown outbox mutation ${id}`);
+    }
+
+    if (current.status !== expectedStatus) {
+      throw new Error(`Outbox mutation ${id} expected ${expectedStatus}, got ${current.status}`);
+    }
+
+    assertOutboxTransition(current.status, nextStatus);
+
+    if (nextStatus === 'applied' && patch.appliedAt === undefined) {
+      throw new Error('Applied outbox mutation requires appliedAt');
+    }
+
+    if (nextStatus === 'retry_wait' && patch.nextAttemptAt === undefined) {
+      throw new Error('Retrying outbox mutation requires nextAttemptAt');
+    }
+
+    const next: OutboxMutation = {
+      ...current,
+      ...patch,
+      status: nextStatus,
+      attemptCount: nextStatus === 'processing' ? current.attemptCount + 1 : current.attemptCount,
+    };
+    const store = this.getStore();
+    assertOutboxStore(store);
+    await requestResult(store.put(cloneValue(next)));
+    return cloneValue(next);
+  }
+}
+
+function assertOutboxStore(store: IDBObjectStore): void {
+  if (store.name !== indexedDbStores.outboxMutations) {
+    throw new Error(`Expected ${indexedDbStores.outboxMutations} object store`);
+  }
+}

--- a/src/data/indexeddb/indexedDbRepository.ts
+++ b/src/data/indexeddb/indexedDbRepository.ts
@@ -1,0 +1,157 @@
+import {
+  DomainEntityMap,
+  PutOptions,
+  RepositoryName,
+  RepositoryPage,
+  RepositoryQuery,
+  RepositoryScope,
+  TombstoneOptions,
+  TransactionRepository,
+} from '../contracts';
+import { indexedDbIndexes } from './indexedDbSchema';
+import {
+  assertEntityMatchesScope,
+  assertExpectedVersion,
+  cloneValue,
+  readDeletedAt,
+  readEntityVersion,
+  requestResult,
+  scopeRange,
+} from './indexedDbUtils';
+
+interface IndexedDbDomainRecord<Name extends RepositoryName = RepositoryName> {
+  readonly key: string;
+  readonly collection: Name;
+  readonly organizationId: string;
+  readonly branchId: string;
+  readonly entityId: string;
+  readonly version: number;
+  readonly deletedAt?: string;
+  readonly entity: DomainEntityMap[Name];
+}
+
+export class IndexedDbRepository<Name extends RepositoryName> implements TransactionRepository<
+  DomainEntityMap[Name]
+> {
+  constructor(
+    private readonly name: Name,
+    private readonly getStore: () => IDBObjectStore,
+  ) {}
+
+  async getById(
+    scope: RepositoryScope,
+    id: DomainEntityMap[Name]['id'],
+  ): Promise<DomainEntityMap[Name] | null> {
+    const record = await this.findRecord(scope, id, false);
+    return record && record.deletedAt === undefined ? cloneValue(record.entity) : null;
+  }
+
+  async list(
+    scope: RepositoryScope,
+    query: RepositoryQuery = {},
+  ): Promise<RepositoryPage<DomainEntityMap[Name]>> {
+    const limit = query.limit ?? 100;
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error('Repository query limit must be a positive safe integer');
+    }
+
+    const offset = query.after ? Number(query.after) : 0;
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+      throw new Error('Repository cursor is invalid');
+    }
+
+    const store = this.getStore();
+    const indexName =
+      scope.branchId === undefined
+        ? indexedDbIndexes.domainOrganizationCollectionEntity
+        : indexedDbIndexes.domainScopeCollectionEntity;
+    const records = await requestResult<IndexedDbDomainRecord<Name>[]>(
+      store.index(indexName).getAll(scopeRange(scope, [this.name])),
+    );
+    const matching = records
+      .filter((record) => query.includeDeleted === true || record.deletedAt === undefined)
+      .sort((left, right) => left.entityId.localeCompare(right.entityId));
+    const page = matching.slice(offset, offset + limit);
+    const nextOffset = offset + page.length;
+
+    return {
+      items: page.map((record) => cloneValue(record.entity)),
+      nextCursor: nextOffset < matching.length ? String(nextOffset) : undefined,
+    };
+  }
+
+  async put(
+    scope: RepositoryScope,
+    entity: DomainEntityMap[Name],
+    options: PutOptions = {},
+  ): Promise<DomainEntityMap[Name]> {
+    assertEntityMatchesScope(this.name, entity, scope);
+    const existing = await this.findRecord(scope, entity.id, true);
+    const actualVersion = existing?.version ?? null;
+    assertExpectedVersion(this.name, entity.id, options.expectedVersion, actualVersion);
+
+    const record: IndexedDbDomainRecord<Name> = {
+      key: recordKey(this.name, scope, entity.id),
+      collection: this.name,
+      organizationId: scope.organizationId,
+      branchId: scope.branchId ?? '',
+      entityId: entity.id,
+      version: readEntityVersion(entity) ?? (actualVersion ?? 0) + 1,
+      ...(readDeletedAt(entity) === undefined ? {} : { deletedAt: readDeletedAt(entity) }),
+      entity: cloneValue(entity),
+    };
+    await requestResult(this.getStore().put(record));
+    return cloneValue(entity);
+  }
+
+  async tombstone(
+    scope: RepositoryScope,
+    id: DomainEntityMap[Name]['id'],
+    options: TombstoneOptions,
+  ): Promise<DomainEntityMap[Name]> {
+    const existing = await this.findRecord(scope, id, true);
+    if (!existing) {
+      throw new Error(`Cannot tombstone missing ${this.name}/${id}`);
+    }
+
+    assertExpectedVersion(this.name, id, options.expectedVersion, existing.version);
+    const nextVersion = existing.version + 1;
+    const entity = {
+      ...cloneValue(existing.entity),
+      deletedAt: options.deletedAt,
+      ...('version' in existing.entity ? { version: nextVersion } : {}),
+    } as DomainEntityMap[Name];
+    const next: IndexedDbDomainRecord<Name> = {
+      ...existing,
+      version: nextVersion,
+      deletedAt: options.deletedAt,
+      entity,
+    };
+
+    await requestResult(this.getStore().put(next));
+    return cloneValue(entity);
+  }
+
+  private async findRecord(
+    scope: RepositoryScope,
+    id: string,
+    exactBranch: boolean,
+  ): Promise<IndexedDbDomainRecord<Name> | undefined> {
+    const store = this.getStore();
+    const record =
+      exactBranch || scope.branchId !== undefined
+        ? await requestResult<IndexedDbDomainRecord<Name> | undefined>(
+            store.get(recordKey(this.name, scope, id)),
+          )
+        : await requestResult<IndexedDbDomainRecord<Name> | undefined>(
+            store
+              .index(indexedDbIndexes.domainOrganizationCollectionEntity)
+              .get([scope.organizationId, this.name, id]),
+          );
+    return record;
+  }
+}
+
+function recordKey(repository: RepositoryName, scope: RepositoryScope, entityId: string): string {
+  return [repository, scope.organizationId, scope.branchId ?? '', entityId].join('::');
+}

--- a/src/data/indexeddb/indexedDbSchema.ts
+++ b/src/data/indexeddb/indexedDbSchema.ts
@@ -1,0 +1,129 @@
+export const indexedDbSchemaVersion = 1;
+
+export const indexedDbStores = {
+  domainRecords: 'domain_records',
+  metadata: 'metadata',
+  outboxMutations: 'outbox_mutations',
+  syncConflicts: 'sync_conflicts',
+  syncCursors: 'sync_cursors',
+} as const;
+
+export const indexedDbStoreNames = Object.values(indexedDbStores);
+
+export const indexedDbIndexes = {
+  domainOrganizationCollectionEntity: 'by_organization_collection_entity',
+  domainScopeCollectionEntity: 'by_scope_collection_entity',
+  outboxDeviceClientMutation: 'by_device_client_mutation',
+  outboxOrganizationCreated: 'by_organization_created',
+  outboxScopeCreated: 'by_scope_created',
+  conflictOrganizationDetected: 'by_organization_detected',
+  conflictScopeDetected: 'by_scope_detected',
+} as const;
+
+export interface IndexedDbMigration {
+  readonly version: number;
+  readonly name: string;
+  upgrade(database: IDBDatabase): void;
+}
+
+export const indexedDbMigrations: readonly IndexedDbMigration[] = [
+  {
+    version: 1,
+    name: 'local_first_foundation',
+    upgrade(database) {
+      const domainRecords = database.createObjectStore(indexedDbStores.domainRecords, {
+        keyPath: 'key',
+      });
+      domainRecords.createIndex(indexedDbIndexes.domainScopeCollectionEntity, [
+        'organizationId',
+        'branchId',
+        'collection',
+        'entityId',
+      ]);
+      domainRecords.createIndex(indexedDbIndexes.domainOrganizationCollectionEntity, [
+        'organizationId',
+        'collection',
+        'entityId',
+      ]);
+
+      const outbox = database.createObjectStore(indexedDbStores.outboxMutations, { keyPath: 'id' });
+      outbox.createIndex(
+        indexedDbIndexes.outboxDeviceClientMutation,
+        ['deviceId', 'clientMutationId'],
+        { unique: true },
+      );
+      outbox.createIndex(indexedDbIndexes.outboxScopeCreated, [
+        'organizationId',
+        'branchId',
+        'createdAt',
+        'id',
+      ]);
+      outbox.createIndex(indexedDbIndexes.outboxOrganizationCreated, [
+        'organizationId',
+        'createdAt',
+        'id',
+      ]);
+
+      database.createObjectStore(indexedDbStores.syncCursors, {
+        keyPath: 'key',
+      });
+
+      const conflicts = database.createObjectStore(indexedDbStores.syncConflicts, {
+        keyPath: 'id',
+      });
+      conflicts.createIndex(indexedDbIndexes.conflictScopeDetected, [
+        'organizationId',
+        'branchId',
+        'detectedAt',
+        'id',
+      ]);
+      conflicts.createIndex(indexedDbIndexes.conflictOrganizationDetected, [
+        'organizationId',
+        'detectedAt',
+        'id',
+      ]);
+
+      database.createObjectStore(indexedDbStores.metadata, {
+        keyPath: 'key',
+      });
+    },
+  },
+];
+
+export function openIndexedDbConnection(
+  factory: IDBFactory,
+  databaseName: string,
+): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(databaseName, indexedDbSchemaVersion);
+    let settled = false;
+
+    request.onupgradeneeded = (event) => {
+      const oldVersion = event.oldVersion;
+      const newVersion = event.newVersion ?? indexedDbSchemaVersion;
+
+      for (const migration of indexedDbMigrations) {
+        if (migration.version > oldVersion && migration.version <= newVersion) {
+          migration.upgrade(request.result);
+        }
+      }
+    };
+    request.onerror = () => {
+      settled = true;
+      reject(request.error ?? new Error('Could not open IndexedDB'));
+    };
+    request.onblocked = () => {
+      settled = true;
+      reject(new Error(`IndexedDB upgrade for "${databaseName}" is blocked by another tab`));
+    };
+    request.onsuccess = () => {
+      if (settled) {
+        request.result.close();
+        return;
+      }
+
+      settled = true;
+      resolve(request.result);
+    };
+  });
+}

--- a/src/data/indexeddb/indexedDbSyncStateRepository.ts
+++ b/src/data/indexeddb/indexedDbSyncStateRepository.ts
@@ -1,0 +1,123 @@
+import {
+  RepositoryScope,
+  SyncConflict,
+  SyncConflictStatus,
+  SyncCursor,
+  SyncStateRepository,
+} from '../contracts';
+import { JsonValue } from '../../domain/entities';
+import { SyncConflictId } from '../../domain/ids';
+import { indexedDbIndexes, indexedDbStores } from './indexedDbSchema';
+import { cloneValue, requestResult, scopeRange } from './indexedDbUtils';
+
+interface StoredSyncCursor extends SyncCursor {
+  readonly key: string;
+}
+
+export class IndexedDbSyncStateRepository implements SyncStateRepository {
+  constructor(
+    private readonly getStore: (
+      name: typeof indexedDbStores.syncCursors | typeof indexedDbStores.syncConflicts,
+    ) => IDBObjectStore,
+  ) {}
+
+  async getCursor(scope: RepositoryScope): Promise<SyncCursor | null> {
+    if (scope.branchId === undefined) return null;
+
+    const cursor = await requestResult<StoredSyncCursor | undefined>(
+      this.getStore(indexedDbStores.syncCursors).get(
+        cursorKey({
+          organizationId: scope.organizationId,
+          branchId: scope.branchId,
+        }),
+      ),
+    );
+    return cursor ? withoutCursorKey(cursor) : null;
+  }
+
+  async setCursor(cursor: SyncCursor): Promise<SyncCursor> {
+    const stored: StoredSyncCursor = {
+      ...cloneValue(cursor),
+      key: cursorKey(cursor),
+    };
+    await requestResult(this.getStore(indexedDbStores.syncCursors).put(stored));
+    return cloneValue(cursor);
+  }
+
+  async addConflict(conflict: SyncConflict): Promise<SyncConflict> {
+    if (conflict.status !== 'unresolved') {
+      throw new Error('New sync conflicts must start unresolved');
+    }
+
+    if (await this.getConflict(conflict.id)) {
+      throw new Error(`Sync conflict already exists: ${conflict.id}`);
+    }
+
+    await requestResult(this.getStore(indexedDbStores.syncConflicts).add(cloneValue(conflict)));
+    return cloneValue(conflict);
+  }
+
+  async getConflict(id: SyncConflictId): Promise<SyncConflict | null> {
+    const conflict = await requestResult<SyncConflict | undefined>(
+      this.getStore(indexedDbStores.syncConflicts).get(id),
+    );
+    return conflict ? cloneValue(conflict) : null;
+  }
+
+  async listConflicts(
+    scope: RepositoryScope,
+    statuses?: readonly SyncConflictStatus[],
+  ): Promise<readonly SyncConflict[]> {
+    if (statuses?.length === 0) return [];
+
+    const store = this.getStore(indexedDbStores.syncConflicts);
+    const indexName =
+      scope.branchId === undefined
+        ? indexedDbIndexes.conflictOrganizationDetected
+        : indexedDbIndexes.conflictScopeDetected;
+    const conflicts = await requestResult<SyncConflict[]>(
+      store.index(indexName).getAll(scopeRange(scope)),
+    );
+    return conflicts
+      .filter((conflict) => statuses === undefined || statuses.includes(conflict.status))
+      .sort(
+        (left, right) =>
+          left.detectedAt.localeCompare(right.detectedAt) || left.id.localeCompare(right.id),
+      )
+      .map(cloneValue);
+  }
+
+  async resolveConflict(
+    id: SyncConflictId,
+    status: Exclude<SyncConflictStatus, 'unresolved'>,
+    resolvedAt: string,
+    resolutionPayload?: JsonValue,
+  ): Promise<SyncConflict> {
+    const current = await this.getConflict(id);
+    if (!current) {
+      throw new Error(`Unknown sync conflict ${id}`);
+    }
+
+    if (current.status !== 'unresolved') {
+      throw new Error(`Sync conflict ${id} is already resolved`);
+    }
+
+    const next: SyncConflict = {
+      ...current,
+      status,
+      resolvedAt,
+      resolutionPayload,
+    };
+    await requestResult(this.getStore(indexedDbStores.syncConflicts).put(cloneValue(next)));
+    return cloneValue(next);
+  }
+}
+
+function cursorKey(scope: Pick<SyncCursor, 'organizationId' | 'branchId'>): string {
+  return `${scope.organizationId}::${scope.branchId}`;
+}
+
+function withoutCursorKey(cursor: StoredSyncCursor): SyncCursor {
+  const { key: _key, ...value } = cursor;
+  return cloneValue(value);
+}

--- a/src/data/indexeddb/indexedDbUtils.ts
+++ b/src/data/indexeddb/indexedDbUtils.ts
@@ -1,0 +1,148 @@
+import { OptimisticConcurrencyError, RepositoryName, RepositoryScope } from '../contracts';
+
+export function requestResult<Result>(request: IDBRequest<Result>): Promise<Result> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error('IndexedDB request failed'));
+    };
+  });
+}
+
+export function transactionResult(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => {
+      resolve();
+    };
+    transaction.onabort = () => {
+      reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+    };
+    transaction.onerror = () => {
+      reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    };
+  });
+}
+
+export function keepTransactionAlive(
+  transaction: IDBTransaction,
+  metadataStoreName: string,
+): () => void {
+  let active = true;
+
+  const pump = () => {
+    if (!active) return;
+
+    const request = transaction.objectStore(metadataStoreName).get('__transaction_keep_alive__');
+    request.onsuccess = () => {
+      pump();
+    };
+    request.onerror = () => {
+      active = false;
+    };
+  };
+
+  pump();
+  return () => {
+    active = false;
+  };
+}
+
+export function createStrictReadWriteTransaction(
+  database: IDBDatabase,
+  storeNames: readonly string[],
+): IDBTransaction {
+  try {
+    return database.transaction([...storeNames], 'readwrite', {
+      durability: 'strict',
+    });
+  } catch {
+    return database.transaction([...storeNames], 'readwrite');
+  }
+}
+
+export function scopeRange(
+  scope: RepositoryScope,
+  suffix: readonly IDBValidKey[] = [],
+): IDBKeyRange {
+  const prefix: IDBValidKey[] = [scope.organizationId];
+  if (scope.branchId !== undefined) {
+    prefix.push(scope.branchId);
+  }
+  prefix.push(...suffix);
+  return IDBKeyRange.bound(prefix, [...prefix, []]);
+}
+
+export function cloneValue<Value>(value: Value): Value {
+  return JSON.parse(JSON.stringify(value)) as Value;
+}
+
+export function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`;
+  }
+
+  if (value && typeof value === 'object') {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableSerialize(entry)}`)
+      .join(',')}}`;
+  }
+
+  return JSON.stringify(value) ?? 'undefined';
+}
+
+export function assertEntityMatchesScope(
+  repository: RepositoryName,
+  entity: object & { readonly id: string },
+  scope: RepositoryScope,
+): void {
+  const organizationId =
+    'organizationId' in entity && typeof entity.organizationId === 'string'
+      ? entity.organizationId
+      : undefined;
+  const branchId =
+    'branchId' in entity && typeof entity.branchId === 'string' ? entity.branchId : undefined;
+
+  if (organizationId !== undefined && organizationId !== scope.organizationId) {
+    throw new Error('Entity organization does not match repository scope');
+  }
+
+  if (branchId !== undefined && branchId !== scope.branchId) {
+    throw new Error('Entity branch does not match repository scope');
+  }
+
+  if (repository === 'organizations' && entity.id !== scope.organizationId) {
+    throw new Error('Organization entity ID does not match repository scope');
+  }
+}
+
+export function assertExpectedVersion(
+  repository: RepositoryName,
+  entityId: string,
+  expectedVersion: number | null | undefined,
+  actualVersion: number | null,
+): void {
+  if (expectedVersion === undefined) return;
+
+  if (expectedVersion !== actualVersion) {
+    throw new OptimisticConcurrencyError(repository, entityId, expectedVersion, actualVersion);
+  }
+}
+
+export function readEntityVersion(entity: object): number | undefined {
+  if ('version' in entity && typeof entity.version === 'number') {
+    return entity.version;
+  }
+
+  return undefined;
+}
+
+export function readDeletedAt(entity: object): string | undefined {
+  if ('deletedAt' in entity && typeof entity.deletedAt === 'string') {
+    return entity.deletedAt;
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- implement the shared local database contract with IndexedDB for the web/PWA runtime
- add versioned object-store migrations and indexed tenant/branch queries
- keep browser transactions alive across async application work and request strict durability when supported
- persist outbox mutations, cursors, and conflicts across browser reloads
- add rollback/reopen recovery coverage using the browser IndexedDB API in Jest

## Verification
- `npm run verify:full`
- `npx expo install --check`
- 50 Jest tests, web export, and Chromium smoke test pass

Closes #12

Depends on #38