### PR TITLE
fix(search): normalize Turkish dotted and dotless i

### DIFF
--- a/src/utils/__tests__/searchUtils.test.ts
+++ b/src/utils/__tests__/searchUtils.test.ts
@@ -7,6 +7,20 @@ describe('createTextMatcher', () => {
     expect(matches('Icecek')).toBe(true);
   });
 
+  it.each(['I', 'İ', 'i', 'ı'])('folds Turkish I variant %s consistently', (variant) => {
+    const matches = createTextMatcher(`${variant}ZM${variant}R`);
+
+    expect(matches('İzmir')).toBe(true);
+    expect(matches('IZMIR')).toBe(true);
+    expect(matches('ızmır')).toBe(true);
+    expect(matches('izmir')).toBe(true);
+  });
+
+  it('preserves English and Bulgarian matching behavior', () => {
+    expect(createTextMatcher('GRILL')('Mixed Grill')).toBe(true);
+    expect(createTextMatcher('шопска')('ШОПСКА САЛАТА')).toBe(true);
+  });
+
   it('requires every query word to be present', () => {
     const matches = createTextMatcher('patates peynirli');
 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 
 // Debounced search hook
 export function useDebounceSearch(initialValue: string = '', delay: number = 300) {
@@ -41,9 +41,10 @@ export function createTextMatcher(query: string) {
 // Text normalization: remove accents and convert to lowercase
 function normalizeText(text: string): string {
   return text
-    .toLowerCase()
     .normalize('NFD') // Decompose accented characters
     .replace(/[\u0300-\u036f]/g, '') // Remove accent marks
+    .replace(/[Iı]/g, 'i') // Fold Turkish dotted and dotless I to one search key
+    .toLowerCase()
     .trim();
 }
 


### PR DESCRIPTION
## Summary
- fold `I`, `İ`, `i`, and `ı` into the same search key after accent decomposition
- retain case-insensitive English and Bulgarian matching
- remove an unused hook import and lower the tracked legacy lint baseline from 78 to 77

## Validation
- `npm run verify:full`
- 20 Jest suites / 137 tests
- Expo web export and Playwright Chromium smoke test

## Stack
Base: #45 (`feat/18-design-system`)

Closes #31