### PR TITLE
feat(service): add live waiter shift board

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import { QRMenuProvider } from './src/contexts/QRMenuContext';
 import { initializeSampleData } from './src/utils/sampleData';
 import { AuthProvider } from './src/contexts/AuthContext';
 import { AuthGate } from './src/components/AuthGate';
+import { OrderiaDataProvider } from './src/data/runtime';
 
 export default function App() {
   useEffect(() => {
@@ -24,16 +25,18 @@ export default function App() {
       <LocalizationProvider>
         <ThemeProvider>
           <AuthProvider>
-            <AuthGate>
-              <NotificationProvider>
-                <AnalyticsProvider>
-                  <QRMenuProvider>
-                    <AppNavigator />
-                    <StatusBar style="auto" />
-                  </QRMenuProvider>
-                </AnalyticsProvider>
-              </NotificationProvider>
-            </AuthGate>
+            <OrderiaDataProvider>
+              <AuthGate>
+                <NotificationProvider>
+                  <AnalyticsProvider>
+                    <QRMenuProvider>
+                      <AppNavigator />
+                      <StatusBar style="auto" />
+                    </QRMenuProvider>
+                  </AnalyticsProvider>
+                </NotificationProvider>
+              </AuthGate>
+            </OrderiaDataProvider>
           </AuthProvider>
         </ThemeProvider>
       </LocalizationProvider>

--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -1,9 +1,35 @@
 import { expect, test } from '@playwright/test';
 
-test('loads the Orderia application shell', async ({ page }) => {
+test('loads the responsive Orderia service console', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');
 
-  await expect(page).toHaveTitle(/Masalar|Tables/i);
-  await expect(page.getByText(/Bugünkü Toplam|Today's Total/i)).toBeVisible();
-  await expect(page.getByText('Orderia').first()).toBeVisible();
+  await expect(page).toHaveTitle(/Orderia/i);
+  await expect(
+    page.getByRole('heading', {
+      name: /Canlı Servis|Обслужване на живо|Live service/i,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/Yalnız bu cihaz|Само на това устройство|This device only/i),
+  ).toBeVisible();
+  await expect(page.getByRole('tab', { name: /Tümü|Всички|All/i })).toBeVisible();
+  await expect(page.getByRole('tab', { name: /Benim|Моите|Mine/i })).toBeVisible();
+  await expect(page.getByRole('tab', { name: /Uyarılar|Сигнали|Alerts/i })).toBeVisible();
+
+  const allFilter = page.getByRole('tab', {
+    name: /Tümü|Всички|All/i,
+  });
+  const box = await allFilter.boundingBox();
+  expect(box?.height).toBeGreaterThanOrEqual(48);
+
+  await expect(page.getByText(/Servis|Обслужване|Service/i).last()).toBeVisible();
+  await expect(page.getByText(/Menü|Меню|Menu/i).last()).toBeVisible();
+
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const rail = page.getByTestId('manager-navigation-rail');
+  await expect(rail).toBeVisible();
+  const railBox = await rail.boundingBox();
+  expect(railBox?.width).toBe(240);
+  expect(railBox?.height).toBe(900);
 });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,5 @@
 export * from './contracts';
 export * from './indexeddb';
+export * from './runtime';
 export * from './sqlite';
 export * from './sync';

--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -1,0 +1,341 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { AppState, Platform } from 'react-native';
+import { useAuth } from '../../contexts/AuthContext';
+import { BranchId, OrganizationId, toDomainId } from '../../domain';
+import { Database, getSupabaseClient } from '../../services/supabase';
+import { LocalDatabase, RepositoryScope } from '../contracts';
+import {
+  OutboxPushWorker,
+  SupabaseMutationPushGateway,
+  SupabaseSyncPullGateway,
+  SyncPullEngine,
+  SyncStatusSnapshot,
+  deriveSyncStatus,
+  subscribeToRealtimeSyncHints,
+} from '../sync';
+import { openPlatformLocalDatabase } from './openPlatformLocalDatabase';
+import { inspectLocalSync } from './syncInspection';
+
+export type OrderiaDataMode = 'local_only' | 'cloud';
+export type OrderiaDataReadiness = 'opening' | 'ready' | 'error';
+
+export interface OrderiaDataContextValue {
+  readonly database: LocalDatabase | null;
+  readonly mode: OrderiaDataMode;
+  readonly readiness: OrderiaDataReadiness;
+  readonly scope: Required<RepositoryScope> | null;
+  readonly sync: SyncStatusSnapshot;
+  readonly revision: number;
+  readonly lastSuccessfulSyncAt?: string;
+  readonly errorMessage?: string;
+  refresh(): Promise<void>;
+  resolveProfileNames(userIds: readonly string[]): Promise<Readonly<Record<string, string>>>;
+}
+
+interface OrderiaDataProviderProps {
+  readonly children: React.ReactNode;
+  readonly openDatabase?: () => Promise<LocalDatabase>;
+  readonly client?: SupabaseClient<Database> | null;
+}
+
+const initialSync = deriveSyncStatus({
+  online: browserIsOnline(),
+  pendingCount: 0,
+  conflictCount: 0,
+  syncing: false,
+  hasError: false,
+});
+
+const OrderiaDataContext = createContext<OrderiaDataContextValue | undefined>(undefined);
+
+export function OrderiaDataProvider({
+  children,
+  openDatabase = openPlatformLocalDatabase,
+  client: suppliedClient,
+}: OrderiaDataProviderProps) {
+  const { activeBranch } = useAuth();
+  const [database, setDatabase] = useState<LocalDatabase | null>(null);
+  const [readiness, setReadiness] = useState<OrderiaDataReadiness>('opening');
+  const [sync, setSync] = useState<SyncStatusSnapshot>(initialSync);
+  const [revision, setRevision] = useState(0);
+  const [lastSuccessfulSyncAt, setLastSuccessfulSyncAt] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const refreshInFlight = useRef<Promise<void> | null>(null);
+  const mounted = useRef(true);
+
+  const client = useMemo(() => {
+    if (suppliedClient !== undefined) return suppliedClient;
+    try {
+      return getSupabaseClient();
+    } catch {
+      return null;
+    }
+  }, [suppliedClient]);
+
+  const scope = useMemo<Required<RepositoryScope> | null>(() => {
+    if (!activeBranch) return null;
+    return {
+      organizationId: toDomainId<OrganizationId>(activeBranch.organization_id),
+      branchId: toDomainId<BranchId>(activeBranch.id),
+    };
+  }, [activeBranch]);
+
+  useEffect(() => {
+    mounted.current = true;
+    let openedDatabase: LocalDatabase | null = null;
+    let active = true;
+
+    setReadiness('opening');
+    void openDatabase()
+      .then((opened) => {
+        openedDatabase = opened;
+        if (!active) {
+          return opened.close();
+        }
+        setDatabase(opened);
+        setReadiness('ready');
+        setErrorMessage(undefined);
+      })
+      .catch(() => {
+        if (!active) return;
+        setDatabase(null);
+        setReadiness('error');
+        setErrorMessage('Local orders could not be opened on this device.');
+      });
+
+    return () => {
+      active = false;
+      mounted.current = false;
+      refreshInFlight.current = null;
+      if (openedDatabase) {
+        void openedDatabase.close();
+      }
+    };
+  }, [openDatabase]);
+
+  const refresh = useCallback(async () => {
+    if (refreshInFlight.current) return refreshInFlight.current;
+
+    const job = (async () => {
+      if (!database || !scope || !client) {
+        if (mounted.current) {
+          setRevision((current) => current + 1);
+        }
+        return;
+      }
+
+      const online = browserIsOnline();
+      setSync((current) =>
+        deriveSyncStatus({
+          ...syncCounts(current),
+          online,
+          syncing: online,
+          hasError: false,
+        }),
+      );
+
+      try {
+        if (online) {
+          const pushWorker = new OutboxPushWorker(
+            database,
+            new SupabaseMutationPushGateway(client),
+          );
+          await pushWorker.runOnce(scope);
+          const engine = new SyncPullEngine(database, new SupabaseSyncPullGateway(client));
+          await engine.runOnce(scope);
+        }
+
+        const next = await inspectLocalSync(database, scope, online, false);
+        if (!mounted.current) return;
+        setSync(next);
+        setRevision((current) => current + 1);
+        setErrorMessage(undefined);
+        if (online) {
+          setLastSuccessfulSyncAt(new Date().toISOString());
+        }
+      } catch {
+        const next = await inspectLocalSync(database, scope, browserIsOnline(), true).catch(() =>
+          deriveSyncStatus({
+            online: browserIsOnline(),
+            pendingCount: 0,
+            conflictCount: 0,
+            syncing: false,
+            hasError: true,
+          }),
+        );
+        if (!mounted.current) return;
+        setSync(next);
+        setRevision((current) => current + 1);
+        setErrorMessage('Cloud refresh failed. Saved local orders remain available.');
+      }
+    })();
+
+    refreshInFlight.current = job;
+    try {
+      await job;
+    } finally {
+      if (refreshInFlight.current === job) {
+        refreshInFlight.current = null;
+      }
+    }
+  }, [client, database, scope]);
+
+  const resolveProfileNames = useCallback(
+    async (userIds: readonly string[]): Promise<Readonly<Record<string, string>>> => {
+      const uniqueUserIds = [...new Set(userIds)];
+      if (!client || uniqueUserIds.length === 0) return {};
+
+      const { data, error } = await client
+        .from('profiles')
+        .select('id, display_name')
+        .in('id', uniqueUserIds);
+      if (error) throw error;
+      return Object.fromEntries(data.map((profile) => [profile.id, profile.display_name]));
+    },
+    [client],
+  );
+
+  useEffect(() => {
+    if (!database || !scope || !client) return;
+
+    let active = true;
+    let unsubscribeHints: (() => Promise<void>) | undefined;
+    void refresh();
+    void subscribeToRealtimeSyncHints(
+      client,
+      scope,
+      () => {
+        if (active) void refresh();
+      },
+      (state) => {
+        if (!active || state === 'connecting' || state === 'subscribed') return;
+        setSync((current) =>
+          deriveSyncStatus({
+            ...syncCounts(current),
+            online: browserIsOnline(),
+            syncing: false,
+            hasError: true,
+          }),
+        );
+      },
+    )
+      .then((subscription) => {
+        if (!active) {
+          return subscription.unsubscribe();
+        }
+        unsubscribeHints = subscription.unsubscribe;
+      })
+      .catch(() => {
+        if (!active) return;
+        setSync((current) =>
+          deriveSyncStatus({
+            ...syncCounts(current),
+            online: browserIsOnline(),
+            syncing: false,
+            hasError: true,
+          }),
+        );
+      });
+
+    const appStateSubscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') void refresh();
+    });
+
+    return () => {
+      active = false;
+      appStateSubscription.remove();
+      if (unsubscribeHints) {
+        void unsubscribeHints();
+      }
+    };
+  }, [client, database, refresh, scope]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+
+    const updateConnection = () => {
+      setSync((current) =>
+        deriveSyncStatus({
+          ...syncCounts(current),
+          online: browserIsOnline(),
+          syncing: false,
+          hasError: current.hasError,
+        }),
+      );
+      if (browserIsOnline()) void refresh();
+    };
+    window.addEventListener('online', updateConnection);
+    window.addEventListener('offline', updateConnection);
+    return () => {
+      window.removeEventListener('online', updateConnection);
+      window.removeEventListener('offline', updateConnection);
+    };
+  }, [refresh]);
+
+  const value = useMemo<OrderiaDataContextValue>(
+    () => ({
+      database,
+      mode: client && scope ? 'cloud' : 'local_only',
+      readiness,
+      scope,
+      sync,
+      revision,
+      lastSuccessfulSyncAt,
+      errorMessage,
+      refresh,
+      resolveProfileNames,
+    }),
+    [
+      client,
+      database,
+      errorMessage,
+      lastSuccessfulSyncAt,
+      readiness,
+      refresh,
+      resolveProfileNames,
+      revision,
+      scope,
+      sync,
+    ],
+  );
+
+  return <OrderiaDataContext.Provider value={value}>{children}</OrderiaDataContext.Provider>;
+}
+
+export function useOrderiaData(): OrderiaDataContextValue {
+  const context = useContext(OrderiaDataContext);
+  if (!context) {
+    throw new Error('useOrderiaData must be used within OrderiaDataProvider');
+  }
+  return context;
+}
+
+function browserIsOnline(): boolean {
+  if (
+    Platform.OS === 'web' &&
+    typeof navigator !== 'undefined' &&
+    typeof navigator.onLine === 'boolean'
+  ) {
+    return navigator.onLine;
+  }
+  return true;
+}
+
+function syncCounts(snapshot: SyncStatusSnapshot): {
+  readonly pendingCount: number;
+  readonly conflictCount: number;
+} {
+  return {
+    pendingCount: snapshot.pendingCount,
+    conflictCount: snapshot.conflictCount,
+  };
+}

--- a/src/data/runtime/__tests__/OrderiaDataContext.test.ts
+++ b/src/data/runtime/__tests__/OrderiaDataContext.test.ts
@@ -1,0 +1,85 @@
+import {
+  BranchId,
+  DeviceId,
+  MutationId,
+  OrganizationId,
+  SyncConflictId,
+  toDomainId,
+} from '../../../domain';
+import { OutboxMutation, RepositoryScope, SyncConflict } from '../../contracts';
+import { InMemoryLocalDatabase } from '../../testing';
+import { inspectLocalSync } from '../syncInspection';
+
+const organizationId = toDomainId<OrganizationId>('organization-runtime');
+const branchId = toDomainId<BranchId>('branch-runtime');
+const mutationId = toDomainId<MutationId>('mutation-runtime');
+const scope: Required<RepositoryScope> = { organizationId, branchId };
+const timestamp = '2026-07-26T13:00:00.000Z';
+
+describe('inspectLocalSync', () => {
+  let database: InMemoryLocalDatabase;
+
+  beforeEach(() => {
+    database = new InMemoryLocalDatabase();
+  });
+
+  afterEach(async () => {
+    await database.close();
+  });
+
+  it('reports a clean online database as synced', async () => {
+    await expect(inspectLocalSync(database, scope, true, false)).resolves.toMatchObject({
+      state: 'synced',
+      pendingCount: 0,
+      conflictCount: 0,
+    });
+  });
+
+  it('counts durable queued work and unresolved conflicts', async () => {
+    await database.transaction(async (transaction) => {
+      await transaction.outbox.enqueue(createMutation());
+      await transaction.syncState.addConflict(createConflict());
+    });
+
+    await expect(inspectLocalSync(database, scope, true, false)).resolves.toMatchObject({
+      state: 'conflict',
+      pendingCount: 1,
+      conflictCount: 1,
+    });
+  });
+});
+
+function createMutation(): OutboxMutation {
+  return {
+    id: mutationId,
+    organizationId,
+    branchId,
+    deviceId: toDomainId<DeviceId>('device-runtime'),
+    clientMutationId: mutationId,
+    idempotencyKey: 'device-runtime:mutation-runtime',
+    repository: 'halls',
+    entityId: 'hall-runtime',
+    operation: 'create',
+    payload: { name: 'Terrace' },
+    status: 'pending',
+    attemptCount: 0,
+    createdAt: timestamp,
+  };
+}
+
+function createConflict(): SyncConflict {
+  return {
+    id: toDomainId<SyncConflictId>('conflict-runtime'),
+    organizationId,
+    branchId,
+    mutationId,
+    repository: 'halls',
+    entityId: 'hall-runtime',
+    baseVersion: 1,
+    serverVersion: 2,
+    localPayload: { name: 'Terrace local' },
+    serverPayload: { name: 'Terrace server' },
+    status: 'unresolved',
+    detectedAt: timestamp,
+  };
+}

--- a/src/data/runtime/index.ts
+++ b/src/data/runtime/index.ts
@@ -1,0 +1,2 @@
+export * from './OrderiaDataContext';
+export * from './syncInspection';

--- a/src/data/runtime/openPlatformLocalDatabase.native.ts
+++ b/src/data/runtime/openPlatformLocalDatabase.native.ts
@@ -1,0 +1,6 @@
+import { LocalDatabase } from '../contracts';
+import { openNativeLocalDatabase } from '../sqlite';
+
+export function openPlatformLocalDatabase(): Promise<LocalDatabase> {
+  return openNativeLocalDatabase();
+}

--- a/src/data/runtime/openPlatformLocalDatabase.ts
+++ b/src/data/runtime/openPlatformLocalDatabase.ts
@@ -1,0 +1,5 @@
+import { LocalDatabase } from '../contracts';
+
+export async function openPlatformLocalDatabase(): Promise<LocalDatabase> {
+  throw new Error('A platform-specific local database adapter was not selected');
+}

--- a/src/data/runtime/openPlatformLocalDatabase.web.ts
+++ b/src/data/runtime/openPlatformLocalDatabase.web.ts
@@ -1,0 +1,6 @@
+import { LocalDatabase } from '../contracts';
+import { IndexedDbLocalDatabase } from '../indexeddb';
+
+export function openPlatformLocalDatabase(): Promise<LocalDatabase> {
+  return IndexedDbLocalDatabase.open();
+}

--- a/src/data/runtime/syncInspection.ts
+++ b/src/data/runtime/syncInspection.ts
@@ -1,0 +1,22 @@
+import { LocalDatabase, RepositoryScope } from '../contracts';
+import { SyncStatusSnapshot, deriveSyncStatus } from '../sync';
+
+export async function inspectLocalSync(
+  database: LocalDatabase,
+  scope: Required<RepositoryScope>,
+  online: boolean,
+  hasError: boolean,
+): Promise<SyncStatusSnapshot> {
+  const [pending, outboxConflicts, conflicts] = await Promise.all([
+    database.outbox.list(scope, ['pending', 'processing', 'retry_wait']),
+    database.outbox.list(scope, ['conflict', 'rejected']),
+    database.syncState.listConflicts(scope, ['unresolved']),
+  ]);
+  return deriveSyncStatus({
+    online,
+    pendingCount: pending.length,
+    conflictCount: outboxConflicts.length + conflicts.length,
+    syncing: false,
+    hasError,
+  });
+}

--- a/src/features/service-board/ServiceTableCard.tsx
+++ b/src/features/service-board/ServiceTableCard.tsx
@@ -1,0 +1,312 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceIconButton, ServiceSurface } from '../../design-system';
+import { Language, useLocalization } from '../../i18n';
+import { ShiftBoardTable, ShiftBoardTableState } from './shiftBoardModel';
+
+export interface ServiceTableCardProps {
+  readonly table: ShiftBoardTable;
+  readonly onPress: () => void;
+  readonly onMore?: () => void;
+}
+
+export function ServiceTableCard({ table, onPress, onMore }: ServiceTableCardProps) {
+  const { tokens } = useTheme();
+  const { language, t } = useLocalization();
+  const [focused, setFocused] = useState(false);
+  const state = statePresentation(table.state, t);
+  const stateColors = statePalette(table.state, tokens.colors);
+  const accessibleWaiters = table.waiterNames.length > 0 ? `, ${table.waiterNames.join(', ')}` : '';
+  const accessibilityLabel = [
+    table.label,
+    state.label,
+    table.durationMinutes === undefined ? undefined : `${table.durationMinutes} ${t.minutes}`,
+    table.remainingMinor > 0
+      ? formatMinorCurrency(table.remainingMinor, table.currencyCode, language)
+      : undefined,
+    table.checkCount > 0 ? `${table.checkCount} ${t.checksCount}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <ServiceSurface
+      padding="none"
+      style={{
+        backgroundColor: stateColors.background,
+        borderColor: focused ? tokens.colors.focus : stateColors.border,
+        borderWidth: focused ? 3 : 1,
+        minHeight: tokens.sizing.tableCardMinimumHeight,
+        overflow: 'hidden',
+      }}
+    >
+      <Pressable
+        accessibilityHint={`${table.hallName}${accessibleWaiters}`}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole="button"
+        onBlur={() => setFocused(false)}
+        onFocus={() => setFocused(true)}
+        onPress={onPress}
+        style={({ pressed }) => ({
+          minHeight: tokens.sizing.tableCardMinimumHeight,
+          opacity: pressed ? 0.78 : 1,
+          padding: tokens.space.sm,
+          paddingRight: onMore ? 52 : tokens.space.sm,
+        })}
+      >
+        <View
+          style={{
+            alignItems: 'flex-start',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Text
+            numberOfLines={2}
+            style={[tokens.typography.bodyStrong, { color: tokens.colors.text, flexShrink: 1 }]}
+          >
+            {table.label}
+          </Text>
+          {table.needsAttention ? (
+            <Ionicons
+              accessibilityLabel={state.label}
+              color={stateColors.content}
+              name="alert-circle"
+              size={20}
+            />
+          ) : null}
+        </View>
+
+        <View
+          style={{
+            alignItems: 'center',
+            flexDirection: 'row',
+            marginTop: tokens.space.xs,
+          }}
+        >
+          <Ionicons color={stateColors.content} name={state.icon} size={16} />
+          <Text
+            style={[
+              tokens.typography.caption,
+              {
+                color: stateColors.content,
+                marginLeft: tokens.space.xxs,
+                textTransform: 'uppercase',
+              },
+            ]}
+          >
+            {state.label}
+            {table.durationMinutes === undefined
+              ? ''
+              : ` · ${table.durationMinutes}${minuteSuffix(language)}`}
+          </Text>
+        </View>
+
+        {table.state === 'available' ? (
+          table.capacity ? (
+            <Text
+              style={[
+                tokens.typography.caption,
+                {
+                  color: tokens.colors.textSubtle,
+                  marginTop: tokens.space.sm,
+                },
+              ]}
+            >
+              {table.capacity} {t.seatsCount}
+            </Text>
+          ) : (
+            <View style={{ flex: 1 }} />
+          )
+        ) : (
+          <>
+            <Text
+              style={[
+                tokens.typography.subtitle,
+                {
+                  color: tokens.colors.text,
+                  marginTop: tokens.space.sm,
+                },
+              ]}
+            >
+              {formatMinorCurrency(table.remainingMinor, table.currencyCode, language)}
+            </Text>
+            <View
+              style={{
+                alignItems: 'center',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                marginTop: tokens.space.xs,
+              }}
+            >
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {table.checkCount} {t.checksCount}
+              </Text>
+              <WaiterInitials initials={table.waiterInitials} />
+            </View>
+          </>
+        )}
+
+        {table.pendingMutationCount > 0 ? (
+          <View
+            style={{
+              alignItems: 'center',
+              flexDirection: 'row',
+              marginTop: tokens.space.xs,
+            }}
+          >
+            <Ionicons color={tokens.colors.warning} name="cloud-upload-outline" size={14} />
+            <Text
+              style={[
+                tokens.typography.caption,
+                {
+                  color: tokens.colors.textSubtle,
+                  marginLeft: tokens.space.xxs,
+                },
+              ]}
+            >
+              {table.pendingMutationCount} {t.queuedChanges}
+            </Text>
+          </View>
+        ) : null}
+      </Pressable>
+
+      {onMore ? (
+        <View style={{ position: 'absolute', right: 2, top: 2 }}>
+          <ServiceIconButton
+            icon="ellipsis-horizontal"
+            label={`${table.label}, ${t.moreTableActions}`}
+            onPress={onMore}
+          />
+        </View>
+      ) : null}
+    </ServiceSurface>
+  );
+}
+
+function WaiterInitials({ initials }: { readonly initials: readonly string[] }) {
+  const { tokens } = useTheme();
+  const { t } = useLocalization();
+  if (initials.length === 0) return null;
+
+  return (
+    <View
+      accessibilityLabel={`${initials.length} ${t.waitersCount}`}
+      style={{ flexDirection: 'row' }}
+    >
+      {initials.slice(0, 3).map((value, index) => (
+        <View
+          key={`${value}-${index}`}
+          style={{
+            alignItems: 'center',
+            backgroundColor: tokens.colors.surfaceAlt,
+            borderColor: tokens.colors.border,
+            borderRadius: tokens.radius.full,
+            borderWidth: 1,
+            height: 26,
+            justifyContent: 'center',
+            marginLeft: index === 0 ? 0 : -4,
+            width: 26,
+          }}
+        >
+          <Text
+            style={[tokens.typography.caption, { color: tokens.colors.textSubtle, fontSize: 10 }]}
+          >
+            {value}
+          </Text>
+        </View>
+      ))}
+      {initials.length > 3 ? (
+        <Text
+          style={[
+            tokens.typography.caption,
+            {
+              color: tokens.colors.textSubtle,
+              marginLeft: tokens.space.xxs,
+            },
+          ]}
+        >
+          +{initials.length - 3}
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+function statePresentation(
+  state: ShiftBoardTableState,
+  t: ReturnType<typeof useLocalization>['t'],
+): {
+  readonly label: string;
+  readonly icon: keyof typeof Ionicons.glyphMap;
+} {
+  switch (state) {
+    case 'open':
+      return { label: t.openState, icon: 'restaurant-outline' };
+    case 'payment_pending':
+      return { label: t.paymentDueState, icon: 'card-outline' };
+    case 'sync_issue':
+      return { label: t.syncIssueState, icon: 'cloud-offline-outline' };
+    case 'conflict':
+      return { label: t.needsReviewState, icon: 'warning-outline' };
+    default:
+      return { label: t.availableState, icon: 'ellipse-outline' };
+  }
+}
+
+function statePalette(
+  state: ShiftBoardTableState,
+  colors: ReturnType<typeof useTheme>['colors'],
+): { readonly background: string; readonly border: string; readonly content: string } {
+  switch (state) {
+    case 'open':
+      return {
+        background: colors.state.delivered.bg,
+        border: colors.state.delivered.border,
+        content: colors.state.delivered.text,
+      };
+    case 'payment_pending':
+      return {
+        background: colors.state.pending.bg,
+        border: colors.state.pending.border,
+        content: colors.state.pending.text,
+      };
+    case 'sync_issue':
+    case 'conflict':
+      return {
+        background: colors.state.cancelled.bg,
+        border: colors.state.cancelled.border,
+        content: colors.state.cancelled.text,
+      };
+    default:
+      return {
+        background: colors.surface,
+        border: colors.border,
+        content: colors.textSubtle,
+      };
+  }
+}
+
+export function formatMinorCurrency(
+  amountMinor: number,
+  currencyCode: string,
+  language: Language,
+): string {
+  const locale = language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-IE';
+  try {
+    return new Intl.NumberFormat(locale, {
+      currency: currencyCode,
+      style: 'currency',
+    }).format(amountMinor / 100);
+  } catch {
+    return `${currencyCode} ${(amountMinor / 100).toFixed(2)}`;
+  }
+}
+
+function minuteSuffix(language: Language): string {
+  if (language === 'tr') return 'dk';
+  if (language === 'bg') return 'м';
+  return 'm';
+}

--- a/src/features/service-board/__tests__/ServiceTableCard.test.tsx
+++ b/src/features/service-board/__tests__/ServiceTableCard.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { ThemeProvider } from '../../../contexts/ThemeContext';
+import { LocalizationProvider } from '../../../i18n';
+import { ShiftBoardTable } from '../shiftBoardModel';
+import { ServiceTableCard, formatMinorCurrency } from '../ServiceTableCard';
+
+const table: ShiftBoardTable = {
+  id: 'table-4',
+  hallId: 'hall-1',
+  hallName: 'Terrace',
+  label: 'Table 4',
+  sequenceNumber: 4,
+  state: 'payment_pending',
+  syncStatus: 'pending',
+  pendingMutationCount: 2,
+  openedAt: '2026-07-26T12:30:00.000Z',
+  durationMinutes: 30,
+  totalMinor: 4250,
+  paidMinor: 1000,
+  remainingMinor: 3250,
+  currencyCode: 'EUR',
+  checkCount: 2,
+  waiterNames: ['Deniz Kaya', 'Ayşe Yılmaz'],
+  waiterInitials: ['DK', 'AY'],
+  isMine: true,
+  needsAttention: true,
+};
+
+describe('ServiceTableCard', () => {
+  it('provides a large named table action and a separate visible more action', async () => {
+    const onPress = jest.fn();
+    const onMore = jest.fn();
+    const screen = await render(
+      <LocalizationProvider>
+        <ThemeProvider>
+          <ServiceTableCard onMore={onMore} onPress={onPress} table={table} />
+        </ThemeProvider>
+      </LocalizationProvider>,
+    );
+
+    const tableAction = screen.getByRole('button', {
+      name: /Table 4.*32,50.*2 hesap/i,
+    });
+    await fireEvent.press(tableAction);
+    await fireEvent.press(
+      screen.getByRole('button', {
+        name: /Table 4, Masa işlemleri/i,
+      }),
+    );
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onMore).toHaveBeenCalledTimes(1);
+    expect(tableAction.props.style.minHeight).toBe(104);
+  });
+});
+
+describe('formatMinorCurrency', () => {
+  it('formats integer minor units using the selected locale and currency', () => {
+    const formatted = formatMinorCurrency(4250, 'EUR', 'tr');
+    expect(formatted).toContain('42,50');
+    expect(formatted).toContain('€');
+  });
+});

--- a/src/features/service-board/__tests__/legacyShiftBoardAdapter.test.ts
+++ b/src/features/service-board/__tests__/legacyShiftBoardAdapter.test.ts
@@ -1,0 +1,71 @@
+import { buildLegacyShiftBoard } from '../legacyShiftBoardAdapter';
+
+describe('buildLegacyShiftBoard', () => {
+  it('keeps local-only tables usable and excludes cancelled lines from totals', () => {
+    const snapshot = buildLegacyShiftBoard(
+      {
+        currencyCode: 'EUR',
+        currentWaiterName: 'Deniz Kaya',
+        fallbackHallName: 'Unassigned',
+        halls: [
+          {
+            id: 'hall-1',
+            name: 'Terrace',
+            createdAt: 1,
+            nextTableSequence: 2,
+          },
+        ],
+        tables: [
+          {
+            id: 'hall-1-1',
+            hallId: 'hall-1',
+            seq: 1,
+            isOpen: true,
+            activeTicketIds: ['ticket-1'],
+          },
+        ],
+        tickets: {
+          'ticket-1': {
+            id: 'ticket-1',
+            tableId: 'hall-1-1',
+            status: 'open',
+            createdAt: Date.parse('2026-07-26T12:45:00.000Z'),
+            lines: [
+              {
+                id: 'line-1',
+                menuItemId: 'fries',
+                nameSnapshot: 'Fries',
+                priceSnapshot: 400,
+                quantity: 2,
+                status: 'pending',
+                createdAt: 1,
+                updatedAt: 1,
+              },
+              {
+                id: 'line-2',
+                menuItemId: 'steak',
+                nameSnapshot: 'Steak',
+                priceSnapshot: 5000,
+                quantity: 1,
+                status: 'cancelled',
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          },
+        },
+      },
+      new Date('2026-07-26T13:00:00.000Z'),
+    );
+
+    expect(snapshot.tables[0]).toMatchObject({
+      syncStatus: 'local',
+      state: 'open',
+      durationMinutes: 15,
+      totalMinor: 800,
+      remainingMinor: 800,
+      waiterNames: ['Deniz Kaya'],
+      isMine: true,
+    });
+  });
+});

--- a/src/features/service-board/__tests__/shiftBoardModel.test.ts
+++ b/src/features/service-board/__tests__/shiftBoardModel.test.ts
@@ -1,0 +1,372 @@
+import {
+  BranchId,
+  CheckId,
+  DeviceId,
+  HallId,
+  MenuItemId,
+  MutationId,
+  OrderBatchId,
+  OrderItemId,
+  OrganizationId,
+  PaymentAllocationId,
+  PaymentId,
+  RestaurantTableId,
+  TableSessionId,
+  UserId,
+  toCurrencyCode,
+  toDomainId,
+} from '../../../domain';
+import { InMemoryLocalDatabase } from '../../../data/testing';
+import {
+  DomainShiftBoardSource,
+  buildDomainShiftBoard,
+  filterShiftBoardTables,
+  loadDomainShiftBoard,
+} from '../shiftBoardModel';
+
+const organizationId = toDomainId<OrganizationId>('organization-1');
+const branchId = toDomainId<BranchId>('branch-1');
+const hallId = toDomainId<HallId>('hall-1');
+const tableId = toDomainId<RestaurantTableId>('table-1');
+const availableTableId = toDomainId<RestaurantTableId>('table-2');
+const sessionId = toDomainId<TableSessionId>('session-1');
+const checkId = toDomainId<CheckId>('check-1');
+const itemId = toDomainId<OrderItemId>('item-1');
+const cancelledItemId = toDomainId<OrderItemId>('item-cancelled');
+const paymentId = toDomainId<PaymentId>('payment-1');
+const waiterId = toDomainId<UserId>('waiter-deniz');
+const secondWaiterId = toDomainId<UserId>('waiter-ayse');
+const timestamp = '2026-07-26T12:30:00.000Z';
+const now = new Date('2026-07-26T13:00:00.000Z');
+const currencyCode = toCurrencyCode('EUR');
+
+describe('buildDomainShiftBoard', () => {
+  it('summarizes table, checks, waiters, duration and partial payment safely', () => {
+    const snapshot = buildDomainShiftBoard(fixture(), now);
+    const active = snapshot.tables.find((table) => table.id === tableId);
+    const available = snapshot.tables.find((table) => table.id === availableTableId);
+
+    expect(active).toMatchObject({
+      state: 'payment_pending',
+      syncStatus: 'pending',
+      pendingMutationCount: 1,
+      durationMinutes: 30,
+      totalMinor: 1000,
+      paidMinor: 300,
+      remainingMinor: 700,
+      checkCount: 1,
+      waiterNames: ['Deniz Kaya', 'Ayşe Yılmaz'],
+      waiterInitials: ['DK', 'AY'],
+      isMine: true,
+      needsAttention: true,
+    });
+    expect(available).toMatchObject({
+      state: 'available',
+      totalMinor: 0,
+      checkCount: 0,
+      isMine: false,
+    });
+    expect(snapshot).toMatchObject({
+      openCount: 1,
+      attentionCount: 1,
+      totalOpenMinor: 700,
+    });
+  });
+
+  it('prioritizes a conflict over ordinary service and payment states', () => {
+    const source = fixture();
+    const snapshot = buildDomainShiftBoard(
+      {
+        ...source,
+        items: source.items.map((item) =>
+          item.id === itemId ? { ...item, syncStatus: 'conflict' } : item,
+        ),
+      },
+      now,
+    );
+
+    expect(snapshot.tables[0]).toMatchObject({
+      state: 'conflict',
+      syncStatus: 'conflict',
+      needsAttention: true,
+    });
+  });
+
+  it('marks a financially inconsistent card for review instead of crashing the board', () => {
+    const source = fixture();
+    const snapshot = buildDomainShiftBoard(
+      {
+        ...source,
+        allocations: source.allocations.map((allocation) => ({
+          ...allocation,
+          amountMinor: 1200,
+        })),
+      },
+      now,
+    );
+
+    expect(snapshot.tables[0]).toMatchObject({
+      state: 'sync_issue',
+      totalMinor: 0,
+      remainingMinor: 0,
+      needsAttention: true,
+    });
+  });
+});
+
+describe('loadDomainShiftBoard', () => {
+  it('resolves authorized colleague names in one batch without making profiles local entities', async () => {
+    const database = new InMemoryLocalDatabase();
+    const source = fixture();
+    const scope = { organizationId, branchId };
+    const resolveWaiterNames = jest.fn(async () => ({
+      [waiterId]: 'Deniz Kaya',
+      [secondWaiterId]: 'Ayşe Yılmaz',
+    }));
+
+    try {
+      await database.transaction(async (transaction) => {
+        for (const entity of source.halls) {
+          await transaction.repository('halls').put(scope, entity);
+        }
+        for (const entity of source.tables) {
+          await transaction.repository('restaurantTables').put(scope, entity);
+        }
+        for (const entity of source.sessions) {
+          await transaction.repository('tableSessions').put(scope, entity);
+        }
+        for (const entity of source.checks) {
+          await transaction.repository('checks').put(scope, entity);
+        }
+        for (const entity of source.items) {
+          await transaction.repository('orderItems').put(scope, entity);
+        }
+        for (const entity of source.modifiers) {
+          await transaction.repository('orderItemModifiers').put(scope, entity);
+        }
+        for (const entity of source.payments) {
+          await transaction.repository('payments').put(scope, entity);
+        }
+        for (const entity of source.allocations) {
+          await transaction.repository('paymentAllocations').put(scope, entity);
+        }
+      });
+
+      const snapshot = await loadDomainShiftBoard(
+        database,
+        scope,
+        {
+          currentUserId: waiterId,
+          fallbackCurrencyCode: 'EUR',
+          fallbackHallName: 'Unassigned',
+          unknownWaiterName: 'Waiter',
+          resolveWaiterNames,
+        },
+        now,
+      );
+
+      expect(resolveWaiterNames).toHaveBeenCalledTimes(1);
+      expect(resolveWaiterNames).toHaveBeenCalledWith(
+        expect.arrayContaining([waiterId, secondWaiterId]),
+      );
+      expect(snapshot.tables[0].waiterNames).toEqual(['Deniz Kaya', 'Ayşe Yılmaz']);
+    } finally {
+      await database.close();
+    }
+  });
+});
+
+describe('filterShiftBoardTables', () => {
+  const tables = buildDomainShiftBoard(fixture(), now).tables;
+
+  it('combines mine, hall and Turkish-normalized table/waiter search', () => {
+    expect(
+      filterShiftBoardTables(tables, {
+        scope: 'mine',
+        hallId,
+        query: 'IC SALON deniz',
+      }).map((table) => table.id),
+    ).toEqual([tableId]);
+  });
+
+  it('shows only operational exceptions in alerts', () => {
+    expect(filterShiftBoardTables(tables, { scope: 'alerts' }).map((table) => table.id)).toEqual([
+      tableId,
+    ]);
+  });
+});
+
+function fixture(): DomainShiftBoardSource {
+  return {
+    fallbackCurrencyCode: 'EUR',
+    fallbackHallName: 'Unassigned',
+    unknownWaiterName: 'Waiter',
+    currentUserId: waiterId,
+    waiterNames: {
+      [waiterId]: 'Deniz Kaya',
+      [secondWaiterId]: 'Ayşe Yılmaz',
+    },
+    halls: [
+      {
+        id: hallId,
+        organizationId,
+        branchId,
+        name: 'İç Salon',
+        sortOrder: 1,
+        syncStatus: 'synced',
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    tables: [
+      {
+        id: tableId,
+        organizationId,
+        branchId,
+        hallId,
+        label: 'İçeri Masa 4',
+        sequenceNumber: 4,
+        capacity: 4,
+        sortOrder: 4,
+        syncStatus: 'synced',
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      {
+        id: availableTableId,
+        organizationId,
+        branchId,
+        hallId,
+        label: 'Masa 5',
+        sequenceNumber: 5,
+        capacity: 2,
+        sortOrder: 5,
+        syncStatus: 'synced',
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    sessions: [
+      {
+        id: sessionId,
+        organizationId,
+        branchId,
+        tableId,
+        status: 'payment_pending',
+        openedBy: waiterId,
+        openedAt: timestamp,
+        syncStatus: 'synced',
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    checks: [
+      {
+        id: checkId,
+        organizationId,
+        branchId,
+        tableSessionId: sessionId,
+        name: 'Main',
+        status: 'partially_paid',
+        openedBy: waiterId,
+        openedAt: timestamp,
+        syncStatus: 'synced',
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    items: [
+      {
+        id: itemId,
+        organizationId,
+        branchId,
+        tableSessionId: sessionId,
+        checkId,
+        orderBatchId: toDomainId<OrderBatchId>('batch-1'),
+        menuItemId: toDomainId<MenuItemId>('menu-fries'),
+        nameSnapshot: 'Fries',
+        unitPriceMinor: 400,
+        currencyCode,
+        taxRateBasisPoints: 0,
+        quantity: 2,
+        status: 'ordered',
+        createdBy: secondWaiterId,
+        updatedBy: secondWaiterId,
+        originalTableId: tableId,
+        originalTableSessionId: sessionId,
+        syncStatus: 'pending',
+        clientMutationId: toDomainId<MutationId>('mutation-item-1'),
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      {
+        id: cancelledItemId,
+        organizationId,
+        branchId,
+        tableSessionId: sessionId,
+        checkId,
+        orderBatchId: toDomainId<OrderBatchId>('batch-2'),
+        nameSnapshot: 'Cancelled steak',
+        unitPriceMinor: 9999,
+        currencyCode,
+        taxRateBasisPoints: 0,
+        quantity: 1,
+        status: 'cancelled',
+        createdBy: waiterId,
+        updatedBy: waiterId,
+        cancelledBy: waiterId,
+        cancelledAt: timestamp,
+        originalTableId: tableId,
+        originalTableSessionId: sessionId,
+        syncStatus: 'synced',
+        version: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ],
+    modifiers: [
+      {
+        id: toDomainId('modifier-cheese'),
+        orderItemId: itemId,
+        modifierGroupNameSnapshot: 'Cheese',
+        modifierOptionNameSnapshot: 'Cheddar',
+        priceDeltaMinor: 100,
+        quantity: 1,
+      },
+    ],
+    payments: [
+      {
+        id: paymentId,
+        organizationId,
+        branchId,
+        tableSessionId: sessionId,
+        method: 'card',
+        status: 'confirmed',
+        amountMinor: 300,
+        tenderedMinor: 300,
+        changeMinor: 0,
+        currencyCode,
+        createdBy: waiterId,
+        createdAt: timestamp,
+        confirmedAt: timestamp,
+        idempotencyKey: 'payment-1',
+        deviceId: toDomainId<DeviceId>('device-1'),
+        syncStatus: 'synced',
+      },
+    ],
+    allocations: [
+      {
+        id: toDomainId<PaymentAllocationId>('allocation-1'),
+        paymentId,
+        checkId,
+        amountMinor: 300,
+      },
+    ],
+  };
+}

--- a/src/features/service-board/index.ts
+++ b/src/features/service-board/index.ts
@@ -1,0 +1,3 @@
+export * from './legacyShiftBoardAdapter';
+export * from './ServiceTableCard';
+export * from './shiftBoardModel';

--- a/src/features/service-board/legacyShiftBoardAdapter.ts
+++ b/src/features/service-board/legacyShiftBoardAdapter.ts
@@ -1,0 +1,96 @@
+import { ShiftBoardSnapshot, ShiftBoardTable } from './shiftBoardModel';
+import { Hall, Table, Ticket } from '../../types';
+import { calculateLinesTotal } from '../../utils/financeUtils';
+
+export interface LegacyShiftBoardSource {
+  readonly halls: readonly Hall[];
+  readonly tables: readonly Table[];
+  readonly tickets: Readonly<Record<string, Ticket>>;
+  readonly currentWaiterName: string;
+  readonly currencyCode: string;
+  readonly fallbackHallName: string;
+}
+
+export function buildLegacyShiftBoard(
+  source: LegacyShiftBoardSource,
+  now = new Date(),
+): ShiftBoardSnapshot {
+  const hallById = new Map(source.halls.map((hall) => [hall.id, hall]));
+  const halls = source.halls.map((hall, index) => ({
+    id: hall.id,
+    name: hall.name,
+    sortOrder: index,
+  }));
+  const tables = source.tables
+    .map((table) => {
+      const tickets = table.activeTicketIds
+        .map((ticketId) => source.tickets[ticketId])
+        .filter((ticket): ticket is Ticket => Boolean(ticket));
+      return buildLegacyTable(table, tickets, source, hallById, now);
+    })
+    .sort((left, right) => {
+      const hallOrder =
+        (halls.find((hall) => hall.id === left.hallId)?.sortOrder ?? 0) -
+        (halls.find((hall) => hall.id === right.hallId)?.sortOrder ?? 0);
+      return hallOrder || left.sequenceNumber - right.sequenceNumber;
+    });
+
+  return {
+    halls,
+    tables,
+    openCount: tables.filter((table) => table.state !== 'available').length,
+    attentionCount: 0,
+    totalOpenMinor: tables.reduce((total, table) => total + table.remainingMinor, 0),
+  };
+}
+
+function buildLegacyTable(
+  table: Table,
+  tickets: readonly Ticket[],
+  source: LegacyShiftBoardSource,
+  hallById: ReadonlyMap<string, Hall>,
+  now: Date,
+): ShiftBoardTable {
+  const totalMinor = tickets.reduce(
+    (total, ticket) => total + calculateLinesTotal(ticket.lines),
+    0,
+  );
+  const openedAtMs =
+    tickets.length > 0 ? Math.min(...tickets.map((ticket) => ticket.createdAt)) : undefined;
+  const isOpen = table.isOpen || tickets.length > 0;
+
+  return {
+    id: table.id,
+    hallId: table.hallId,
+    hallName: hallById.get(table.hallId)?.name ?? source.fallbackHallName,
+    label: table.label || `Table ${table.seq}`,
+    sequenceNumber: table.seq,
+    state: isOpen ? 'open' : 'available',
+    syncStatus: 'local',
+    pendingMutationCount: 0,
+    ...(openedAtMs === undefined
+      ? {}
+      : {
+          openedAt: new Date(openedAtMs).toISOString(),
+          durationMinutes: Math.max(0, Math.floor((now.getTime() - openedAtMs) / 60_000)),
+        }),
+    totalMinor,
+    paidMinor: 0,
+    remainingMinor: totalMinor,
+    currencyCode: source.currencyCode,
+    checkCount: tickets.length,
+    waiterNames: isOpen ? [source.currentWaiterName] : [],
+    waiterInitials: isOpen ? [initials(source.currentWaiterName)] : [],
+    isMine: isOpen,
+    needsAttention: false,
+  };
+}
+
+function initials(name: string): string {
+  return name
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toLocaleUpperCase() ?? '')
+    .join('');
+}

--- a/src/features/service-board/shiftBoardModel.ts
+++ b/src/features/service-board/shiftBoardModel.ts
@@ -1,0 +1,392 @@
+import {
+  Check,
+  Hall,
+  OrderItem,
+  OrderItemModifier,
+  Payment,
+  PaymentAllocation,
+  RestaurantTable,
+  TableSession,
+  calculateCheckBalance,
+} from '../../domain';
+import {
+  DomainEntityMap,
+  LocalDatabase,
+  RepositoryName,
+  RepositoryScope,
+} from '../../data/contracts';
+import { createTextMatcher } from '../../utils/searchUtils';
+
+export type ShiftBoardTableState =
+  'available' | 'open' | 'payment_pending' | 'sync_issue' | 'conflict';
+
+export type ShiftBoardEntitySync = 'local' | 'synced' | 'pending' | 'rejected' | 'conflict';
+
+export interface ShiftBoardHall {
+  readonly id: string;
+  readonly name: string;
+  readonly sortOrder: number;
+}
+
+export interface ShiftBoardTable {
+  readonly id: string;
+  readonly hallId: string;
+  readonly hallName: string;
+  readonly label: string;
+  readonly sequenceNumber: number;
+  readonly capacity?: number;
+  readonly state: ShiftBoardTableState;
+  readonly syncStatus: ShiftBoardEntitySync;
+  readonly pendingMutationCount: number;
+  readonly openedAt?: string;
+  readonly durationMinutes?: number;
+  readonly totalMinor: number;
+  readonly paidMinor: number;
+  readonly remainingMinor: number;
+  readonly currencyCode: string;
+  readonly checkCount: number;
+  readonly waiterNames: readonly string[];
+  readonly waiterInitials: readonly string[];
+  readonly isMine: boolean;
+  readonly needsAttention: boolean;
+}
+
+export interface ShiftBoardSnapshot {
+  readonly halls: readonly ShiftBoardHall[];
+  readonly tables: readonly ShiftBoardTable[];
+  readonly openCount: number;
+  readonly attentionCount: number;
+  readonly totalOpenMinor: number;
+}
+
+export interface DomainShiftBoardSource {
+  readonly halls: readonly Hall[];
+  readonly tables: readonly RestaurantTable[];
+  readonly sessions: readonly TableSession[];
+  readonly checks: readonly Check[];
+  readonly items: readonly OrderItem[];
+  readonly modifiers: readonly OrderItemModifier[];
+  readonly payments: readonly Payment[];
+  readonly allocations: readonly PaymentAllocation[];
+  readonly currentUserId?: string;
+  readonly waiterNames?: Readonly<Record<string, string>>;
+  readonly fallbackCurrencyCode: string;
+  readonly fallbackHallName: string;
+  readonly unknownWaiterName: string;
+}
+
+export type ShiftBoardScopeFilter = 'all' | 'mine' | 'alerts';
+
+export interface ShiftBoardFilters {
+  readonly scope: ShiftBoardScopeFilter;
+  readonly hallId?: string;
+  readonly query?: string;
+}
+
+export interface LoadDomainShiftBoardOptions extends Pick<
+  DomainShiftBoardSource,
+  | 'currentUserId'
+  | 'waiterNames'
+  | 'fallbackCurrencyCode'
+  | 'fallbackHallName'
+  | 'unknownWaiterName'
+> {
+  readonly resolveWaiterNames?: (
+    userIds: readonly string[],
+  ) => Promise<Readonly<Record<string, string>>>;
+}
+
+export async function loadDomainShiftBoard(
+  database: LocalDatabase,
+  scope: Required<RepositoryScope>,
+  options: LoadDomainShiftBoardOptions,
+  now = new Date(),
+): Promise<ShiftBoardSnapshot> {
+  const [halls, tables, sessions, checks, items, modifiers, payments, allocations] =
+    await Promise.all([
+      loadAll(database, 'halls', scope),
+      loadAll(database, 'restaurantTables', scope),
+      loadAll(database, 'tableSessions', scope),
+      loadAll(database, 'checks', scope),
+      loadAll(database, 'orderItems', scope),
+      loadAll(database, 'orderItemModifiers', scope),
+      loadAll(database, 'payments', scope),
+      loadAll(database, 'paymentAllocations', scope),
+    ]);
+  const resolvedWaiterNames = options.resolveWaiterNames
+    ? await options
+        .resolveWaiterNames(
+          unique([
+            ...sessions.map((session) => session.openedBy),
+            ...checks.map((check) => check.openedBy),
+            ...items.flatMap((item) => [item.createdBy, item.updatedBy]),
+            ...payments.map((payment) => payment.createdBy),
+          ]),
+        )
+        .catch(() => ({}))
+    : {};
+
+  return buildDomainShiftBoard(
+    {
+      halls,
+      tables,
+      sessions,
+      checks,
+      items,
+      modifiers,
+      payments,
+      allocations,
+      ...options,
+      waiterNames: {
+        ...options.waiterNames,
+        ...resolvedWaiterNames,
+      },
+    },
+    now,
+  );
+}
+
+export function buildDomainShiftBoard(
+  source: DomainShiftBoardSource,
+  now = new Date(),
+): ShiftBoardSnapshot {
+  const halls = source.halls
+    .map((hall) => ({
+      id: hall.id,
+      name: hall.name,
+      sortOrder: hall.sortOrder,
+    }))
+    .sort(compareHall);
+  const hallById = new Map<string, ShiftBoardHall>(halls.map((hall) => [hall.id, hall]));
+  const activeSessions = source.sessions.filter(
+    (session) => session.status === 'open' || session.status === 'payment_pending',
+  );
+  const tables = source.tables
+    .map((table) => buildTable(table, hallById.get(table.hallId), activeSessions, source, now))
+    .sort((left, right) => {
+      const hallOrder =
+        (hallById.get(left.hallId)?.sortOrder ?? 0) - (hallById.get(right.hallId)?.sortOrder ?? 0);
+      return (
+        hallOrder ||
+        left.sequenceNumber - right.sequenceNumber ||
+        left.label.localeCompare(right.label)
+      );
+    });
+
+  return {
+    halls,
+    tables,
+    openCount: tables.filter((table) => table.state !== 'available').length,
+    attentionCount: tables.filter((table) => table.needsAttention).length,
+    totalOpenMinor: tables.reduce((total, table) => total + table.remainingMinor, 0),
+  };
+}
+
+export function filterShiftBoardTables(
+  tables: readonly ShiftBoardTable[],
+  filters: ShiftBoardFilters,
+): readonly ShiftBoardTable[] {
+  const matches = createTextMatcher(filters.query ?? '');
+
+  return tables.filter((table) => {
+    if (filters.hallId && table.hallId !== filters.hallId) return false;
+    if (filters.scope === 'mine' && !table.isMine) return false;
+    if (filters.scope === 'alerts' && !table.needsAttention) return false;
+
+    return matches(
+      [table.label, table.hallName, ...table.waiterNames, ...table.waiterInitials].join(' '),
+    );
+  });
+}
+
+function buildTable(
+  table: RestaurantTable,
+  hall: ShiftBoardHall | undefined,
+  activeSessions: readonly TableSession[],
+  source: DomainShiftBoardSource,
+  now: Date,
+): ShiftBoardTable {
+  const tableSessions = activeSessions
+    .filter((session) => session.tableId === table.id)
+    .sort((left, right) => right.openedAt.localeCompare(left.openedAt));
+  const session = tableSessions[0];
+
+  if (!session) {
+    return {
+      id: table.id,
+      hallId: table.hallId,
+      hallName: hall?.name ?? source.fallbackHallName,
+      label: table.label,
+      sequenceNumber: table.sequenceNumber,
+      ...(table.capacity === undefined ? {} : { capacity: table.capacity }),
+      state: table.syncStatus === 'conflict' ? 'conflict' : 'available',
+      syncStatus: mapSyncStatus(table.syncStatus),
+      pendingMutationCount: table.syncStatus === 'pending' ? 1 : 0,
+      totalMinor: 0,
+      paidMinor: 0,
+      remainingMinor: 0,
+      currencyCode: source.fallbackCurrencyCode,
+      checkCount: 0,
+      waiterNames: [],
+      waiterInitials: [],
+      isMine: false,
+      needsAttention: table.syncStatus === 'conflict',
+    };
+  }
+
+  const checks = source.checks.filter(
+    (check) =>
+      check.tableSessionId === session.id && check.status !== 'voided' && check.status !== 'paid',
+  );
+  const items = source.items.filter((item) => item.tableSessionId === session.id);
+  const modifiers = source.modifiers.filter((modifier) =>
+    items.some((item) => item.id === modifier.orderItemId),
+  );
+  const payments = source.payments.filter((payment) => payment.tableSessionId === session.id);
+  const paymentIds = new Set(payments.map((payment) => payment.id));
+  const allocations = source.allocations.filter((allocation) =>
+    paymentIds.has(allocation.paymentId),
+  );
+  const participantIds = unique([
+    session.openedBy,
+    ...checks.map((check) => check.openedBy),
+    ...items.flatMap((item) => [item.createdBy, item.updatedBy]),
+    ...payments.map((payment) => payment.createdBy),
+  ]);
+  const waiterNames = participantIds.map(
+    (userId, index) => source.waiterNames?.[userId] ?? `${source.unknownWaiterName} ${index + 1}`,
+  );
+  const financial = calculateTableFinancials(checks, items, modifiers, payments, allocations);
+  const relatedSyncStatuses = [
+    table.syncStatus,
+    session.syncStatus,
+    ...checks.map((check) => check.syncStatus),
+    ...items.map((item) => item.syncStatus),
+    ...payments.map((payment) => payment.syncStatus),
+  ];
+  const syncStatus = highestSyncStatus(relatedSyncStatuses);
+  const hasDuplicateActiveSession = tableSessions.length > 1;
+  const financialIssue = financial === null;
+  const state =
+    syncStatus === 'conflict'
+      ? 'conflict'
+      : syncStatus === 'rejected' || hasDuplicateActiveSession || financialIssue
+        ? 'sync_issue'
+        : session.status === 'payment_pending' ||
+            checks.some((check) => check.status === 'partially_paid')
+          ? 'payment_pending'
+          : 'open';
+  const openedAtMs = Date.parse(session.openedAt);
+  const durationMinutes = Number.isFinite(openedAtMs)
+    ? Math.max(0, Math.floor((now.getTime() - openedAtMs) / 60_000))
+    : undefined;
+  const totals = financial ?? {
+    totalMinor: 0,
+    paidMinor: 0,
+    remainingMinor: 0,
+  };
+
+  return {
+    id: table.id,
+    hallId: table.hallId,
+    hallName: hall?.name ?? source.fallbackHallName,
+    label: table.label,
+    sequenceNumber: table.sequenceNumber,
+    ...(table.capacity === undefined ? {} : { capacity: table.capacity }),
+    state,
+    syncStatus,
+    pendingMutationCount: relatedSyncStatuses.filter((status) => status === 'pending').length,
+    openedAt: session.openedAt,
+    ...(durationMinutes === undefined ? {} : { durationMinutes }),
+    ...totals,
+    currencyCode: items[0]?.currencyCode ?? source.fallbackCurrencyCode,
+    checkCount: checks.length,
+    waiterNames,
+    waiterInitials: waiterNames.map(initials),
+    isMine: source.currentUserId !== undefined && participantIds.includes(source.currentUserId),
+    needsAttention: state === 'payment_pending' || state === 'sync_issue' || state === 'conflict',
+  };
+}
+
+function calculateTableFinancials(
+  checks: readonly Check[],
+  items: readonly OrderItem[],
+  modifiers: readonly OrderItemModifier[],
+  payments: readonly Payment[],
+  allocations: readonly PaymentAllocation[],
+): {
+  readonly totalMinor: number;
+  readonly paidMinor: number;
+  readonly remainingMinor: number;
+} | null {
+  try {
+    return checks.reduce(
+      (totals, check) => {
+        const balance = calculateCheckBalance(check, items, modifiers, payments, allocations);
+        return {
+          totalMinor: totals.totalMinor + balance.totalMinor,
+          paidMinor: totals.paidMinor + balance.paidMinor,
+          remainingMinor: totals.remainingMinor + balance.remainingMinor,
+        };
+      },
+      { totalMinor: 0, paidMinor: 0, remainingMinor: 0 },
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function loadAll<Name extends RepositoryName>(
+  database: LocalDatabase,
+  repositoryName: Name,
+  scope: Required<RepositoryScope>,
+): Promise<readonly DomainEntityMap[Name][]> {
+  const repository = database.repository(repositoryName);
+  const items: DomainEntityMap[Name][] = [];
+  let after: string | undefined;
+  let pages = 0;
+
+  do {
+    const page = await repository.list(scope, { after, limit: 250 });
+    items.push(...page.items);
+    after = page.nextCursor;
+    pages += 1;
+    if (pages > 1_000) {
+      throw new Error(`Local ${repositoryName} pagination limit reached`);
+    }
+  } while (after);
+
+  return items;
+}
+
+function highestSyncStatus(
+  statuses: readonly ('synced' | 'pending' | 'conflict' | 'rejected')[],
+): Exclude<ShiftBoardEntitySync, 'local'> {
+  if (statuses.includes('conflict')) return 'conflict';
+  if (statuses.includes('rejected')) return 'rejected';
+  if (statuses.includes('pending')) return 'pending';
+  return 'synced';
+}
+
+function mapSyncStatus(
+  status: 'synced' | 'pending' | 'conflict' | 'rejected',
+): Exclude<ShiftBoardEntitySync, 'local'> {
+  return status;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toLocaleUpperCase() ?? '')
+    .join('');
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
+}
+
+function compareHall(left: ShiftBoardHall, right: ShiftBoardHall): number {
+  return left.sortOrder - right.sortOrder || left.name.localeCompare(right.name);
+}

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -26,6 +26,50 @@ export interface Translation {
   orders: string;
   history: string;
   settings: string;
+  serviceNav: string;
+  receiptsNav: string;
+  profileNav: string;
+  reportsNav: string;
+  moreNav: string;
+  serviceConsoleName: string;
+  managerRole: string;
+  primaryNavigation: string;
+
+  // Service console
+  shiftBoard: string;
+  searchTableOrWaiter: string;
+  mine: string;
+  alerts: string;
+  allHalls: string;
+  availableState: string;
+  openState: string;
+  paymentDueState: string;
+  syncIssueState: string;
+  needsReviewState: string;
+  checksCount: string;
+  deviceOnly: string;
+  syncedState: string;
+  syncingState: string;
+  offlineState: string;
+  queuedChanges: string;
+  syncErrorState: string;
+  noTablesConfigured: string;
+  askManagerForTables: string;
+  configureTables: string;
+  configureTablesDescription: string;
+  openTablesSummary: string;
+  attentionSummary: string;
+  moreTableActions: string;
+  seatsCount: string;
+  waitersCount: string;
+  noMatchingTables: string;
+  clearFilters: string;
+  retrySync: string;
+  boardReadFailed: string;
+  refreshFailed: string;
+  loadingTable: string;
+  unknownWaiter: string;
+  unassignedHall: string;
 
   // Navigation titles
   tablesTitle: string;
@@ -346,6 +390,50 @@ export const translations: Record<string, Translation> = {
     orders: 'Siparişler',
     history: 'Geçmiş',
     settings: 'Ayarlar',
+    serviceNav: 'Servis',
+    receiptsNav: 'Fişler',
+    profileNav: 'Profil',
+    reportsNav: 'Raporlar',
+    moreNav: 'Diğer',
+    serviceConsoleName: 'Servis Konsolu',
+    managerRole: 'Yönetici',
+    primaryNavigation: 'Ana navigasyon',
+
+    // Service console
+    shiftBoard: 'Canlı Servis',
+    searchTableOrWaiter: 'Masa veya garson ara',
+    mine: 'Benim',
+    alerts: 'Uyarılar',
+    allHalls: 'Tüm salonlar',
+    availableState: 'Müsait',
+    openState: 'Açık',
+    paymentDueState: 'Ödeme bekliyor',
+    syncIssueState: 'Senkron sorunu',
+    needsReviewState: 'Kontrol gerekli',
+    checksCount: 'hesap',
+    deviceOnly: 'Yalnız bu cihaz',
+    syncedState: 'Senkron',
+    syncingState: 'Senkronlanıyor',
+    offlineState: 'Çevrimdışı',
+    queuedChanges: 'bekleyen değişiklik',
+    syncErrorState: 'Bağlantı sorunu',
+    noTablesConfigured: 'Henüz masa tanımlanmamış',
+    askManagerForTables: 'Yöneticinizden masa düzenini oluşturmasını isteyin.',
+    configureTables: 'Masaları ayarla',
+    configureTablesDescription: 'Servise başlamak için ilk salonu ve masaları oluşturun.',
+    openTablesSummary: 'açık masa',
+    attentionSummary: 'dikkat gerekiyor',
+    moreTableActions: 'Masa işlemleri',
+    seatsCount: 'kişilik',
+    waitersCount: 'garson',
+    noMatchingTables: 'Bu filtrelere uyan masa yok',
+    clearFilters: 'Filtreleri temizle',
+    retrySync: 'Tekrar dene',
+    boardReadFailed: 'Kayıtlı masalar okunamadı. Yenilemek için aşağı çekin.',
+    refreshFailed: 'Yenileme başarısız oldu. Cihazdaki kayıtlı masalar kullanılabilir.',
+    loadingTable: 'Masa yükleniyor',
+    unknownWaiter: 'Garson',
+    unassignedHall: 'Salonsuz',
 
     // Navigation titles
     tablesTitle: 'Orderia - Masalar',
@@ -670,6 +758,50 @@ export const translations: Record<string, Translation> = {
     orders: 'Поръчки',
     history: 'История',
     settings: 'Настройки',
+    serviceNav: 'Обслужване',
+    receiptsNav: 'Касови бележки',
+    profileNav: 'Профил',
+    reportsNav: 'Отчети',
+    moreNav: 'Още',
+    serviceConsoleName: 'Конзола за обслужване',
+    managerRole: 'Управител',
+    primaryNavigation: 'Основна навигация',
+
+    // Service console
+    shiftBoard: 'Обслужване на живо',
+    searchTableOrWaiter: 'Търси маса или сервитьор',
+    mine: 'Моите',
+    alerts: 'Сигнали',
+    allHalls: 'Всички зали',
+    availableState: 'Свободна',
+    openState: 'Отворена',
+    paymentDueState: 'Очаква плащане',
+    syncIssueState: 'Проблем със синхронизацията',
+    needsReviewState: 'Нужен е преглед',
+    checksCount: 'сметки',
+    deviceOnly: 'Само на това устройство',
+    syncedState: 'Синхронизирано',
+    syncingState: 'Синхронизиране',
+    offlineState: 'Офлайн',
+    queuedChanges: 'чакащи промени',
+    syncErrorState: 'Проблем с връзката',
+    noTablesConfigured: 'Все още няма настроени маси',
+    askManagerForTables: 'Помолете управителя да настрои масите.',
+    configureTables: 'Настрой масите',
+    configureTablesDescription: 'Създайте първата зала и масите, за да започнете обслужване.',
+    openTablesSummary: 'отворени маси',
+    attentionSummary: 'изискват внимание',
+    moreTableActions: 'Действия за масата',
+    seatsCount: 'места',
+    waitersCount: 'сервитьори',
+    noMatchingTables: 'Няма маси за тези филтри',
+    clearFilters: 'Изчисти филтрите',
+    retrySync: 'Опитай отново',
+    boardReadFailed: 'Запазените маси не могат да бъдат прочетени. Издърпайте за нов опит.',
+    refreshFailed: 'Обновяването не успя. Запазените на устройството маси остават достъпни.',
+    loadingTable: 'Зареждане на маса',
+    unknownWaiter: 'Сервитьор',
+    unassignedHall: 'Без зала',
 
     // Navigation titles
     tablesTitle: 'Orderia - Маси',
@@ -995,6 +1127,50 @@ export const translations: Record<string, Translation> = {
     orders: 'Orders',
     history: 'History',
     settings: 'Settings',
+    serviceNav: 'Service',
+    receiptsNav: 'Receipts',
+    profileNav: 'Profile',
+    reportsNav: 'Reports',
+    moreNav: 'More',
+    serviceConsoleName: 'Service Console',
+    managerRole: 'Manager',
+    primaryNavigation: 'Primary navigation',
+
+    // Service console
+    shiftBoard: 'Live service',
+    searchTableOrWaiter: 'Search table or waiter',
+    mine: 'Mine',
+    alerts: 'Alerts',
+    allHalls: 'All halls',
+    availableState: 'Available',
+    openState: 'Open',
+    paymentDueState: 'Payment due',
+    syncIssueState: 'Sync issue',
+    needsReviewState: 'Needs review',
+    checksCount: 'checks',
+    deviceOnly: 'This device only',
+    syncedState: 'Synced',
+    syncingState: 'Syncing',
+    offlineState: 'Offline',
+    queuedChanges: 'queued changes',
+    syncErrorState: 'Connection issue',
+    noTablesConfigured: 'No tables configured yet',
+    askManagerForTables: 'Ask your manager to configure the table layout.',
+    configureTables: 'Configure tables',
+    configureTablesDescription: 'Create the first hall and tables to start service.',
+    openTablesSummary: 'open tables',
+    attentionSummary: 'need attention',
+    moreTableActions: 'Table actions',
+    seatsCount: 'seats',
+    waitersCount: 'waiters',
+    noMatchingTables: 'No tables match these filters',
+    clearFilters: 'Clear filters',
+    retrySync: 'Try again',
+    boardReadFailed: 'Saved tables could not be read. Pull down to try again.',
+    refreshFailed: 'Refresh failed. Saved local tables remain available.',
+    loadingTable: 'Loading table',
+    unknownWaiter: 'Waiter',
+    unassignedHall: 'Unassigned',
 
     // Navigation titles
     tablesTitle: 'Orderia - Tables',

--- a/src/navigation/AdaptiveTabBar.tsx
+++ b/src/navigation/AdaptiveTabBar.tsx
@@ -1,0 +1,202 @@
+import { Ionicons } from '@expo/vector-icons';
+import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
+import React, { useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useAuth } from '../contexts/AuthContext';
+import { useTheme } from '../contexts/ThemeContext';
+import { useAdaptiveLayout } from '../design-system';
+import { useLocalization } from '../i18n';
+import type { TabParamList } from './AppNavigator';
+
+export function AdaptiveTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
+  const { tokens } = useTheme();
+  const { activeMembership, status, workspace } = useAuth();
+  const { t } = useLocalization();
+  const layout = useAdaptiveLayout();
+  const insets = useSafeAreaInsets();
+  const isManager = status === 'unconfigured' || activeMembership?.role === 'manager';
+  const expanded = layout.mode === 'expanded' && isManager;
+  const profileName = workspace?.profile.display_name;
+
+  return (
+    <View
+      accessibilityLabel={t.primaryNavigation}
+      accessibilityRole="tablist"
+      testID={expanded ? 'manager-navigation-rail' : 'bottom-navigation'}
+      style={
+        expanded
+          ? {
+              backgroundColor: tokens.colors.surface,
+              borderRightColor: tokens.colors.border,
+              borderRightWidth: 1,
+              bottom: 0,
+              left: 0,
+              paddingBottom: Math.max(insets.bottom, tokens.space.md),
+              paddingHorizontal: tokens.space.md,
+              paddingTop: Math.max(insets.top, tokens.space.lg),
+              position: 'absolute',
+              top: 0,
+              width: tokens.sizing.expandedRailWidth,
+              zIndex: 20,
+            }
+          : {
+              alignItems: 'stretch',
+              backgroundColor: tokens.colors.surface,
+              borderTopColor: tokens.colors.border,
+              borderTopWidth: 1,
+              flexDirection: 'row',
+              minHeight: tokens.sizing.bottomNavigationHeight + insets.bottom,
+              paddingBottom: insets.bottom,
+            }
+      }
+    >
+      {expanded ? (
+        <View style={{ marginBottom: tokens.space.xl }}>
+          <Text style={[tokens.typography.title, { color: tokens.colors.primary }]}>Orderia</Text>
+          <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+            {t.serviceConsoleName}
+          </Text>
+        </View>
+      ) : null}
+
+      {state.routes.map((route, index) => {
+        const options = descriptors[route.key].options;
+        const selected = state.index === index;
+        const label =
+          typeof options.tabBarLabel === 'string'
+            ? options.tabBarLabel
+            : typeof options.title === 'string'
+              ? options.title
+              : route.name;
+
+        return (
+          <AdaptiveTabItem
+            key={route.key}
+            expanded={expanded}
+            icon={tabIcon(route.name as keyof TabParamList, selected)}
+            label={label}
+            onLongPress={() => {
+              navigation.emit({
+                target: route.key,
+                type: 'tabLongPress',
+              });
+            }}
+            onPress={() => {
+              const event = navigation.emit({
+                canPreventDefault: true,
+                target: route.key,
+                type: 'tabPress',
+              });
+              if (!selected && !event.defaultPrevented) {
+                navigation.navigate(route.name, route.params);
+              }
+            }}
+            selected={selected}
+          />
+        );
+      })}
+
+      {expanded ? (
+        <View
+          style={{
+            borderTopColor: tokens.colors.borderLight,
+            borderTopWidth: 1,
+            marginTop: 'auto',
+            paddingTop: tokens.space.md,
+          }}
+        >
+          <Text numberOfLines={1} style={[tokens.typography.label, { color: tokens.colors.text }]}>
+            {profileName ?? `Orderia ${t.managerRole}`}
+          </Text>
+          <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+            {t.managerRole}
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function AdaptiveTabItem({
+  expanded,
+  icon,
+  label,
+  onLongPress,
+  onPress,
+  selected,
+}: {
+  readonly expanded: boolean;
+  readonly icon: keyof typeof Ionicons.glyphMap;
+  readonly label: string;
+  readonly onLongPress: () => void;
+  readonly onPress: () => void;
+  readonly selected: boolean;
+}) {
+  const { tokens } = useTheme();
+  const [focused, setFocused] = useState(false);
+
+  return (
+    <Pressable
+      accessibilityLabel={label}
+      accessibilityRole="tab"
+      accessibilityState={{ selected }}
+      onBlur={() => setFocused(false)}
+      onFocus={() => setFocused(true)}
+      onLongPress={onLongPress}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        alignItems: 'center',
+        backgroundColor: selected ? tokens.colors.surfaceAlt : 'transparent',
+        borderColor: focused
+          ? tokens.colors.focus
+          : selected
+            ? tokens.colors.primary
+            : 'transparent',
+        borderRadius: tokens.radius.medium,
+        borderWidth: focused ? 3 : expanded && selected ? 1 : 0,
+        flex: expanded ? undefined : 1,
+        flexDirection: expanded ? 'row' : 'column',
+        justifyContent: expanded ? 'flex-start' : 'center',
+        marginBottom: expanded ? tokens.space.xs : 0,
+        minHeight: expanded ? tokens.sizing.primaryTarget : tokens.sizing.minimumTarget,
+        opacity: pressed ? 0.76 : 1,
+        paddingHorizontal: expanded ? tokens.space.md : tokens.space.xs,
+      })}
+    >
+      <Ionicons
+        color={selected ? tokens.colors.primary : tokens.colors.textSubtle}
+        name={icon}
+        size={expanded ? 24 : 22}
+      />
+      <Text
+        numberOfLines={1}
+        style={[
+          tokens.typography.caption,
+          {
+            color: selected ? tokens.colors.primary : tokens.colors.textSubtle,
+            marginLeft: expanded ? tokens.space.sm : 0,
+            marginTop: expanded ? 0 : 2,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function tabIcon(route: keyof TabParamList, focused: boolean): keyof typeof Ionicons.glyphMap {
+  const icons: Record<
+    keyof TabParamList,
+    readonly [keyof typeof Ionicons.glyphMap, keyof typeof Ionicons.glyphMap]
+  > = {
+    Service: ['restaurant-outline', 'restaurant'],
+    Receipts: ['receipt-outline', 'receipt'],
+    Profile: ['person-outline', 'person'],
+    Menu: ['book-outline', 'book'],
+    Reports: ['bar-chart-outline', 'bar-chart'],
+    More: ['grid-outline', 'grid'],
+  };
+  return icons[route][focused ? 1 : 0];
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,39 +1,30 @@
-import {
-  NavigationContainer,
-  NavigationProp,
-  useNavigation,
-  CompositeNavigationProp,
-} from '@react-navigation/native';
-import { createBottomTabNavigator, BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import {
   createNativeStackNavigator,
-  NativeStackNavigationProp,
+  NativeStackNavigationOptions,
 } from '@react-navigation/native-stack';
-import { Ionicons } from '@expo/vector-icons';
-import { Text } from 'react-native';
+import React from 'react';
+import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { useAdaptiveLayout } from '../design-system';
 import { useLocalization } from '../i18n';
-// Screen imports (we'll create these next)
 import {
-  TablesScreen,
-  MenuScreen,
-  HistoryScreen,
-  SettingsScreen,
-  TableDetailScreen,
-  AddMenuItemScreen,
-  AddHallScreen,
-  EditTableScreen,
   AddCategoryScreen,
+  AddHallScreen,
+  AddMenuItemScreen,
   AnalyticsScreen,
-  QRMenuScreen,
   DeviceManagementScreen,
+  EditTableScreen,
+  HistoryScreen,
+  MenuScreen,
+  QRMenuScreen,
+  SettingsScreen,
+  ShiftBoardScreen,
+  TableDetailScreen,
 } from '../screens';
-import { PrimaryButton } from '../components';
+import { AdaptiveTabBar } from './AdaptiveTabBar';
 
-type MainTabsNavigationProp = CompositeNavigationProp<
-  BottomTabNavigationProp<TabParamList>,
-  NativeStackNavigationProp<RootStackParamList>
->;
 export type RootStackParamList = {
   MainTabs: undefined;
   TableDetail: { tableId: string };
@@ -47,208 +38,189 @@ export type RootStackParamList = {
 };
 
 export type TabParamList = {
-  Tables: undefined;
+  Service: undefined;
+  Receipts: undefined;
+  Profile: undefined;
   Menu: undefined;
-  Analytics: undefined;
-  QRMenu: undefined;
-  Settings: undefined;
+  Reports: undefined;
+  More: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<TabParamList>();
 
 function MainTabs() {
-  const navigation = useNavigation<MainTabsNavigationProp>();
-  const { colors } = useTheme();
+  const { activeMembership, status } = useAuth();
+  const { tokens } = useTheme();
   const { t } = useLocalization();
+  const isManager = status === 'unconfigured' || activeMembership?.role === 'manager';
+  const layout = useAdaptiveLayout();
+  const expandedManager = layout.mode === 'expanded' && isManager;
 
   return (
     <Tab.Navigator
-      screenOptions={({ route }) => ({
-        tabBarIcon: ({ focused, color, size }) => {
-          let iconName: keyof typeof Ionicons.glyphMap;
-
-          switch (route.name) {
-            case 'Tables':
-              iconName = focused ? 'restaurant' : 'restaurant-outline';
-              break;
-            case 'Menu':
-              iconName = focused ? 'menu' : 'menu-outline';
-              break;
-            case 'Analytics':
-              iconName = focused ? 'analytics' : 'analytics-outline';
-              break;
-            case 'QRMenu':
-              iconName = focused ? 'qr-code' : 'qr-code-outline';
-              break;
-            case 'Settings':
-              iconName = focused ? 'settings' : 'settings-outline';
-              break;
-            default:
-              iconName = 'help-outline';
-              break;
-          }
-
-          return <Ionicons name={iconName} size={size} color={color} />;
-        },
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.textSubtle,
-        tabBarStyle: {
-          backgroundColor: colors.surface,
-          borderTopColor: colors.border,
-          borderTopWidth: 1,
-        },
+      sceneContainerStyle={
+        expandedManager ? { marginLeft: tokens.sizing.expandedRailWidth } : undefined
+      }
+      tabBar={(props) => <AdaptiveTabBar {...props} />}
+      screenOptions={{
         headerStyle: {
-          backgroundColor: colors.surface,
+          backgroundColor: tokens.colors.surface,
         },
-        headerTintColor: colors.text,
-        headerTitleStyle: {
-          fontWeight: '600',
+        headerTintColor: tokens.colors.text,
+        headerTitleStyle: tokens.typography.subtitle,
+        tabBarActiveTintColor: tokens.colors.primary,
+        tabBarHideOnKeyboard: true,
+        tabBarInactiveTintColor: tokens.colors.textSubtle,
+        tabBarItemStyle: {
+          minHeight: tokens.sizing.minimumTarget,
         },
-      })}
+        tabBarLabelStyle: tokens.typography.caption,
+        tabBarStyle: {
+          backgroundColor: tokens.colors.surface,
+          borderTopColor: tokens.colors.border,
+          borderTopWidth: 1,
+          minHeight: tokens.sizing.bottomNavigationHeight,
+        },
+      }}
     >
       <Tab.Screen
-        name="Tables"
-        component={TablesScreen}
+        component={ShiftBoardScreen}
+        name="Service"
         options={{
-          title: t.tables,
-          headerTitle: '',
-          headerLeft: () => (
-            <Text
-              style={{
-                marginLeft: 12,
-                fontSize: 20,
-                fontWeight: 'bold',
-                color: colors.primary,
-              }}
-            >
-              Orderia
-            </Text>
-          ),
-          headerRight: () => (
-            <Ionicons
-              name="add-circle-outline"
-              size={28}
-              color={colors.primary}
-              style={{ marginRight: 16 }}
-              onPress={() => navigation.navigate('AddHall', {})}
-            />
-          ),
+          headerShown: false,
+          title: t.serviceNav,
         }}
       />
-      <Tab.Screen
-        name="Menu"
-        component={MenuScreen}
-        options={{
-          title: t.menu,
-          headerTitle: t.menuManagement,
-        }}
-      />
-      <Tab.Screen
-        name="Analytics"
-        component={AnalyticsScreen}
-        options={{
-          title: t.analytics || 'Analytics',
-          headerTitle: t.salesAnalytics || 'Sales Analytics',
-        }}
-      />
-      {/* <Tab.Screen 
-        name="QRMenu" 
-        component={QRMenuScreen}
-        options={{
-          title: t.qrMenu || 'QR Menu',
-          headerTitle: t.qrMenuManagement || 'QR Menu Management',
-        }}
-      /> */}
-      <Tab.Screen
-        name="Settings"
-        component={SettingsScreen}
-        options={{
-          title: t.settings,
-          headerTitle: t.settings,
-        }}
-      />
+      {isManager ? (
+        <>
+          <Tab.Screen
+            component={MenuScreen}
+            name="Menu"
+            options={{
+              headerTitle: t.menuManagement,
+              title: t.menu,
+            }}
+          />
+          <Tab.Screen
+            component={AnalyticsScreen}
+            name="Reports"
+            options={{
+              headerTitle: t.salesAnalytics,
+              title: t.reportsNav,
+            }}
+          />
+          <Tab.Screen
+            component={SettingsScreen}
+            name="More"
+            options={{
+              headerTitle: t.settings,
+              title: t.moreNav,
+            }}
+          />
+        </>
+      ) : (
+        <>
+          <Tab.Screen
+            component={HistoryScreen}
+            name="Receipts"
+            options={{
+              headerTitle: t.salesHistory,
+              title: t.receiptsNav,
+            }}
+          />
+          <Tab.Screen
+            component={SettingsScreen}
+            name="Profile"
+            options={{
+              headerTitle: t.profileNav,
+              title: t.profileNav,
+            }}
+          />
+        </>
+      )}
     </Tab.Navigator>
   );
 }
 
 export default function AppNavigator() {
-  const { colors } = useTheme();
+  const { tokens } = useTheme();
   const { t } = useLocalization();
+  const stackOptions: NativeStackNavigationOptions = {
+    headerStyle: {
+      backgroundColor: tokens.colors.surface,
+    },
+    headerTintColor: tokens.colors.text,
+    headerTitleStyle: tokens.typography.subtitle,
+  };
 
   return (
-    <NavigationContainer>
-      <Stack.Navigator
-        screenOptions={{
-          headerStyle: {
-            backgroundColor: colors.surface,
-          },
-          headerTintColor: colors.text,
-          headerTitleStyle: {
-            fontWeight: '600',
-          },
-        }}
-      >
-        <Stack.Screen name="MainTabs" component={MainTabs} options={{ headerShown: false }} />
+    <NavigationContainer
+      documentTitle={{
+        formatter: (options) => (options?.title ? `${options.title} · Orderia` : 'Orderia'),
+      }}
+    >
+      <Stack.Navigator screenOptions={stackOptions}>
+        <Stack.Screen component={MainTabs} name="MainTabs" options={{ headerShown: false }} />
         <Stack.Screen
-          name="TableDetail"
           component={TableDetailScreen}
+          name="TableDetail"
           options={{
+            presentation: 'modal',
             title: t.tableDetail,
-            presentation: 'modal',
           }}
         />
         <Stack.Screen
-          name="AddMenuItem"
           component={AddMenuItemScreen}
+          name="AddMenuItem"
           options={{
+            presentation: 'modal',
             title: t.addMenuItem,
-            presentation: 'modal',
           }}
         />
         <Stack.Screen
-          name="AddHall"
           component={AddHallScreen}
+          name="AddHall"
           options={{
+            presentation: 'modal',
             title: t.addHall,
-            presentation: 'modal',
           }}
         />
         <Stack.Screen
-          name="EditTable"
           component={EditTableScreen}
+          name="EditTable"
           options={{
+            presentation: 'modal',
             title: t.editTable,
-            presentation: 'modal',
           }}
         />
         <Stack.Screen
-          name="AddCategory"
           component={AddCategoryScreen}
+          name="AddCategory"
           options={{
+            presentation: 'modal',
             title: t.addCategory,
-            presentation: 'modal',
           }}
         />
         <Stack.Screen
-          name="Analytics"
           component={AnalyticsScreen}
+          name="Analytics"
           options={{
-            title: t.analytics || 'Analytics',
             presentation: 'modal',
+            title: t.analytics,
           }}
         />
         <Stack.Screen
-          name="QRMenu"
           component={QRMenuScreen}
+          name="QRMenu"
           options={{
-            title: t.qrMenu || 'QR Menu',
             presentation: 'modal',
+            title: t.qrMenu,
           }}
         />
         <Stack.Screen
-          name="Devices"
           component={DeviceManagementScreen}
+          name="Devices"
           options={{
             title: 'Authorized devices',
           }}

--- a/src/screens/ShiftBoardScreen.tsx
+++ b/src/screens/ShiftBoardScreen.tsx
@@ -1,0 +1,655 @@
+import { Ionicons } from '@expo/vector-icons';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../contexts/AuthContext';
+import { useTheme } from '../contexts/ThemeContext';
+import { useOrderiaData } from '../data/runtime';
+import {
+  ServiceButton,
+  ServiceEmptyState,
+  ServiceSkeleton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+  useAdaptiveLayout,
+} from '../design-system';
+import {
+  ServiceTableCard,
+  ShiftBoardScopeFilter,
+  ShiftBoardSnapshot,
+  buildLegacyShiftBoard,
+  filterShiftBoardTables,
+  loadDomainShiftBoard,
+} from '../features/service-board';
+import { useLocalization } from '../i18n';
+import { RootStackParamList } from '../navigation/AppNavigator';
+import { useLayoutStore, useOrderStore } from '../stores';
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+
+const emptySnapshot: ShiftBoardSnapshot = {
+  halls: [],
+  tables: [],
+  openCount: 0,
+  attentionCount: 0,
+  totalOpenMinor: 0,
+};
+
+export default function ShiftBoardScreen() {
+  const navigation = useNavigation<NavigationProp>();
+  const { tokens } = useTheme();
+  const { currency, t } = useLocalization();
+  const auth = useAuth();
+  const {
+    database,
+    errorMessage: runtimeError,
+    mode,
+    readiness,
+    refresh,
+    resolveProfileNames,
+    revision,
+    scope,
+    sync,
+  } = useOrderiaData();
+  const halls = useLayoutStore((state) => state.halls);
+  const legacyTables = useLayoutStore((state) => state.tables);
+  const openTickets = useOrderStore((state) => state.openTickets);
+  const layout = useAdaptiveLayout();
+  const [cloudSnapshot, setCloudSnapshot] = useState<ShiftBoardSnapshot | null>(null);
+  const [boardError, setBoardError] = useState<string>();
+  const [refreshing, setRefreshing] = useState(false);
+  const [query, setQuery] = useState('');
+  const [scopeFilter, setScopeFilter] = useState<ShiftBoardScopeFilter>('all');
+  const [hallId, setHallId] = useState<string>();
+  const [clock, setClock] = useState(() => Date.now());
+
+  const fallbackCurrencyCode = auth.activeBranch?.currency_code ?? currency;
+  const currentWaiterName = auth.workspace?.profile.display_name ?? t.deviceOnly;
+  const waiterNames = useMemo(
+    () =>
+      auth.workspace?.profile
+        ? {
+            [auth.workspace.profile.id]: auth.workspace.profile.display_name,
+          }
+        : {},
+    [auth.workspace],
+  );
+  const cloudMode = mode === 'cloud' && scope !== null;
+
+  const legacySnapshot = useMemo(
+    () =>
+      buildLegacyShiftBoard(
+        {
+          halls,
+          tables: legacyTables,
+          tickets: openTickets,
+          currentWaiterName,
+          currencyCode: fallbackCurrencyCode,
+          fallbackHallName: t.unassignedHall,
+        },
+        new Date(clock),
+      ),
+    [
+      clock,
+      currentWaiterName,
+      fallbackCurrencyCode,
+      halls,
+      legacyTables,
+      openTickets,
+      t.unassignedHall,
+    ],
+  );
+
+  const loadCloudBoard = useCallback(async () => {
+    if (!database || !scope) return null;
+    return loadDomainShiftBoard(
+      database,
+      scope,
+      {
+        currentUserId: auth.session?.user.id,
+        waiterNames,
+        fallbackCurrencyCode,
+        fallbackHallName: t.unassignedHall,
+        unknownWaiterName: t.unknownWaiter,
+        resolveWaiterNames: resolveProfileNames,
+      },
+      new Date(),
+    );
+  }, [
+    auth.session?.user.id,
+    database,
+    fallbackCurrencyCode,
+    resolveProfileNames,
+    scope,
+    t.unassignedHall,
+    t.unknownWaiter,
+    waiterNames,
+  ]);
+
+  useEffect(() => {
+    if (!cloudMode || !database || !scope) {
+      setCloudSnapshot(null);
+      setBoardError(undefined);
+      return;
+    }
+
+    let active = true;
+    void loadCloudBoard()
+      .then((snapshot) => {
+        if (!active || !snapshot) return;
+        setCloudSnapshot(snapshot);
+        setBoardError(undefined);
+      })
+      .catch(() => {
+        if (!active) return;
+        setBoardError(t.boardReadFailed);
+      });
+    return () => {
+      active = false;
+    };
+  }, [cloudMode, database, loadCloudBoard, revision, scope, t.boardReadFailed]);
+
+  useEffect(() => {
+    const timer = setInterval(() => setClock(Date.now()), 60_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await refresh();
+      const snapshot = cloudMode ? await loadCloudBoard() : null;
+      if (snapshot) setCloudSnapshot(snapshot);
+      setClock(Date.now());
+      setBoardError(undefined);
+    } catch {
+      setBoardError(t.refreshFailed);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [cloudMode, loadCloudBoard, refresh, t.refreshFailed]);
+
+  const snapshot = cloudMode ? (cloudSnapshot ?? emptySnapshot) : legacySnapshot;
+  const tablesWithCurrentAge = useMemo(
+    () =>
+      snapshot.tables.map((table) =>
+        table.openedAt
+          ? {
+              ...table,
+              durationMinutes: Math.max(
+                0,
+                Math.floor((clock - Date.parse(table.openedAt)) / 60_000),
+              ),
+            }
+          : table,
+      ),
+    [clock, snapshot.tables],
+  );
+  const filteredTables = useMemo(
+    () =>
+      filterShiftBoardTables(tablesWithCurrentAge, {
+        scope: scopeFilter,
+        hallId,
+        query,
+      }),
+    [hallId, query, scopeFilter, tablesWithCurrentAge],
+  );
+  const isManager = auth.status === 'unconfigured' || auth.activeMembership?.role === 'manager';
+  const isInitialLoading =
+    cloudMode && cloudSnapshot === null && readiness !== 'error' && !boardError;
+  const errorMessage = boardError ?? (runtimeError ? t.syncErrorState : undefined);
+
+  const resetFilters = () => {
+    setQuery('');
+    setHallId(undefined);
+    setScopeFilter('all');
+  };
+
+  return (
+    <SafeAreaView
+      edges={['top', 'left', 'right']}
+      style={{ backgroundColor: tokens.colors.bg, flex: 1 }}
+    >
+      <FlatList
+        key={`shift-board-${layout.tableColumns}`}
+        accessibilityLabel={t.shiftBoard}
+        columnWrapperStyle={layout.tableColumns > 1 ? { alignItems: 'stretch' } : undefined}
+        contentContainerStyle={{
+          paddingBottom: tokens.space.xxl,
+          paddingHorizontal: layout.horizontalPadding - 6,
+        }}
+        data={filteredTables}
+        keyExtractor={(table) => table.id}
+        ListHeaderComponent={
+          <View style={{ paddingHorizontal: 6 }}>
+            <BoardHeader
+              branchName={auth.activeBranch?.name ?? 'Orderia'}
+              clock={clock}
+              mode={mode}
+              openCount={snapshot.openCount}
+              attentionCount={snapshot.attentionCount}
+              sync={sync}
+            />
+
+            {errorMessage ? (
+              <ServiceSurface
+                accessibilityRole="alert"
+                variant="outlined"
+                style={{
+                  borderColor: tokens.colors.error,
+                  marginBottom: tokens.space.md,
+                }}
+              >
+                <Text style={[tokens.typography.body, { color: tokens.colors.text }]}>
+                  {errorMessage}
+                </Text>
+                <ServiceButton
+                  label={t.retrySync}
+                  onPress={() => {
+                    void handleRefresh();
+                  }}
+                  style={{ marginTop: tokens.space.sm }}
+                  variant="outline"
+                />
+              </ServiceSurface>
+            ) : null}
+
+            <ServiceTextField
+              label={t.searchTableOrWaiter}
+              onChangeText={setQuery}
+              placeholder={t.searchTableOrWaiter}
+              returnKeyType="search"
+              value={query}
+            />
+
+            <View
+              accessibilityRole="tablist"
+              style={{
+                flexDirection: 'row',
+                marginTop: tokens.space.sm,
+              }}
+            >
+              <BoardFilter
+                label={t.all}
+                onPress={() => setScopeFilter('all')}
+                selected={scopeFilter === 'all'}
+              />
+              <BoardFilter
+                label={t.mine}
+                onPress={() => setScopeFilter('mine')}
+                selected={scopeFilter === 'mine'}
+              />
+              <BoardFilter
+                badge={snapshot.attentionCount}
+                label={t.alerts}
+                onPress={() => setScopeFilter('alerts')}
+                selected={scopeFilter === 'alerts'}
+              />
+            </View>
+
+            <ScrollView
+              horizontal
+              accessibilityLabel={t.allHalls}
+              contentContainerStyle={{ paddingVertical: tokens.space.sm }}
+              showsHorizontalScrollIndicator={false}
+            >
+              <HallFilter
+                label={t.allHalls}
+                onPress={() => setHallId(undefined)}
+                selected={hallId === undefined}
+              />
+              {snapshot.halls.map((hall) => (
+                <HallFilter
+                  key={hall.id}
+                  label={hall.name}
+                  onPress={() => setHallId(hall.id)}
+                  selected={hallId === hall.id}
+                />
+              ))}
+            </ScrollView>
+          </View>
+        }
+        ListEmptyComponent={
+          <View style={{ paddingHorizontal: 6 }}>
+            {isInitialLoading ? (
+              <BoardSkeletons columns={layout.tableColumns} label={t.loadingTable} />
+            ) : snapshot.tables.length === 0 ? (
+              <ServiceEmptyState
+                action={
+                  isManager
+                    ? {
+                        label: t.configureTables,
+                        onPress: () => navigation.navigate('AddHall', {}),
+                      }
+                    : undefined
+                }
+                body={isManager ? t.configureTablesDescription : t.askManagerForTables}
+                icon="grid-outline"
+                title={t.noTablesConfigured}
+              />
+            ) : (
+              <ServiceEmptyState
+                action={{
+                  label: t.clearFilters,
+                  onPress: resetFilters,
+                }}
+                body={t.searchTableOrWaiter}
+                icon="search-outline"
+                title={t.noMatchingTables}
+              />
+            )}
+          </View>
+        }
+        numColumns={layout.tableColumns}
+        refreshControl={
+          <RefreshControl
+            colors={[tokens.colors.primary]}
+            onRefresh={() => {
+              void handleRefresh();
+            }}
+            refreshing={refreshing}
+            tintColor={tokens.colors.primary}
+          />
+        }
+        renderItem={({ item }) => (
+          <View
+            style={{
+              flexBasis: `${100 / layout.tableColumns}%`,
+              flexGrow: 0,
+              flexShrink: 0,
+              padding: 6,
+            }}
+          >
+            <ServiceTableCard
+              onMore={() =>
+                navigation.navigate('TableDetail', {
+                  tableId: item.id,
+                })
+              }
+              onPress={() =>
+                navigation.navigate('TableDetail', {
+                  tableId: item.id,
+                })
+              }
+              table={item}
+            />
+          </View>
+        )}
+      />
+    </SafeAreaView>
+  );
+}
+
+function BoardHeader({
+  branchName,
+  clock,
+  mode,
+  openCount,
+  attentionCount,
+  sync,
+}: {
+  readonly branchName: string;
+  readonly clock: number;
+  readonly mode: ReturnType<typeof useOrderiaData>['mode'];
+  readonly openCount: number;
+  readonly attentionCount: number;
+  readonly sync: ReturnType<typeof useOrderiaData>['sync'];
+}) {
+  const { tokens } = useTheme();
+  const { language, t } = useLocalization();
+  const syncPresentation = globalSyncPresentation(mode, sync, t);
+  const locale = language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-GB';
+
+  return (
+    <View style={{ paddingBottom: tokens.space.md, paddingTop: tokens.space.sm }}>
+      <View
+        style={{
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <View style={{ flex: 1, marginRight: tokens.space.sm }}>
+          <Text
+            numberOfLines={1}
+            style={[tokens.typography.label, { color: tokens.colors.textSubtle }]}
+          >
+            {branchName}
+          </Text>
+          <Text
+            accessibilityRole="header"
+            style={[tokens.typography.title, { color: tokens.colors.text }]}
+          >
+            {t.shiftBoard}
+          </Text>
+        </View>
+        <View style={{ alignItems: 'flex-end' }}>
+          <Text
+            style={[
+              tokens.typography.label,
+              {
+                color: tokens.colors.textSubtle,
+                marginBottom: tokens.space.xxs,
+              },
+            ]}
+          >
+            {new Date(clock).toLocaleTimeString(locale, {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </Text>
+          <ServiceStatusPill
+            icon={syncPresentation.icon}
+            label={syncPresentation.label}
+            tone={syncPresentation.tone}
+          />
+        </View>
+      </View>
+      <Text
+        style={[
+          tokens.typography.caption,
+          { color: tokens.colors.textSubtle, marginTop: tokens.space.xs },
+        ]}
+      >
+        {openCount} {t.openTablesSummary}
+        {attentionCount > 0 ? ` · ${attentionCount} ${t.attentionSummary}` : ''}
+      </Text>
+    </View>
+  );
+}
+
+function BoardFilter({
+  badge,
+  label,
+  onPress,
+  selected,
+}: {
+  readonly badge?: number;
+  readonly label: string;
+  readonly onPress: () => void;
+  readonly selected: boolean;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        alignItems: 'center',
+        backgroundColor: selected ? tokens.colors.primary : tokens.colors.surface,
+        borderColor: selected ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.medium,
+        borderWidth: 1,
+        flex: 1,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        marginRight: tokens.space.xs,
+        minHeight: tokens.sizing.minimumTarget,
+        opacity: pressed ? 0.8 : 1,
+        paddingHorizontal: tokens.space.sm,
+      })}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          {
+            color: selected ? tokens.colors.primaryContrast : tokens.colors.text,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+      {badge ? (
+        <View
+          style={{
+            alignItems: 'center',
+            backgroundColor: selected
+              ? tokens.colors.primaryContrast
+              : tokens.colors.state.pending.bg,
+            borderRadius: tokens.radius.full,
+            justifyContent: 'center',
+            marginLeft: tokens.space.xs,
+            minHeight: 22,
+            minWidth: 22,
+            paddingHorizontal: tokens.space.xxs,
+          }}
+        >
+          <Text
+            style={[
+              tokens.typography.caption,
+              {
+                color: selected ? tokens.colors.primary : tokens.colors.state.pending.text,
+              },
+            ]}
+          >
+            {badge}
+          </Text>
+        </View>
+      ) : null}
+    </Pressable>
+  );
+}
+
+function HallFilter({
+  label,
+  onPress,
+  selected,
+}: {
+  readonly label: string;
+  readonly onPress: () => void;
+  readonly selected: boolean;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        alignItems: 'center',
+        backgroundColor: selected ? tokens.colors.surfaceAlt : tokens.colors.surface,
+        borderColor: selected ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.full,
+        borderWidth: selected ? 2 : 1,
+        justifyContent: 'center',
+        marginRight: tokens.space.xs,
+        minHeight: tokens.sizing.minimumTarget,
+        opacity: pressed ? 0.8 : 1,
+        paddingHorizontal: tokens.space.md,
+      })}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          {
+            color: selected ? tokens.colors.primary : tokens.colors.textSubtle,
+          },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function BoardSkeletons({ columns, label }: { readonly columns: number; readonly label: string }) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+      {Array.from({ length: Math.max(4, columns * 2) }, (_, index) => (
+        <View
+          key={index}
+          style={{
+            padding: 6,
+            width: `${100 / columns}%`,
+          }}
+        >
+          <ServiceSkeleton
+            height={tokens.sizing.tableCardMinimumHeight}
+            label={`${label} ${index + 1}`}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function globalSyncPresentation(
+  mode: ReturnType<typeof useOrderiaData>['mode'],
+  sync: ReturnType<typeof useOrderiaData>['sync'],
+  t: ReturnType<typeof useLocalization>['t'],
+): {
+  readonly label: string;
+  readonly tone: 'neutral' | 'info' | 'success' | 'warning' | 'error';
+  readonly icon: keyof typeof Ionicons.glyphMap;
+} {
+  if (mode === 'local_only') {
+    return {
+      label: t.deviceOnly,
+      tone: 'neutral',
+      icon: 'phone-portrait-outline',
+    };
+  }
+  switch (sync.state) {
+    case 'synced':
+      return {
+        label: t.syncedState,
+        tone: 'success',
+        icon: 'cloud-done-outline',
+      };
+    case 'syncing':
+      return {
+        label: t.syncingState,
+        tone: 'info',
+        icon: 'sync-outline',
+      };
+    case 'offline':
+      return {
+        label: sync.pendingCount > 0 ? `${t.offlineState} · ${sync.pendingCount}` : t.offlineState,
+        tone: 'warning',
+        icon: 'cloud-offline-outline',
+      };
+    case 'pending':
+      return {
+        label: `${sync.pendingCount} ${t.queuedChanges}`,
+        tone: 'warning',
+        icon: 'cloud-upload-outline',
+      };
+    case 'conflict':
+      return {
+        label: `${sync.conflictCount} ${t.needsReviewState}`,
+        tone: 'error',
+        icon: 'warning-outline',
+      };
+    default:
+      return {
+        label: t.syncErrorState,
+        tone: 'error',
+        icon: 'alert-circle-outline',
+      };
+  }
+}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -10,3 +10,4 @@ export { default as AddCategoryScreen } from './AddCategoryScreen';
 export { default as AnalyticsScreen } from './AnalyticsScreen';
 export { default as QRMenuScreen } from './QRMenuScreen';
 export { default as DeviceManagementScreen } from './DeviceManagementScreen';
+export { default as ShiftBoardScreen } from './ShiftBoardScreen';


### PR DESCRIPTION
## Summary
- replace the legacy tables landing page with the responsive Orderia Service Console shift board
- show explicit table state, age, remaining balance, check count, waiter attribution, queued work and conflicts without relying on color alone
- add mine/all/alerts, hall and Turkish-safe table/waiter filtering with 48 px minimum targets
- introduce role-adaptive navigation: waiter Service/Receipts/Profile, manager Service/Menu/Reports/More, plus a 240 px expanded manager rail
- wire the app to platform-specific IndexedDB/SQLite, real outbox push, durable cursor pull and private Realtime hints; local-only mode is labelled honestly
- resolve authorized colleague display names through existing profile RLS while retaining local data if that lookup fails
- retain a migration-compatible legacy local-only adapter until production data migration lands

## Validation
- `npm run verify:full`
- `npx expo install --check`
- 24 Jest suites / 148 tests / 1 component render snapshot
- Expo production web export
- Playwright Chromium validates 390 px compact controls and 1280 px / 240 px expanded manager rail
- lint remains within the pinned legacy ceiling and falls from 77 to 74 warnings; new code adds none
- manual visual inspection performed at 390×844 and 1280×900

## Stack
Base: #46 (`fix/31-turkish-search`)
Depends on: #45, #44 and #43

Real-waiter validation remains an explicit gate in #44. This PR implements the provisional service-board design without claiming that human validation is complete.

Closes #19