### PR TITLE
feat(sync): push idempotent outbox mutations

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,3 +1,4 @@
 export * from './contracts';
 export * from './indexeddb';
 export * from './sqlite';
+export * from './sync';

--- a/src/data/sync/__tests__/localMutation.test.ts
+++ b/src/data/sync/__tests__/localMutation.test.ts
@@ -1,0 +1,132 @@
+import {
+  BranchId,
+  DeviceId,
+  Hall,
+  HallId,
+  MutationId,
+  OrganizationId,
+  toDomainId,
+} from '../../../domain';
+import { OutboxMutation } from '../../contracts';
+import { InMemoryLocalDatabase } from '../../testing';
+import { commitLocalEntityMutation } from '../localMutation';
+
+const organizationId = toDomainId<OrganizationId>('22000000-0000-4000-8000-000000000001');
+const branchId = toDomainId<BranchId>('32000000-0000-4000-8000-000000000001');
+const hallId = toDomainId<HallId>('52000000-0000-4000-8000-000000000001');
+const deviceId = toDomainId<DeviceId>('42000000-0000-4000-8000-000000000001');
+const mutationId = toDomainId<MutationId>('62000000-0000-4000-8000-000000000001');
+const scope = { organizationId, branchId };
+
+describe('commitLocalEntityMutation', () => {
+  it('commits the entity and outbox record atomically', async () => {
+    const database = new InMemoryLocalDatabase();
+    const hall = createHall('Main Hall', 1);
+    const mutation = createMutation(hall);
+
+    const result = await commitLocalEntityMutation(database, {
+      scope,
+      repository: 'halls',
+      entity: hall,
+      mutation,
+    });
+
+    await expect(database.repository('halls').getById(scope, hall.id)).resolves.toEqual(hall);
+    await expect(database.outbox.getById(mutation.id)).resolves.toEqual(mutation);
+    expect(result).toEqual({ entity: hall, mutation });
+  });
+
+  it('rolls back the entity update when enqueueing fails', async () => {
+    const database = new InMemoryLocalDatabase();
+    const original = createHall('Original', 1);
+    const originalMutation = createMutation(original);
+    await commitLocalEntityMutation(database, {
+      scope,
+      repository: 'halls',
+      entity: original,
+      mutation: originalMutation,
+    });
+
+    const edited: Hall = {
+      ...original,
+      name: 'Must Roll Back',
+      version: 2,
+      updatedAt: '2026-07-26T19:01:00.000Z',
+    };
+    const reusedMutation: OutboxMutation = {
+      ...originalMutation,
+      payload: {
+        name: edited.name,
+        sortOrder: edited.sortOrder,
+        version: edited.version,
+      },
+    };
+
+    await expect(
+      commitLocalEntityMutation(database, {
+        scope,
+        repository: 'halls',
+        entity: edited,
+        mutation: reusedMutation,
+        putOptions: { expectedVersion: 1 },
+      }),
+    ).rejects.toThrow('Client mutation ID was reused with different content');
+
+    await expect(database.repository('halls').getById(scope, hallId)).resolves.toEqual(original);
+  });
+
+  it('rejects a mismatched tenant scope before opening a transaction', async () => {
+    const database = new InMemoryLocalDatabase();
+    const hall = createHall('Main Hall', 1);
+    const mutation = {
+      ...createMutation(hall),
+      branchId: toDomainId<BranchId>('32000000-0000-4000-8000-000000000002'),
+    };
+
+    await expect(
+      commitLocalEntityMutation(database, {
+        scope,
+        repository: 'halls',
+        entity: hall,
+        mutation,
+      }),
+    ).rejects.toThrow('Outbox tenant scope does not match');
+  });
+});
+
+function createHall(name: string, version: number): Hall {
+  return {
+    id: hallId,
+    organizationId,
+    branchId,
+    name,
+    sortOrder: 1,
+    version,
+    createdAt: '2026-07-26T19:00:00.000Z',
+    updatedAt: '2026-07-26T19:00:00.000Z',
+    syncStatus: 'pending',
+    clientMutationId: mutationId,
+  };
+}
+
+function createMutation(hall: Hall): OutboxMutation {
+  return {
+    id: mutationId,
+    organizationId,
+    branchId,
+    deviceId,
+    clientMutationId: mutationId,
+    idempotencyKey: `${deviceId}:${mutationId}`,
+    repository: 'halls',
+    entityId: hall.id,
+    operation: 'create',
+    payload: {
+      name: hall.name,
+      sortOrder: hall.sortOrder,
+      version: hall.version,
+    },
+    status: 'pending',
+    attemptCount: 0,
+    createdAt: '2026-07-26T19:00:00.000Z',
+  };
+}

--- a/src/data/sync/__tests__/outboxPushWorker.test.ts
+++ b/src/data/sync/__tests__/outboxPushWorker.test.ts
@@ -1,0 +1,199 @@
+import { BranchId, DeviceId, MutationId, OrganizationId, toDomainId } from '../../../domain';
+import { OutboxMutation } from '../../contracts';
+import { InMemoryLocalDatabase } from '../../testing';
+import { MutationPushGateway, MutationPushResult } from '../mutationPushGateway';
+import { OutboxPushWorker } from '../outboxPushWorker';
+import { MutationPushError } from '../retryPolicy';
+
+const organizationId = toDomainId<OrganizationId>('22000000-0000-4000-8000-000000000001');
+const branchId = toDomainId<BranchId>('32000000-0000-4000-8000-000000000001');
+const deviceId = toDomainId<DeviceId>('42000000-0000-4000-8000-000000000001');
+const mutationId = toDomainId<MutationId>('62000000-0000-4000-8000-000000000001');
+const scope = { organizationId, branchId };
+const now = new Date('2026-07-26T19:00:00.000Z');
+const appliedResult: MutationPushResult = {
+  status: 'applied',
+  repository: 'halls',
+  entityId: '52000000-0000-4000-8000-000000000001',
+  serverVersion: 1,
+  committedAt: now.toISOString(),
+  result: { status: 'applied' },
+};
+
+describe('OutboxPushWorker', () => {
+  it('claims and marks a successful mutation as applied', async () => {
+    const database = await databaseWithMutation();
+    const push = jest.fn().mockResolvedValue(appliedResult);
+    const worker = createWorker(database, push);
+
+    await expect(worker.runOnce(scope)).resolves.toEqual({
+      claimed: 1,
+      applied: 1,
+      retrying: 0,
+      conflicted: 0,
+      rejected: 0,
+      skippedBecauseRunning: false,
+    });
+    await expect(database.outbox.getById(mutationId)).resolves.toMatchObject({
+      status: 'applied',
+      attemptCount: 1,
+      appliedAt: now.toISOString(),
+    });
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules transient failures with exponential backoff and jitter', async () => {
+    const database = await databaseWithMutation();
+    const push = jest.fn().mockRejectedValue(
+      new MutationPushError('Service unavailable', {
+        code: 'PGRST000',
+        status: 503,
+      }),
+    );
+    const worker = createWorker(database, push);
+
+    await expect(worker.runOnce(scope)).resolves.toMatchObject({
+      claimed: 1,
+      retrying: 1,
+    });
+    await expect(database.outbox.getById(mutationId)).resolves.toMatchObject({
+      status: 'retry_wait',
+      attemptCount: 1,
+      nextAttemptAt: '2026-07-26T19:00:00.500Z',
+      errorCode: 'PGRST000',
+    });
+
+    await expect(worker.runOnce(scope)).resolves.toMatchObject({ claimed: 0 });
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it('separates conflicts from permanent rejection', async () => {
+    const conflictDatabase = await databaseWithMutation();
+    const conflictWorker = createWorker(
+      conflictDatabase,
+      jest.fn().mockRejectedValue(new MutationPushError('version_conflict', { code: 'P0001' })),
+    );
+    await expect(conflictWorker.runOnce(scope)).resolves.toMatchObject({
+      conflicted: 1,
+    });
+    await expect(conflictDatabase.outbox.getById(mutationId)).resolves.toMatchObject({
+      status: 'conflict',
+      errorMessage: 'version_conflict',
+    });
+
+    const rejectedDatabase = await databaseWithMutation();
+    const rejectedWorker = createWorker(
+      rejectedDatabase,
+      jest.fn().mockRejectedValue(new MutationPushError('Forbidden', { status: 403 })),
+    );
+    await expect(rejectedWorker.runOnce(scope)).resolves.toMatchObject({
+      rejected: 1,
+    });
+    await expect(rejectedDatabase.outbox.getById(mutationId)).resolves.toMatchObject({
+      status: 'rejected',
+      errorMessage: 'Forbidden',
+    });
+  });
+
+  it('stops retrying after the configured attempt limit', async () => {
+    const database = await databaseWithMutation();
+    const worker = createWorker(
+      database,
+      jest.fn().mockRejectedValue(new TypeError('Network request failed')),
+      1,
+    );
+
+    await expect(worker.runOnce(scope)).resolves.toMatchObject({
+      retrying: 0,
+      rejected: 1,
+    });
+    await expect(database.outbox.getById(mutationId)).resolves.toMatchObject({
+      status: 'rejected',
+      attemptCount: 1,
+      errorCode: 'RETRY_ATTEMPTS_EXHAUSTED',
+    });
+  });
+
+  it('recovers a mutation left processing by an interrupted app session', async () => {
+    const database = await databaseWithMutation();
+    await database.transaction(async (transaction) => {
+      await transaction.outbox.claimNext(scope, 1, '2026-07-26T18:55:00.000Z');
+    });
+    const worker = createWorker(database, jest.fn().mockResolvedValue(appliedResult));
+
+    await expect(worker.runOnce(scope)).resolves.toMatchObject({
+      claimed: 1,
+      applied: 1,
+    });
+    await expect(database.outbox.getById(mutationId)).resolves.toMatchObject({
+      status: 'applied',
+      attemptCount: 2,
+    });
+  });
+
+  it('does not run overlapping push cycles', async () => {
+    const database = await databaseWithMutation();
+    let releasePush!: (result: MutationPushResult) => void;
+    const push = jest.fn(
+      () =>
+        new Promise<MutationPushResult>((resolve) => {
+          releasePush = resolve;
+        }),
+    );
+    const worker = createWorker(database, push);
+
+    const firstCycle = worker.runOnce(scope);
+    while (push.mock.calls.length === 0) {
+      await Promise.resolve();
+    }
+    await expect(worker.runOnce(scope)).resolves.toMatchObject({
+      claimed: 0,
+      skippedBecauseRunning: true,
+    });
+    releasePush(appliedResult);
+    await expect(firstCycle).resolves.toMatchObject({ applied: 1 });
+  });
+});
+
+async function databaseWithMutation(): Promise<InMemoryLocalDatabase> {
+  const database = new InMemoryLocalDatabase();
+  await database.transaction(async (transaction) => {
+    await transaction.outbox.enqueue(createMutation());
+  });
+  return database;
+}
+
+function createMutation(): OutboxMutation {
+  return {
+    id: mutationId,
+    organizationId,
+    branchId,
+    deviceId,
+    clientMutationId: mutationId,
+    idempotencyKey: `${deviceId}:${mutationId}`,
+    repository: 'halls',
+    entityId: appliedResult.entityId,
+    operation: 'create',
+    payload: { name: 'Main Hall', sortOrder: 1 },
+    status: 'pending',
+    attemptCount: 0,
+    createdAt: now.toISOString(),
+  };
+}
+
+function createWorker(
+  database: InMemoryLocalDatabase,
+  push: MutationPushGateway['push'],
+  maximumAttempts = 8,
+): OutboxPushWorker {
+  const gateway: MutationPushGateway = { push };
+  return new OutboxPushWorker(database, gateway, {
+    now: () => now,
+    random: () => 0.5,
+    retryPolicy: {
+      baseDelayMs: 1_000,
+      maximumDelayMs: 60_000,
+      maximumAttempts,
+    },
+  });
+}

--- a/src/data/sync/__tests__/retryPolicy.test.ts
+++ b/src/data/sync/__tests__/retryPolicy.test.ts
@@ -1,0 +1,42 @@
+import { MutationPushError, classifyMutationError, retryDelayMs } from '../retryPolicy';
+
+describe('sync retry policy', () => {
+  it.each([
+    [new TypeError('Network request failed'), 'retryable'],
+    [new MutationPushError('Unavailable', { status: 503 }), 'retryable'],
+    [new MutationPushError('serialization', { code: '40001' }), 'retryable'],
+    [new MutationPushError('version_conflict', { code: 'P0001' }), 'conflict'],
+    [new MutationPushError('Forbidden', { status: 403 }), 'rejected'],
+  ] as const)('classifies %s as %s', (error, expected) => {
+    expect(classifyMutationError(error)).toBe(expected);
+  });
+
+  it('uses full jitter within the exponential cap', () => {
+    expect(
+      retryDelayMs(
+        3,
+        {
+          baseDelayMs: 1_000,
+          maximumDelayMs: 60_000,
+          maximumAttempts: 8,
+        },
+        () => 0.5,
+      ),
+    ).toBe(2_000);
+  });
+
+  it('honors retry-after without exceeding the configured maximum', () => {
+    expect(
+      retryDelayMs(
+        1,
+        {
+          baseDelayMs: 1_000,
+          maximumDelayMs: 10_000,
+          maximumAttempts: 8,
+        },
+        () => 0,
+        30_000,
+      ),
+    ).toBe(10_000);
+  });
+});

--- a/src/data/sync/index.ts
+++ b/src/data/sync/index.ts
@@ -1,0 +1,4 @@
+export * from './localMutation';
+export * from './mutationPushGateway';
+export * from './outboxPushWorker';
+export * from './retryPolicy';

--- a/src/data/sync/localMutation.ts
+++ b/src/data/sync/localMutation.ts
@@ -1,0 +1,55 @@
+import {
+  DomainEntityMap,
+  LocalDatabase,
+  OutboxMutation,
+  PutOptions,
+  RepositoryName,
+  RepositoryScope,
+} from '../contracts';
+
+export interface LocalEntityMutationInput<Name extends RepositoryName> {
+  readonly scope: RepositoryScope;
+  readonly repository: Name;
+  readonly entity: DomainEntityMap[Name];
+  readonly mutation: OutboxMutation;
+  readonly putOptions?: PutOptions;
+}
+
+export interface LocalEntityMutationResult<Name extends RepositoryName> {
+  readonly entity: DomainEntityMap[Name];
+  readonly mutation: OutboxMutation;
+}
+
+export async function commitLocalEntityMutation<Name extends RepositoryName>(
+  database: LocalDatabase,
+  input: LocalEntityMutationInput<Name>,
+): Promise<LocalEntityMutationResult<Name>> {
+  assertMutationMatchesEntity(input);
+
+  return database.transaction(async (transaction) => {
+    const entity = await transaction
+      .repository(input.repository)
+      .put(input.scope, input.entity, input.putOptions);
+    const mutation = await transaction.outbox.enqueue(input.mutation);
+
+    return { entity, mutation };
+  });
+}
+
+function assertMutationMatchesEntity<Name extends RepositoryName>(
+  input: LocalEntityMutationInput<Name>,
+): void {
+  const { mutation, entity, scope } = input;
+
+  if (mutation.repository !== input.repository) {
+    throw new Error('Outbox repository does not match the local entity repository');
+  }
+
+  if (mutation.entityId !== entity.id) {
+    throw new Error('Outbox entity ID does not match the local entity');
+  }
+
+  if (mutation.organizationId !== scope.organizationId || mutation.branchId !== scope.branchId) {
+    throw new Error('Outbox tenant scope does not match the local entity scope');
+  }
+}

--- a/src/data/sync/mutationPushGateway.ts
+++ b/src/data/sync/mutationPushGateway.ts
@@ -1,0 +1,120 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { JsonValue } from '../../domain';
+import { OutboxMutation } from '../contracts';
+import { Database, Json } from '../../services/supabase';
+import { MutationPushError } from './retryPolicy';
+
+export interface MutationPushResult {
+  readonly status: 'applied';
+  readonly repository: string;
+  readonly entityId: string;
+  readonly serverVersion: number;
+  readonly committedAt: string;
+  readonly result: JsonValue;
+}
+
+export interface MutationPushGateway {
+  push(mutation: OutboxMutation): Promise<MutationPushResult>;
+}
+
+export class SupabaseMutationPushGateway implements MutationPushGateway {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async push(mutation: OutboxMutation): Promise<MutationPushResult> {
+    const { data, error } = await this.client.rpc('apply_client_mutation', {
+      requested_organization_id: mutation.organizationId,
+      requested_branch_id: mutation.branchId,
+      requested_device_id: mutation.deviceId,
+      requested_client_mutation_id: mutation.clientMutationId,
+      requested_mutation_type: remoteMutationType(mutation),
+      requested_entity_id: mutation.entityId,
+      requested_payload: remotePayload(mutation),
+      requested_base_version: mutation.baseVersion ?? null,
+    });
+
+    if (error) {
+      throw new MutationPushError(error.message, {
+        code: error.code,
+      });
+    }
+
+    return parseMutationResult(data);
+  }
+}
+
+function remoteMutationType(mutation: OutboxMutation): string {
+  if (
+    mutation.repository === 'halls' &&
+    (mutation.operation === 'create' ||
+      mutation.operation === 'update' ||
+      mutation.operation === 'delete')
+  ) {
+    return 'halls.put';
+  }
+
+  throw new MutationPushError(
+    `No remote mutation handler for ${mutation.repository}.${mutation.operation}`,
+    { code: 'UNSUPPORTED_LOCAL_MUTATION' },
+  );
+}
+
+function remotePayload(mutation: OutboxMutation): Json {
+  if (mutation.repository !== 'halls') {
+    return mutation.payload as Json;
+  }
+
+  const payload = asRecord(mutation.payload);
+  return {
+    name: requiredString(payload.name, 'Hall mutation requires a name'),
+    sortOrder: optionalNumber(payload.sortOrder) ?? 0,
+    ...(typeof payload.deletedAt === 'string' ? { deletedAt: payload.deletedAt } : {}),
+  };
+}
+
+function parseMutationResult(data: Json): MutationPushResult {
+  const result = asRecord(data);
+  const status = requiredString(result.status, 'Mutation response has no status');
+  if (status !== 'applied') {
+    throw new MutationPushError(`Unsupported mutation response status: ${status}`, {
+      code: 'INVALID_MUTATION_RESPONSE',
+    });
+  }
+
+  return {
+    status,
+    repository: requiredString(result.repository, 'Mutation response has no repository'),
+    entityId: requiredString(result.entityId, 'Mutation response has no entity ID'),
+    serverVersion: requiredNumber(result.serverVersion, 'Mutation response has no server version'),
+    committedAt: requiredString(result.committedAt, 'Mutation response has no commit timestamp'),
+    result: data as JsonValue,
+  };
+}
+
+function asRecord(value: JsonValue | Json): Record<string, Json> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new MutationPushError('Mutation value must be a JSON object', {
+      code: 'INVALID_MUTATION_PAYLOAD',
+    });
+  }
+
+  return value as Record<string, Json>;
+}
+
+function requiredString(value: Json | undefined, message: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new MutationPushError(message, { code: 'INVALID_MUTATION_PAYLOAD' });
+  }
+  return value;
+}
+
+function requiredNumber(value: Json | undefined, message: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new MutationPushError(message, { code: 'INVALID_MUTATION_RESPONSE' });
+  }
+  return value;
+}
+
+function optionalNumber(value: Json | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  return requiredNumber(value, 'Mutation number is invalid');
+}

--- a/src/data/sync/outboxPushWorker.ts
+++ b/src/data/sync/outboxPushWorker.ts
@@ -1,0 +1,175 @@
+import {
+  LocalDatabase,
+  OutboxMutation,
+  OutboxTransitionPatch,
+  RepositoryScope,
+} from '../contracts';
+import { MutationPushGateway } from './mutationPushGateway';
+import {
+  RetryPolicy,
+  classifyMutationError,
+  defaultRetryPolicy,
+  mutationErrorDetails,
+  retryDelayMs,
+} from './retryPolicy';
+
+export interface OutboxPushWorkerOptions {
+  readonly batchSize?: number;
+  readonly retryPolicy?: RetryPolicy;
+  readonly processingTimeoutMs?: number;
+  readonly now?: () => Date;
+  readonly random?: () => number;
+}
+
+export interface OutboxPushCycleResult {
+  readonly claimed: number;
+  readonly applied: number;
+  readonly retrying: number;
+  readonly conflicted: number;
+  readonly rejected: number;
+  readonly skippedBecauseRunning: boolean;
+}
+
+export class OutboxPushWorker {
+  private running = false;
+
+  private readonly batchSize: number;
+  private readonly retryPolicy: RetryPolicy;
+  private readonly processingTimeoutMs: number;
+  private readonly now: () => Date;
+  private readonly random: () => number;
+
+  constructor(
+    private readonly database: LocalDatabase,
+    private readonly gateway: MutationPushGateway,
+    options: OutboxPushWorkerOptions = {},
+  ) {
+    this.batchSize = options.batchSize ?? 20;
+    this.retryPolicy = options.retryPolicy ?? defaultRetryPolicy;
+    this.processingTimeoutMs = options.processingTimeoutMs ?? 120_000;
+    this.now = options.now ?? (() => new Date());
+    this.random = options.random ?? Math.random;
+
+    if (!Number.isSafeInteger(this.batchSize) || this.batchSize <= 0) {
+      throw new Error('Outbox push batch size must be a positive safe integer');
+    }
+    if (!Number.isSafeInteger(this.processingTimeoutMs) || this.processingTimeoutMs <= 0) {
+      throw new Error('Outbox processing timeout must be a positive safe integer');
+    }
+  }
+
+  async runOnce(scope: RepositoryScope): Promise<OutboxPushCycleResult> {
+    if (this.running) {
+      return emptyCycle(true);
+    }
+
+    this.running = true;
+    try {
+      const claimedAt = this.now().toISOString();
+      const staleBefore = new Date(
+        new Date(claimedAt).getTime() - this.processingTimeoutMs,
+      ).toISOString();
+      const claimed = await this.database.transaction(async (transaction) => {
+        const processing = await transaction.outbox.list(scope, ['processing']);
+        for (const mutation of processing) {
+          if (mutation.lastAttemptAt === undefined || mutation.lastAttemptAt <= staleBefore) {
+            await transaction.outbox.transition(mutation.id, 'processing', 'retry_wait', {
+              nextAttemptAt: claimedAt,
+              errorCode: 'INTERRUPTED_PUSH_RECOVERED',
+              errorMessage: 'Recovered an interrupted mutation push',
+            });
+          }
+        }
+
+        return transaction.outbox.claimNext(scope, this.batchSize, claimedAt);
+      });
+      const result = emptyCycle(false);
+
+      for (const mutation of claimed) {
+        const outcome = await this.pushOne(mutation);
+        result[outcome] += 1;
+      }
+
+      result.claimed = claimed.length;
+      return result;
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async pushOne(
+    mutation: OutboxMutation,
+  ): Promise<'applied' | 'retrying' | 'conflicted' | 'rejected'> {
+    try {
+      await this.gateway.push(mutation);
+      await this.transition(mutation, 'applied', {
+        appliedAt: this.now().toISOString(),
+        nextAttemptAt: undefined,
+        errorCode: undefined,
+        errorMessage: undefined,
+      });
+      return 'applied';
+    } catch (error) {
+      const details = mutationErrorDetails(error);
+      const disposition = classifyMutationError(error);
+      const patch = {
+        errorCode: details.code,
+        errorMessage: details.message,
+      };
+
+      if (disposition === 'retryable' && mutation.attemptCount < this.retryPolicy.maximumAttempts) {
+        const delay = retryDelayMs(
+          mutation.attemptCount,
+          this.retryPolicy,
+          this.random,
+          details.retryAfterMs,
+        );
+        const nextAttemptAt = new Date(this.now().getTime() + delay).toISOString();
+        await this.transition(mutation, 'retry_wait', {
+          ...patch,
+          nextAttemptAt,
+        });
+        return 'retrying';
+      }
+
+      if (disposition === 'conflict') {
+        await this.transition(mutation, 'conflict', patch);
+        return 'conflicted';
+      }
+
+      await this.transition(mutation, 'rejected', {
+        ...patch,
+        errorCode: disposition === 'retryable' ? 'RETRY_ATTEMPTS_EXHAUSTED' : details.code,
+      });
+      return 'rejected';
+    }
+  }
+
+  private async transition(
+    mutation: OutboxMutation,
+    nextStatus: 'applied' | 'retry_wait' | 'conflict' | 'rejected',
+    patch: OutboxTransitionPatch,
+  ): Promise<void> {
+    await this.database.transaction(async (transaction) => {
+      await transaction.outbox.transition(mutation.id, 'processing', nextStatus, patch);
+    });
+  }
+}
+
+function emptyCycle(skippedBecauseRunning: boolean): {
+  claimed: number;
+  applied: number;
+  retrying: number;
+  conflicted: number;
+  rejected: number;
+  skippedBecauseRunning: boolean;
+} {
+  return {
+    claimed: 0,
+    applied: 0,
+    retrying: 0,
+    conflicted: 0,
+    rejected: 0,
+    skippedBecauseRunning,
+  };
+}

--- a/src/data/sync/retryPolicy.ts
+++ b/src/data/sync/retryPolicy.ts
@@ -1,0 +1,122 @@
+export type MutationErrorDisposition = 'retryable' | 'conflict' | 'rejected';
+
+export interface MutationErrorDetails {
+  readonly code?: string;
+  readonly status?: number;
+  readonly retryAfterMs?: number;
+  readonly message: string;
+}
+
+export interface RetryPolicy {
+  readonly baseDelayMs: number;
+  readonly maximumDelayMs: number;
+  readonly maximumAttempts: number;
+}
+
+export const defaultRetryPolicy: RetryPolicy = {
+  baseDelayMs: 1_000,
+  maximumDelayMs: 60_000,
+  maximumAttempts: 8,
+};
+
+const retryableCodes = new Set([
+  '40001',
+  '40P01',
+  '55P03',
+  '57014',
+  '08000',
+  '08001',
+  '08003',
+  '08004',
+  '08006',
+  '08007',
+  '08P01',
+  'PGRST000',
+  'PGRST001',
+  'PGRST002',
+  'PGRST003',
+]);
+const conflictCodes = new Set(['23505', '23P01']);
+const retryableStatuses = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export class MutationPushError extends Error {
+  constructor(
+    message: string,
+    readonly details: Omit<MutationErrorDetails, 'message'> = {},
+  ) {
+    super(message);
+    this.name = 'MutationPushError';
+  }
+}
+
+export function mutationErrorDetails(error: unknown): MutationErrorDetails {
+  if (error instanceof MutationPushError) {
+    return { message: error.message, ...error.details };
+  }
+
+  if (error instanceof TypeError) {
+    return { message: error.message, code: 'NETWORK_ERROR' };
+  }
+
+  if (error instanceof Error) {
+    const candidate = error as Error & {
+      readonly code?: unknown;
+      readonly status?: unknown;
+      readonly retryAfterMs?: unknown;
+    };
+    return {
+      message: candidate.message,
+      ...(typeof candidate.code === 'string' ? { code: candidate.code } : {}),
+      ...(typeof candidate.status === 'number' ? { status: candidate.status } : {}),
+      ...(typeof candidate.retryAfterMs === 'number'
+        ? { retryAfterMs: candidate.retryAfterMs }
+        : {}),
+    };
+  }
+
+  return { message: 'Unknown mutation push failure' };
+}
+
+export function classifyMutationError(error: unknown): MutationErrorDisposition {
+  const details = mutationErrorDetails(error);
+
+  if (details.message === 'version_conflict' || details.code === 'VERSION_CONFLICT') {
+    return 'conflict';
+  }
+
+  if (details.code && conflictCodes.has(details.code)) {
+    return 'conflict';
+  }
+
+  if (
+    details.code === 'NETWORK_ERROR' ||
+    (details.code !== undefined && retryableCodes.has(details.code)) ||
+    (details.status !== undefined && retryableStatuses.has(details.status))
+  ) {
+    return 'retryable';
+  }
+
+  return 'rejected';
+}
+
+export function retryDelayMs(
+  attemptCount: number,
+  policy: RetryPolicy = defaultRetryPolicy,
+  random: () => number = Math.random,
+  retryAfterMs?: number,
+): number {
+  if (!Number.isSafeInteger(attemptCount) || attemptCount <= 0) {
+    throw new Error('Retry attempt count must be a positive safe integer');
+  }
+
+  if (retryAfterMs !== undefined) {
+    return Math.min(policy.maximumDelayMs, Math.max(0, retryAfterMs));
+  }
+
+  const exponentialCap = Math.min(
+    policy.maximumDelayMs,
+    policy.baseDelayMs * 2 ** (attemptCount - 1),
+  );
+  const randomUnit = Math.min(1, Math.max(0, random()));
+  return Math.floor(exponentialCap * randomUnit);
+}

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -4,6 +4,8 @@ type MembershipRole = 'waiter' | 'manager';
 type MembershipStatus = 'invited' | 'active' | 'suspended';
 type DevicePlatform = 'android' | 'ios_web' | 'web';
 
+export type Json = boolean | number | string | null | Json[] | { [key: string]: Json | undefined };
+
 export type OrganizationRow = {
   id: string;
   name: string;
@@ -105,6 +107,19 @@ export type Database = {
           device_id: string;
         };
         Returns: DeviceRow;
+      };
+      apply_client_mutation: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_device_id: string;
+          requested_client_mutation_id: string;
+          requested_mutation_type: string;
+          requested_entity_id: string;
+          requested_payload: Json;
+          requested_base_version: number | null;
+        };
+        Returns: Json;
       };
     };
     Enums: Record<never, never>;

--- a/supabase/migrations/20260726190000_idempotent_mutation_push.sql
+++ b/supabase/migrations/20260726190000_idempotent_mutation_push.sql
@@ -1,0 +1,305 @@
+alter table public.client_mutations
+  add column request_fingerprint text;
+
+update public.client_mutations
+set request_fingerprint = md5(
+  concat_ws(
+    ':',
+    device_id::text,
+    client_mutation_id::text,
+    mutation_type,
+    coalesce(entity_id::text, '')
+  )
+);
+
+alter table public.client_mutations
+  alter column request_fingerprint set not null,
+  add constraint client_mutations_request_fingerprint_check
+    check (request_fingerprint ~ '^[a-f0-9]{32}$');
+
+create or replace function public.apply_client_mutation(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_device_id uuid,
+  requested_client_mutation_id uuid,
+  requested_mutation_type text,
+  requested_entity_id uuid,
+  requested_payload jsonb,
+  requested_base_version bigint
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller_user_id uuid := (select auth.uid());
+  fingerprint text;
+  claimed_mutation_id uuid;
+  prior_mutation public.client_mutations;
+  prior_hall public.halls;
+  canonical_hall public.halls;
+  mutation_result jsonb;
+begin
+  if caller_user_id is null then
+    raise exception using
+      errcode = '42501',
+      message = 'authentication_required';
+  end if;
+
+  if requested_payload is null
+    or jsonb_typeof(requested_payload) <> 'object' then
+    raise exception using
+      errcode = '22023',
+      message = 'mutation_payload_must_be_an_object';
+  end if;
+
+  if octet_length(requested_payload::text) > 65536 then
+    raise exception using
+      errcode = '22023',
+      message = 'mutation_payload_too_large';
+  end if;
+
+  if not private.is_active_member(
+    requested_organization_id,
+    requested_branch_id
+  ) then
+    raise exception using
+      errcode = '42501',
+      message = 'branch_access_denied';
+  end if;
+
+  if not exists (
+    select 1
+    from public.devices as device
+    where device.id = requested_device_id
+      and device.organization_id = requested_organization_id
+      and device.branch_id = requested_branch_id
+      and device.user_id = caller_user_id
+      and device.revoked_at is null
+  ) then
+    raise exception using
+      errcode = '42501',
+      message = 'device_access_denied';
+  end if;
+
+  fingerprint := md5(
+    concat_ws(
+      ':',
+      requested_organization_id::text,
+      requested_branch_id::text,
+      requested_device_id::text,
+      requested_client_mutation_id::text,
+      requested_mutation_type,
+      requested_entity_id::text,
+      requested_payload::text,
+      coalesce(requested_base_version::text, 'null')
+    )
+  );
+
+  insert into public.client_mutations (
+    organization_id,
+    branch_id,
+    device_id,
+    client_mutation_id,
+    mutation_type,
+    entity_id,
+    request_fingerprint,
+    result_json
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    requested_device_id,
+    requested_client_mutation_id,
+    requested_mutation_type,
+    requested_entity_id,
+    fingerprint,
+    '{}'::jsonb
+  )
+  on conflict (device_id, client_mutation_id) do nothing
+  returning id into claimed_mutation_id;
+
+  if claimed_mutation_id is null then
+    select mutation.*
+    into prior_mutation
+    from public.client_mutations as mutation
+    where mutation.device_id = requested_device_id
+      and mutation.client_mutation_id = requested_client_mutation_id;
+
+    if prior_mutation.id is null then
+      raise exception using
+        errcode = '40001',
+        message = 'idempotency_result_temporarily_unavailable';
+    end if;
+
+    if prior_mutation.request_fingerprint <> fingerprint then
+      raise exception using
+        errcode = '22023',
+        message = 'client_mutation_id_reused_with_different_content';
+    end if;
+
+    return prior_mutation.result_json;
+  end if;
+
+  case requested_mutation_type
+    when 'halls.put' then
+      if not private.is_manager(
+        requested_organization_id,
+        requested_branch_id
+      ) then
+        raise exception using
+          errcode = '42501',
+          message = 'manager_role_required';
+      end if;
+
+      if requested_payload - array['name', 'sortOrder', 'deletedAt'] <> '{}'::jsonb then
+        raise exception using
+          errcode = '22023',
+          message = 'unsupported_hall_payload_field';
+      end if;
+
+      if nullif(trim(requested_payload ->> 'name'), '') is null then
+        raise exception using
+          errcode = '22023',
+          message = 'hall_name_required';
+      end if;
+
+      select hall.*
+      into prior_hall
+      from public.halls as hall
+      where hall.organization_id = requested_organization_id
+        and hall.branch_id = requested_branch_id
+        and hall.id = requested_entity_id
+      for update;
+
+      if prior_hall.id is null then
+        if requested_base_version is not null
+          and requested_base_version <> 0 then
+          raise exception using
+            errcode = 'P0001',
+            message = 'version_conflict';
+        end if;
+
+        insert into public.halls (
+          id,
+          organization_id,
+          branch_id,
+          name,
+          sort_order,
+          version,
+          deleted_at
+        )
+        values (
+          requested_entity_id,
+          requested_organization_id,
+          requested_branch_id,
+          trim(requested_payload ->> 'name'),
+          coalesce((requested_payload ->> 'sortOrder')::integer, 0),
+          1,
+          (requested_payload ->> 'deletedAt')::timestamptz
+        )
+        returning * into canonical_hall;
+      else
+        if requested_base_version is null
+          or requested_base_version <> prior_hall.version then
+          raise exception using
+            errcode = 'P0001',
+            message = 'version_conflict';
+        end if;
+
+        update public.halls
+        set name = trim(requested_payload ->> 'name'),
+            sort_order = coalesce(
+              (requested_payload ->> 'sortOrder')::integer,
+              prior_hall.sort_order
+            ),
+            version = prior_hall.version + 1,
+            updated_at = now(),
+            deleted_at = case
+              when requested_payload ? 'deletedAt'
+                then (requested_payload ->> 'deletedAt')::timestamptz
+              else prior_hall.deleted_at
+            end
+        where id = prior_hall.id
+        returning * into canonical_hall;
+      end if;
+
+      mutation_result := jsonb_build_object(
+        'status',
+        'applied',
+        'repository',
+        'halls',
+        'entityId',
+        canonical_hall.id,
+        'serverVersion',
+        canonical_hall.version,
+        'committedAt',
+        now()
+      );
+    else
+      raise exception using
+        errcode = '22023',
+        message = 'unsupported_mutation_type';
+  end case;
+
+  insert into public.audit_events (
+    organization_id,
+    branch_id,
+    actor_user_id,
+    device_id,
+    entity_type,
+    entity_id,
+    action,
+    before_json,
+    after_json,
+    client_mutation_id,
+    correlation_id
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    caller_user_id,
+    requested_device_id,
+    split_part(requested_mutation_type, '.', 1),
+    requested_entity_id,
+    requested_mutation_type,
+    case
+      when prior_hall.id is null then null
+      else to_jsonb(prior_hall)
+    end,
+    to_jsonb(canonical_hall),
+    requested_client_mutation_id,
+    requested_client_mutation_id
+  );
+
+  update public.client_mutations
+  set result_json = mutation_result,
+      committed_at = now()
+  where id = claimed_mutation_id;
+
+  return mutation_result;
+end;
+$$;
+
+revoke execute on function public.apply_client_mutation(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  text,
+  uuid,
+  jsonb,
+  bigint
+) from public, anon;
+
+grant execute on function public.apply_client_mutation(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  text,
+  uuid,
+  jsonb,
+  bigint
+) to authenticated;

--- a/supabase/tests/database/003_idempotent_mutation_push.test.sql
+++ b/supabase/tests/database/003_idempotent_mutation_push.test.sql
@@ -1,0 +1,322 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(12);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-4000-8000-000000000001',
+    'authenticated',
+    'authenticated',
+    'mutation-manager@example.com',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Mutation Manager"}',
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '12000000-0000-4000-8000-000000000002',
+    'authenticated',
+    'authenticated',
+    'mutation-waiter@example.com',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Mutation Waiter"}',
+    now(),
+    now()
+  );
+
+insert into public.organizations (id, name, slug, plan, status)
+values (
+  '22000000-0000-4000-8000-000000000001',
+  'Mutation Tenant',
+  'mutation-tenant',
+  'growth',
+  'active'
+);
+
+insert into public.branches (
+  id,
+  organization_id,
+  name,
+  timezone,
+  currency_code,
+  business_day_cutoff,
+  receipt_prefix
+)
+values
+  (
+    '32000000-0000-4000-8000-000000000001',
+    '22000000-0000-4000-8000-000000000001',
+    'Mutation Branch 1',
+    'Europe/Sofia',
+    'EUR',
+    time '04:00',
+    'MB1'
+  ),
+  (
+    '32000000-0000-4000-8000-000000000002',
+    '22000000-0000-4000-8000-000000000001',
+    'Mutation Branch 2',
+    'Europe/Sofia',
+    'EUR',
+    time '04:00',
+    'MB2'
+  );
+
+insert into public.memberships (
+  organization_id,
+  branch_id,
+  user_id,
+  role,
+  status
+)
+values
+  (
+    '22000000-0000-4000-8000-000000000001',
+    null,
+    '12000000-0000-4000-8000-000000000001',
+    'manager',
+    'active'
+  ),
+  (
+    '22000000-0000-4000-8000-000000000001',
+    '32000000-0000-4000-8000-000000000001',
+    '12000000-0000-4000-8000-000000000002',
+    'waiter',
+    'active'
+  );
+
+insert into public.devices (
+  id,
+  organization_id,
+  branch_id,
+  user_id,
+  platform,
+  app_version
+)
+values
+  (
+    '42000000-0000-4000-8000-000000000001',
+    '22000000-0000-4000-8000-000000000001',
+    '32000000-0000-4000-8000-000000000001',
+    '12000000-0000-4000-8000-000000000001',
+    'web',
+    '2.0.0'
+  ),
+  (
+    '42000000-0000-4000-8000-000000000002',
+    '22000000-0000-4000-8000-000000000001',
+    '32000000-0000-4000-8000-000000000001',
+    '12000000-0000-4000-8000-000000000002',
+    'android',
+    '2.0.0'
+  );
+
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"12000000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000001',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000001',
+      '{"name":"Main Hall","sortOrder":1}',
+      null
+    ) ->> 'status'
+  ),
+  'applied',
+  'an authorized manager can push a hall mutation'
+);
+select is(
+  (
+    select count(*)
+    from public.halls
+    where id = '52000000-0000-4000-8000-000000000001'
+  ),
+  1::bigint,
+  'the mutation writes the business entity'
+);
+select is(
+  (
+    select version
+    from public.halls
+    where id = '52000000-0000-4000-8000-000000000001'
+  ),
+  1::bigint,
+  'the create returns the first canonical version'
+);
+select is(
+  (
+    select count(*)
+    from public.audit_events
+    where client_mutation_id = '62000000-0000-4000-8000-000000000001'
+  ),
+  1::bigint,
+  'the server writes one audit event in the same transaction'
+);
+select is(
+  (
+    select count(*)
+    from public.client_mutations
+    where client_mutation_id = '62000000-0000-4000-8000-000000000001'
+  ),
+  1::bigint,
+  'the server stores one idempotency result'
+);
+select is(
+  (
+    public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000001',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000001',
+      '{"name":"Main Hall","sortOrder":1}',
+      null
+    ) ->> 'serverVersion'
+  ),
+  '1',
+  'replaying the same mutation returns the original result'
+);
+select throws_ok(
+  $$
+    select public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000001',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000001',
+      '{"name":"Changed Replay","sortOrder":1}',
+      null
+    )
+  $$,
+  '22023',
+  'client_mutation_id_reused_with_different_content',
+  'a client mutation ID cannot be reused with different content'
+);
+select is(
+  (
+    public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000002',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000001',
+      '{"name":"Main Dining","sortOrder":2}',
+      1
+    ) ->> 'serverVersion'
+  ),
+  '2',
+  'a matching base version advances the canonical version'
+);
+select throws_ok(
+  $$
+    select public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000003',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000001',
+      '{"name":"Stale Edit","sortOrder":3}',
+      1
+    )
+  $$,
+  'P0001',
+  'version_conflict',
+  'a stale base version is rejected as a conflict'
+);
+select throws_ok(
+  $$
+    select public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000002',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000004',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000004',
+      '{"name":"Wrong Device Scope","sortOrder":1}',
+      null
+    )
+  $$,
+  '42501',
+  'device_access_denied',
+  'a device cannot push into another branch'
+);
+select throws_ok(
+  $$
+    select public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000001',
+      '62000000-0000-4000-8000-000000000005',
+      'unsafe.dynamic_sql',
+      '52000000-0000-4000-8000-000000000005',
+      '{}',
+      null
+    )
+  $$,
+  '22023',
+  'unsupported_mutation_type',
+  'unknown mutation types are not dispatched'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"12000000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select throws_ok(
+  $$
+    select public.apply_client_mutation(
+      '22000000-0000-4000-8000-000000000001',
+      '32000000-0000-4000-8000-000000000001',
+      '42000000-0000-4000-8000-000000000002',
+      '62000000-0000-4000-8000-000000000006',
+      'halls.put',
+      '52000000-0000-4000-8000-000000000006',
+      '{"name":"Waiter Hall","sortOrder":1}',
+      null
+    )
+  $$,
+  '42501',
+  'manager_role_required',
+  'a waiter cannot push a manager-only mutation'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- commit local entity and outbox writes through one transaction boundary
- add a non-overlapping outbox worker with stale-processing recovery, retry classification, exponential full jitter, and terminal conflict/rejection states
- push allow-listed mutations through a typed Supabase gateway
- reserve and fingerprint client mutations server-side so retries return the original result and mismatched replays are rejected
- apply manager-authorized hall mutations with optimistic versions and audit events in one database transaction

## Verification
- npm run verify:full (14 suites / 75 tests + web export + Chromium)
- npx expo install --check
- database migration/lint/pgTAP via CI

Closes #15

Depends on #41