### PR TITLE
feat(collaboration): support concurrent waiters on one table

### DIFF
--- a/src/data/contracts/outbox.ts
+++ b/src/data/contracts/outbox.ts
@@ -4,7 +4,7 @@ import { RepositoryName, RepositoryScope } from './repository';
 
 export type MutationOperation = 'create' | 'update' | 'delete' | 'command';
 export type OutboxStatus =
-  'pending' | 'processing' | 'retry_wait' | 'applied' | 'conflict' | 'rejected';
+  'pending' | 'processing' | 'retry_wait' | 'applied' | 'conflict' | 'rejected' | 'resolved';
 
 export interface OutboxMutation {
   readonly id: MutationId;
@@ -61,8 +61,9 @@ const allowedOutboxTransitions: Readonly<Record<OutboxStatus, readonly OutboxSta
   processing: ['applied', 'retry_wait', 'conflict', 'rejected'],
   retry_wait: ['processing'],
   applied: [],
-  conflict: [],
-  rejected: [],
+  conflict: ['resolved'],
+  rejected: ['resolved'],
+  resolved: [],
 };
 
 export function assertOutboxTransition(current: OutboxStatus, next: OutboxStatus): void {

--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -11,7 +11,7 @@ import React, {
 import { AppState, Platform } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
 import { BranchId, OrganizationId, toDomainId } from '../../domain';
-import { Database, getSupabaseClient } from '../../services/supabase';
+import { ActiveSessionParticipantRow, Database, getSupabaseClient } from '../../services/supabase';
 import { LocalDatabase, RepositoryScope } from '../contracts';
 import {
   OutboxPushWorker,
@@ -39,6 +39,9 @@ export interface OrderiaDataContextValue {
   readonly errorMessage?: string;
   refresh(): Promise<void>;
   resolveProfileNames(userIds: readonly string[]): Promise<Readonly<Record<string, string>>>;
+  resolveActiveParticipants(
+    tableSessionId: string,
+  ): Promise<readonly ActiveSessionParticipantRow[]>;
 }
 
 interface OrderiaDataProviderProps {
@@ -204,6 +207,22 @@ export function OrderiaDataProvider({
     [client],
   );
 
+  const resolveActiveParticipants = useCallback(
+    async (tableSessionId: string): Promise<readonly ActiveSessionParticipantRow[]> => {
+      if (!client || !scope) return [];
+      const activeSince = new Date(Date.now() - 15 * 60_000).toISOString();
+      const { data, error } = await client.rpc('list_active_session_participants', {
+        requested_organization_id: scope.organizationId,
+        requested_branch_id: scope.branchId,
+        requested_table_session_id: tableSessionId,
+        active_since: activeSince,
+      });
+      if (error) throw error;
+      return data;
+    },
+    [client, scope],
+  );
+
   useEffect(() => {
     if (!database || !scope || !client) return;
 
@@ -293,6 +312,7 @@ export function OrderiaDataProvider({
       errorMessage,
       refresh,
       resolveProfileNames,
+      resolveActiveParticipants,
     }),
     [
       client,
@@ -301,6 +321,7 @@ export function OrderiaDataProvider({
       lastSuccessfulSyncAt,
       readiness,
       refresh,
+      resolveActiveParticipants,
       resolveProfileNames,
       revision,
       scope,

--- a/src/data/sync/__tests__/mutationPushGateway.test.ts
+++ b/src/data/sync/__tests__/mutationPushGateway.test.ts
@@ -1,0 +1,102 @@
+import { BranchId, DeviceId, MutationId, OrganizationId, toDomainId } from '../../../domain';
+import { OutboxMutation } from '../../contracts';
+import { SupabaseMutationPushGateway } from '../mutationPushGateway';
+
+const organizationId = toDomainId<OrganizationId>('organization-1');
+const branchId = toDomainId<BranchId>('branch-1');
+const deviceId = toDomainId<DeviceId>('device-1');
+const mutationId = toDomainId<MutationId>('mutation-1');
+const createdAt = '2026-07-26T18:00:00.000Z';
+
+describe('SupabaseMutationPushGateway collaboration routes', () => {
+  it('routes append commands through the concurrent order RPC', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        status: 'applied',
+        repository: 'orderBatches',
+        entityId: 'batch-1',
+        serverVersion: 1,
+        committedAt: createdAt,
+      },
+      error: null,
+    });
+    const gateway = new SupabaseMutationPushGateway({ rpc } as never);
+
+    await expect(gateway.push(mutation('orderBatches', 'batch-1', {}))).resolves.toMatchObject({
+      entityId: 'batch-1',
+      repository: 'orderBatches',
+    });
+    expect(rpc).toHaveBeenCalledWith(
+      'apply_concurrent_order_batch',
+      expect.objectContaining({
+        requested_client_mutation_id: mutationId,
+        requested_entity_id: 'batch-1',
+      }),
+    );
+  });
+
+  it('preserves structured stale-note details for the conflict store', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: null,
+      error: {
+        code: 'P0001',
+        message: 'version_conflict',
+        details: JSON.stringify({
+          serverVersion: 4,
+          serverPayload: {
+            id: 'item-1',
+            note: 'Cloud note',
+            version: 4,
+          },
+        }),
+      },
+    });
+    const gateway = new SupabaseMutationPushGateway({ rpc } as never);
+
+    await expect(
+      gateway.push(mutation('orderItems', 'item-1', { note: 'Local note' }, 3)),
+    ).rejects.toMatchObject({
+      message: 'version_conflict',
+      details: {
+        code: 'P0001',
+        serverVersion: 4,
+        serverPayload: {
+          id: 'item-1',
+          note: 'Cloud note',
+          version: 4,
+        },
+      },
+    });
+    expect(rpc).toHaveBeenCalledWith(
+      'apply_order_item_note_command',
+      expect.objectContaining({
+        requested_base_version: 3,
+        requested_entity_id: 'item-1',
+      }),
+    );
+  });
+});
+
+function mutation(
+  repository: 'orderBatches' | 'orderItems',
+  entityId: string,
+  payload: OutboxMutation['payload'],
+  baseVersion?: number,
+): OutboxMutation {
+  return {
+    id: mutationId,
+    organizationId,
+    branchId,
+    deviceId,
+    clientMutationId: mutationId,
+    idempotencyKey: `${deviceId}:${mutationId}`,
+    repository,
+    entityId,
+    operation: 'command',
+    payload,
+    ...(baseVersion === undefined ? {} : { baseVersion }),
+    status: 'pending',
+    attemptCount: 0,
+    createdAt,
+  };
+}

--- a/src/data/sync/mutationPushGateway.ts
+++ b/src/data/sync/mutationPushGateway.ts
@@ -21,25 +21,98 @@ export class SupabaseMutationPushGateway implements MutationPushGateway {
   constructor(private readonly client: SupabaseClient<Database>) {}
 
   async push(mutation: OutboxMutation): Promise<MutationPushResult> {
-    const { data, error } = await this.client.rpc('apply_client_mutation', {
-      requested_organization_id: mutation.organizationId,
-      requested_branch_id: mutation.branchId,
-      requested_device_id: mutation.deviceId,
-      requested_client_mutation_id: mutation.clientMutationId,
-      requested_mutation_type: remoteMutationType(mutation),
-      requested_entity_id: mutation.entityId,
-      requested_payload: remotePayload(mutation),
-      requested_base_version: mutation.baseVersion ?? null,
-    });
+    const payload = remotePayload(mutation);
+    const { data, error } =
+      mutation.repository === 'orderBatches' && mutation.operation === 'command'
+        ? await this.client.rpc('apply_concurrent_order_batch', {
+            requested_organization_id: mutation.organizationId,
+            requested_branch_id: mutation.branchId,
+            requested_device_id: mutation.deviceId,
+            requested_client_mutation_id: mutation.clientMutationId,
+            requested_entity_id: mutation.entityId,
+            requested_payload: payload,
+          })
+        : mutation.repository === 'orderItems' &&
+            mutation.operation === 'command' &&
+            isNoteMutation(payload)
+          ? await this.client.rpc('apply_order_item_note_command', {
+              requested_organization_id: mutation.organizationId,
+              requested_branch_id: mutation.branchId,
+              requested_device_id: mutation.deviceId,
+              requested_client_mutation_id: mutation.clientMutationId,
+              requested_entity_id: mutation.entityId,
+              requested_payload: payload,
+              requested_base_version: mutation.baseVersion ?? null,
+            })
+          : await this.client.rpc('apply_client_mutation', {
+              requested_organization_id: mutation.organizationId,
+              requested_branch_id: mutation.branchId,
+              requested_device_id: mutation.deviceId,
+              requested_client_mutation_id: mutation.clientMutationId,
+              requested_mutation_type: remoteMutationType(mutation),
+              requested_entity_id: mutation.entityId,
+              requested_payload: payload,
+              requested_base_version: mutation.baseVersion ?? null,
+            });
 
     if (error) {
-      throw new MutationPushError(error.message, {
-        code: error.code,
-      });
+      throw new MutationPushError(error.message, parseRemoteErrorDetails(error));
     }
 
     return parseMutationResult(data);
   }
+}
+
+function isNoteMutation(payload: Json): boolean {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    !Array.isArray(payload) &&
+    Object.prototype.hasOwnProperty.call(payload, 'note')
+  );
+}
+
+function parseRemoteErrorDetails(error: { readonly code?: string; readonly details?: string }): {
+  readonly code?: string;
+  readonly serverVersion?: number;
+  readonly serverPayload?: JsonValue;
+} {
+  const base = error.code ? { code: error.code } : {};
+  if (!error.details) return base;
+
+  try {
+    const parsed = JSON.parse(error.details) as {
+      readonly serverVersion?: unknown;
+      readonly serverPayload?: unknown;
+    };
+    return {
+      ...base,
+      ...(typeof parsed.serverVersion === 'number' && Number.isSafeInteger(parsed.serverVersion)
+        ? { serverVersion: parsed.serverVersion }
+        : {}),
+      ...(isJsonValue(parsed.serverPayload)
+        ? { serverPayload: parsed.serverPayload as JsonValue }
+        : {}),
+    };
+  } catch {
+    return base;
+  }
+}
+
+function isJsonValue(value: unknown): boolean {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) return value.every(isJsonValue);
+  if (typeof value === 'object') {
+    return Object.values(value).every(isJsonValue);
+  }
+  return false;
 }
 
 function remoteMutationType(mutation: OutboxMutation): string {

--- a/src/data/sync/outboxPushWorker.ts
+++ b/src/data/sync/outboxPushWorker.ts
@@ -3,7 +3,9 @@ import {
   OutboxMutation,
   OutboxTransitionPatch,
   RepositoryScope,
+  SyncConflict,
 } from '../contracts';
+import { SyncConflictId, toDomainId } from '../../domain';
 import { MutationPushGateway } from './mutationPushGateway';
 import {
   RetryPolicy,
@@ -133,7 +135,7 @@ export class OutboxPushWorker {
       }
 
       if (disposition === 'conflict') {
-        await this.transition(mutation, 'conflict', patch);
+        await this.recordConflict(mutation, details, patch);
         return 'conflicted';
       }
 
@@ -143,6 +145,32 @@ export class OutboxPushWorker {
       });
       return 'rejected';
     }
+  }
+
+  private async recordConflict(
+    mutation: OutboxMutation,
+    details: ReturnType<typeof mutationErrorDetails>,
+    patch: OutboxTransitionPatch,
+  ): Promise<void> {
+    const conflict: SyncConflict = {
+      id: toDomainId<SyncConflictId>(`conflict-${mutation.id}`),
+      organizationId: mutation.organizationId,
+      branchId: mutation.branchId,
+      mutationId: mutation.id,
+      repository: mutation.repository,
+      entityId: mutation.entityId,
+      ...(mutation.baseVersion === undefined ? {} : { baseVersion: mutation.baseVersion }),
+      serverVersion: Math.max(1, details.serverVersion ?? mutation.baseVersion ?? 1),
+      localPayload: mutation.payload,
+      serverPayload: details.serverPayload ?? {},
+      status: 'unresolved',
+      detectedAt: this.now().toISOString(),
+    };
+
+    await this.database.transaction(async (transaction) => {
+      await transaction.outbox.transition(mutation.id, 'processing', 'conflict', patch);
+      await transaction.syncState.addConflict(conflict);
+    });
   }
 
   private async transition(

--- a/src/data/sync/retryPolicy.ts
+++ b/src/data/sync/retryPolicy.ts
@@ -1,9 +1,13 @@
+import { JsonValue } from '../../domain';
+
 export type MutationErrorDisposition = 'retryable' | 'conflict' | 'rejected';
 
 export interface MutationErrorDetails {
   readonly code?: string;
   readonly status?: number;
   readonly retryAfterMs?: number;
+  readonly serverVersion?: number;
+  readonly serverPayload?: JsonValue;
   readonly message: string;
 }
 

--- a/src/features/table-workspace/__tests__/orderCommands.test.ts
+++ b/src/features/table-workspace/__tests__/orderCommands.test.ts
@@ -20,7 +20,13 @@ import {
 } from '../../../domain';
 import { RepositoryScope } from '../../../data/contracts';
 import { InMemoryLocalDatabase } from '../../../data/testing/inMemoryLocalDatabase';
-import { cancelOrderItem, sendOrderBatch } from '../orderCommands';
+import { MutationPushError, OutboxPushWorker } from '../../../data/sync';
+import {
+  cancelOrderItem,
+  resolveOrderItemNoteConflict,
+  sendOrderBatch,
+  updateOrderItemNote,
+} from '../orderCommands';
 import { loadTableWorkspace } from '../workspaceModel';
 
 const organizationId = toDomainId<OrganizationId>('organization-1');
@@ -174,6 +180,101 @@ describe('rapid table workspace commands', () => {
       repository: 'orderItems',
     });
   });
+
+  it('retains both note versions and lets the waiter explicitly keep the local note', async () => {
+    const database = new InMemoryLocalDatabase();
+    await seedWorkspace(database);
+    const workspace = await loadTableWorkspace(database, scope, tableId);
+    const sent = await sendOrderBatch({
+      database,
+      scope,
+      deviceId,
+      actorUserId: userId,
+      tableId,
+      checkName: 'Hesap 1',
+      lines: [
+        {
+          id: 'draft-1',
+          product: workspace!.products[0],
+          quantity: 1,
+          selectedOptionIds: [optionId],
+        },
+      ],
+      now: new Date(timestamp),
+      createUuid: sequentialIds(),
+    });
+    await markPendingApplied(database);
+    const localEdit = await updateOrderItemNote({
+      database,
+      scope,
+      deviceId,
+      actorUserId: userId,
+      item: { ...sent.items[0], syncStatus: 'synced', serverVersion: 1 },
+      note: 'Benim notum',
+      now: new Date('2026-07-26T18:02:00.000Z'),
+      createUuid: () => 'note-mutation',
+    });
+    const worker = new OutboxPushWorker(
+      database,
+      {
+        push: jest.fn().mockRejectedValue(
+          new MutationPushError('version_conflict', {
+            code: 'P0001',
+            serverVersion: 2,
+            serverPayload: {
+              id: localEdit.id,
+              note: 'Diğer garsonun notu',
+              updated_at: '2026-07-26T18:01:00.000Z',
+              updated_by: 'waiter-2',
+              version: 2,
+            },
+          }),
+        ),
+      },
+      { now: () => new Date('2026-07-26T18:03:00.000Z') },
+    );
+
+    await expect(worker.runOnce(scope)).resolves.toMatchObject({ conflicted: 1 });
+    const [conflict] = await database.syncState.listConflicts(scope, ['unresolved']);
+    expect(conflict).toMatchObject({
+      entityId: localEdit.id,
+      localPayload: { note: 'Benim notum' },
+      serverPayload: { note: 'Diğer garsonun notu' },
+      serverVersion: 2,
+    });
+
+    const resolved = await resolveOrderItemNoteConflict({
+      database,
+      scope,
+      deviceId,
+      actorUserId: userId,
+      item: localEdit,
+      conflict,
+      resolution: 'local',
+      now: new Date('2026-07-26T18:04:00.000Z'),
+      createUuid: () => 'note-retry',
+    });
+
+    expect(resolved).toMatchObject({
+      note: 'Benim notum',
+      serverVersion: 2,
+      syncStatus: 'pending',
+      version: 3,
+    });
+    await expect(database.outbox.getById(conflict.mutationId)).resolves.toMatchObject({
+      status: 'resolved',
+    });
+    expect(await database.outbox.list(scope, ['pending'])).toEqual([
+      expect.objectContaining({
+        baseVersion: 2,
+        id: 'note-retry',
+        payload: { note: 'Benim notum' },
+      }),
+    ]);
+    await expect(database.syncState.getConflict(conflict.id)).resolves.toMatchObject({
+      status: 'resolved_local',
+    });
+  });
 });
 
 async function seedWorkspace(database: InMemoryLocalDatabase): Promise<void> {
@@ -271,4 +372,13 @@ async function seedWorkspace(database: InMemoryLocalDatabase): Promise<void> {
 function sequentialIds(): () => string {
   let index = 0;
   return () => `generated-${++index}`;
+}
+
+async function markPendingApplied(database: InMemoryLocalDatabase): Promise<void> {
+  await database.transaction(async (transaction) => {
+    const [claimed] = await transaction.outbox.claimNext(scope, 1, timestamp);
+    await transaction.outbox.transition(claimed.id, 'processing', 'applied', {
+      appliedAt: timestamp,
+    });
+  });
 }

--- a/src/features/table-workspace/orderCommands.ts
+++ b/src/features/table-workspace/orderCommands.ts
@@ -4,6 +4,7 @@ import {
   Check,
   CheckId,
   DeviceId,
+  JsonValue,
   MenuItemId,
   ModifierOptionId,
   MutationId,
@@ -20,7 +21,7 @@ import {
   assertOrderItemTransition,
   toDomainId,
 } from '../../domain';
-import { LocalDatabase, OutboxMutation, RepositoryScope } from '../../data/contracts';
+import { LocalDatabase, OutboxMutation, RepositoryScope, SyncConflict } from '../../data/contracts';
 import { WorkspaceProduct } from './workspaceModel';
 
 export interface DraftOrderLine {
@@ -240,6 +241,170 @@ export async function cancelOrderItem(input: CancelOrderItemInput): Promise<Orde
   });
 }
 
+export interface UpdateOrderItemNoteInput {
+  readonly database: LocalDatabase;
+  readonly scope: Required<RepositoryScope>;
+  readonly deviceId: DeviceId;
+  readonly actorUserId: UserId;
+  readonly item: OrderItem;
+  readonly note?: string;
+  readonly now?: Date;
+  readonly createUuid?: () => string;
+}
+
+export async function updateOrderItemNote(input: UpdateOrderItemNoteInput): Promise<OrderItem> {
+  if (input.item.status === 'cancelled') {
+    throw new Error('A cancelled order item note cannot be edited');
+  }
+  const updatedAt = (input.now ?? new Date()).toISOString();
+  const mutationId = toDomainId<MutationId>((input.createUuid ?? defaultUuid)());
+  const note = input.note?.trim() || undefined;
+  const updated: OrderItem = {
+    ...input.item,
+    note,
+    updatedBy: input.actorUserId,
+    updatedAt,
+    version: input.item.version + 1,
+    syncStatus: 'pending',
+    clientMutationId: mutationId,
+  };
+  const mutation: OutboxMutation = {
+    id: mutationId,
+    ...input.scope,
+    deviceId: input.deviceId,
+    clientMutationId: mutationId,
+    idempotencyKey: `${input.deviceId}:${mutationId}`,
+    repository: 'orderItems',
+    entityId: input.item.id,
+    operation: 'command',
+    payload: { note: note ?? null },
+    baseVersion: input.item.serverVersion ?? input.item.version,
+    status: 'pending',
+    attemptCount: 0,
+    createdAt: updatedAt,
+  };
+
+  return input.database.transaction(async (transaction) => {
+    const stored = await transaction.repository('orderItems').put(input.scope, updated, {
+      expectedVersion: input.item.version,
+    });
+    await transaction.outbox.enqueue(mutation);
+    return stored;
+  });
+}
+
+export type NoteConflictResolution = 'server' | 'local';
+
+export interface ResolveOrderItemNoteConflictInput {
+  readonly database: LocalDatabase;
+  readonly scope: Required<RepositoryScope>;
+  readonly deviceId: DeviceId;
+  readonly actorUserId: UserId;
+  readonly item: OrderItem;
+  readonly conflict: SyncConflict;
+  readonly resolution: NoteConflictResolution;
+  readonly now?: Date;
+  readonly createUuid?: () => string;
+}
+
+export async function resolveOrderItemNoteConflict(
+  input: ResolveOrderItemNoteConflictInput,
+): Promise<OrderItem> {
+  if (
+    input.conflict.repository !== 'orderItems' ||
+    input.conflict.entityId !== input.item.id ||
+    input.conflict.status !== 'unresolved'
+  ) {
+    throw new Error('The note conflict does not belong to this order item');
+  }
+  const occurredAt = (input.now ?? new Date()).toISOString();
+  const oldMutation = await input.database.outbox.getById(input.conflict.mutationId);
+  if (!oldMutation || oldMutation.status !== 'conflict') {
+    throw new Error('The conflicted note mutation is no longer available');
+  }
+  const serverPayload = jsonRecord(input.conflict.serverPayload);
+  const serverNote =
+    typeof serverPayload.note === 'string' && serverPayload.note.trim()
+      ? serverPayload.note.trim()
+      : undefined;
+  const serverUpdatedAt =
+    typeof serverPayload.updated_at === 'string' ? serverPayload.updated_at : occurredAt;
+  const serverUpdatedBy =
+    typeof serverPayload.updated_by === 'string'
+      ? toDomainId<UserId>(serverPayload.updated_by)
+      : input.item.updatedBy;
+  const localPayload = jsonRecord(input.conflict.localPayload);
+  const localNote =
+    typeof localPayload.note === 'string' && localPayload.note.trim()
+      ? localPayload.note.trim()
+      : undefined;
+  const resolvedEntity: OrderItem =
+    input.resolution === 'server'
+      ? {
+          ...input.item,
+          note: serverNote,
+          updatedAt: serverUpdatedAt,
+          updatedBy: serverUpdatedBy,
+          version: input.conflict.serverVersion,
+          syncStatus: 'synced',
+          serverVersion: input.conflict.serverVersion,
+          lastSyncedAt: occurredAt,
+        }
+      : {
+          ...input.item,
+          note: localNote,
+          updatedAt: occurredAt,
+          updatedBy: input.actorUserId,
+          version: input.conflict.serverVersion + 1,
+          syncStatus: 'pending',
+          serverVersion: input.conflict.serverVersion,
+        };
+  const retryMutationId =
+    input.resolution === 'local'
+      ? toDomainId<MutationId>((input.createUuid ?? defaultUuid)())
+      : undefined;
+  const retryMutation: OutboxMutation | undefined = retryMutationId
+    ? {
+        id: retryMutationId,
+        ...input.scope,
+        deviceId: input.deviceId,
+        clientMutationId: retryMutationId,
+        idempotencyKey: `${input.deviceId}:${retryMutationId}`,
+        repository: 'orderItems',
+        entityId: input.item.id,
+        operation: 'command',
+        payload: { note: localNote ?? null },
+        baseVersion: input.conflict.serverVersion,
+        status: 'pending',
+        attemptCount: 0,
+        createdAt: occurredAt,
+      }
+    : undefined;
+
+  return input.database.transaction(async (transaction) => {
+    await transaction.outbox.transition(input.conflict.mutationId, 'conflict', 'resolved', {
+      appliedAt: occurredAt,
+      errorCode: undefined,
+      errorMessage: undefined,
+    });
+    await transaction.syncState.resolveConflict(
+      input.conflict.id,
+      input.resolution === 'server' ? 'resolved_server' : 'resolved_local',
+      occurredAt,
+      {
+        note: input.resolution === 'server' ? (serverNote ?? null) : (localNote ?? null),
+      },
+    );
+    const stored = await transaction
+      .repository('orderItems')
+      .put(input.scope, resolvedEntity, { expectedVersion: input.item.version });
+    if (retryMutation) {
+      await transaction.outbox.enqueue(retryMutation);
+    }
+    return stored;
+  });
+}
+
 function validateDraft(input: SendOrderBatchInput): void {
   if (input.lines.length === 0) {
     throw new OrderDraftValidationError('At least one product is required', 'EMPTY_BATCH');
@@ -357,6 +522,13 @@ function defaultUuid(): string {
   const value = uuid.v4();
   if (typeof value !== 'string') {
     throw new Error('UUID generation failed');
+  }
+  return value;
+}
+
+function jsonRecord(value: JsonValue): Readonly<Record<string, JsonValue>> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
   }
   return value;
 }

--- a/src/features/table-workspace/workspaceModel.ts
+++ b/src/features/table-workspace/workspaceModel.ts
@@ -16,6 +16,7 @@ import {
   LocalDatabase,
   RepositoryName,
   RepositoryScope,
+  SyncConflict,
 } from '../../data/contracts';
 
 export interface WorkspaceModifierGroup extends ModifierGroup {
@@ -36,6 +37,7 @@ export interface TableWorkspaceSnapshot {
   readonly categories: readonly MenuCategory[];
   readonly products: readonly WorkspaceProduct[];
   readonly cancellationReasons: readonly CancellationReason[];
+  readonly conflicts: readonly SyncConflict[];
 }
 
 export async function loadTableWorkspace(
@@ -54,6 +56,7 @@ export async function loadTableWorkspace(
     modifierGroups,
     modifierOptions,
     cancellationReasons,
+    conflicts,
   ] = await Promise.all([
     database.repository('restaurantTables').getById(scope, tableId),
     loadAll(database, 'tableSessions', scope),
@@ -65,6 +68,7 @@ export async function loadTableWorkspace(
     loadAll(database, 'modifierGroups', scope),
     loadAll(database, 'modifierOptions', scope),
     loadAll(database, 'cancellationReasons', scope),
+    database.syncState.listConflicts(scope, ['unresolved']),
   ]);
   if (!table || table.deletedAt) return null;
 
@@ -129,6 +133,7 @@ export async function loadTableWorkspace(
     cancellationReasons: cancellationReasons
       .filter((reason) => reason.isActive && !reason.deletedAt)
       .sort((left, right) => left.name.localeCompare(right.name)),
+    conflicts: conflicts.filter((conflict) => itemIds.has(conflict.entityId as OrderItem['id'])),
   };
 }
 

--- a/src/screens/TableDetailScreen.tsx
+++ b/src/screens/TableDetailScreen.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -47,6 +47,8 @@ import {
   loadWorkspacePreferences,
   saveWorkspacePreferences,
   sendOrderBatch,
+  resolveOrderItemNoteConflict,
+  updateOrderItemNote,
 } from '../features/table-workspace';
 import { Language, useLocalization } from '../i18n';
 import { RootStackParamList } from '../navigation/AppNavigator';
@@ -101,6 +103,7 @@ function CloudTableWorkspace({
     database,
     errorMessage: runtimeError,
     refresh,
+    resolveActiveParticipants,
     resolveProfileNames,
     revision,
     scope,
@@ -124,13 +127,34 @@ function CloudTableWorkspace({
   const [configurationNote, setConfigurationNote] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [cancellingItem, setCancellingItem] = useState<OrderItem>();
+  const [editingNoteItem, setEditingNoteItem] = useState<OrderItem>();
+  const [editingNote, setEditingNote] = useState('');
   const [waiterNames, setWaiterNames] = useState<Readonly<Record<string, string>>>({});
+  const [participantNames, setParticipantNames] = useState<readonly string[]>([]);
+  const [incomingMessage, setIncomingMessage] = useState<string>();
+  const snapshotRef = useRef<TableWorkspaceSnapshot | null>(null);
   const tableId = toDomainId<RestaurantTableId>(route.params.tableId);
 
   const reload = useCallback(async () => {
     if (!database || !scope) return;
     try {
       const next = await loadTableWorkspace(database, scope, tableId);
+      const previous = snapshotRef.current;
+      if (previous && next) {
+        const previousItemIds = new Set(previous.orderItems.map((item) => item.id));
+        const incoming = next.orderItems.filter(
+          (item) => !previousItemIds.has(item.id) && item.createdBy !== actorUserId,
+        );
+        if (incoming.length > 0) {
+          const actorIds = [...new Set(incoming.map((item) => item.createdBy))];
+          const names: Readonly<Record<string, string>> = await resolveProfileNames(actorIds).catch(
+            () => ({}),
+          );
+          const actorNames = actorIds.map((id) => names[id] ?? copy.unknownWaiter);
+          setIncomingMessage(`${actorNames.join(', ')} · ${incoming.length} ${copy.incomingItems}`);
+        }
+      }
+      snapshotRef.current = next;
       setSnapshot(next);
       setLoadError(next ? undefined : copy.tableNotFound);
     } catch {
@@ -138,7 +162,17 @@ function CloudTableWorkspace({
     } finally {
       setLoading(false);
     }
-  }, [copy.loadFailed, copy.tableNotFound, database, scope, tableId]);
+  }, [
+    actorUserId,
+    copy.incomingItems,
+    copy.loadFailed,
+    copy.tableNotFound,
+    copy.unknownWaiter,
+    database,
+    resolveProfileNames,
+    scope,
+    tableId,
+  ]);
 
   useEffect(() => {
     void reload();
@@ -160,6 +194,34 @@ function CloudTableWorkspace({
       .then(setWaiterNames)
       .catch(() => setWaiterNames({}));
   }, [resolveProfileNames, snapshot]);
+
+  useEffect(() => {
+    if (!snapshot?.session) {
+      setParticipantNames([]);
+      return;
+    }
+    void resolveActiveParticipants(snapshot.session.id)
+      .then((participants) =>
+        setParticipantNames(participants.map((participant) => participant.display_name)),
+      )
+      .catch(() => {
+        const cutoff = Date.now() - 15 * 60_000;
+        const userIds = [
+          ...new Set(
+            snapshot.orderItems
+              .filter((item) => Date.parse(item.updatedAt) >= cutoff)
+              .map((item) => item.createdBy),
+          ),
+        ];
+        setParticipantNames(userIds.map((id) => waiterNames[id] ?? copy.unknownWaiter));
+      });
+  }, [copy.unknownWaiter, resolveActiveParticipants, revision, snapshot, waiterNames]);
+
+  useEffect(() => {
+    if (!incomingMessage) return;
+    const timer = setTimeout(() => setIncomingMessage(undefined), 4_000);
+    return () => clearTimeout(timer);
+  }, [incomingMessage]);
 
   useEffect(() => {
     if (!snapshot || selectedCheckId || pendingCheckName) return;
@@ -327,6 +389,48 @@ function CloudTableWorkspace({
     }
   };
 
+  const saveItemNote = async () => {
+    if (!database || !scope || !editingNoteItem) return;
+    try {
+      await updateOrderItemNote({
+        database,
+        scope,
+        actorUserId,
+        deviceId,
+        item: editingNoteItem,
+        note: editingNote,
+      });
+      setEditingNoteItem(undefined);
+      await reload();
+      void refresh();
+    } catch (error) {
+      Alert.alert(copy.noteSaveFailed, error instanceof Error ? error.message : copy.tryAgain);
+    }
+  };
+
+  const resolveNoteConflict = async (
+    item: OrderItem,
+    conflict: TableWorkspaceSnapshot['conflicts'][number],
+    resolution: 'server' | 'local',
+  ) => {
+    if (!database || !scope) return;
+    try {
+      await resolveOrderItemNoteConflict({
+        database,
+        scope,
+        actorUserId,
+        deviceId,
+        item,
+        conflict,
+        resolution,
+      });
+      await reload();
+      void refresh();
+    } catch (error) {
+      Alert.alert(copy.conflictFailed, error instanceof Error ? error.message : copy.tryAgain);
+    }
+  };
+
   const toggleFavorite = (productId: string) => {
     const next = favoriteIds.includes(productId)
       ? favoriteIds.filter((id) => id !== productId)
@@ -385,6 +489,7 @@ function CloudTableWorkspace({
     >
       <WorkspaceHeader
         onBack={navigation.goBack}
+        participantNames={participantNames}
         syncLabel={
           sync.online
             ? sync.pendingCount > 0
@@ -395,6 +500,37 @@ function CloudTableWorkspace({
         syncTone={sync.hasError ? 'error' : sync.pendingCount > 0 ? 'warning' : 'success'}
         tableLabel={snapshot.table.label}
       />
+
+      {incomingMessage ? (
+        <View
+          accessibilityLiveRegion="polite"
+          accessibilityRole="alert"
+          style={{
+            alignItems: 'center',
+            backgroundColor: tokens.colors.accentSoft,
+            flexDirection: 'row',
+            marginBottom: tokens.space.xs,
+            marginHorizontal: tokens.space.md,
+            padding: tokens.space.sm,
+            borderRadius: tokens.radius.medium,
+          }}
+        >
+          <Ionicons color={tokens.colors.accent} name="people-outline" size={20} />
+          <Text
+            style={[
+              tokens.typography.label,
+              { color: tokens.colors.text, flex: 1, marginLeft: tokens.space.xs },
+            ]}
+          >
+            {incomingMessage}
+          </Text>
+          <ServiceIconButton
+            icon="close"
+            label={copy.close}
+            onPress={() => setIncomingMessage(undefined)}
+          />
+        </View>
+      ) : null}
 
       <CheckStrip
         checks={snapshot.checks}
@@ -452,7 +588,13 @@ function CloudTableWorkspace({
             items={visibleItems}
             language={language}
             modifiers={snapshot.orderItemModifiers}
+            conflicts={snapshot.conflicts}
             onCancel={setCancellingItem}
+            onEditNote={(item) => {
+              setEditingNote(item.note ?? '');
+              setEditingNoteItem(item);
+            }}
+            onResolveConflict={resolveNoteConflict}
             waiterNames={waiterNames}
           />
         ) : null}
@@ -537,6 +679,14 @@ function CloudTableWorkspace({
         onClose={() => setCancellingItem(undefined)}
         reasons={snapshot.cancellationReasons}
       />
+      <ItemNoteModal
+        copy={copy}
+        item={editingNoteItem}
+        note={editingNote}
+        onChange={setEditingNote}
+        onClose={() => setEditingNoteItem(undefined)}
+        onConfirm={() => void saveItemNote()}
+      />
 
       {runtimeError ? (
         <View
@@ -561,34 +711,54 @@ function WorkspaceHeader({
   tableLabel,
   syncLabel,
   syncTone,
+  participantNames,
   onBack,
 }: {
   readonly tableLabel: string;
   readonly syncLabel: string;
   readonly syncTone: 'success' | 'warning' | 'error';
+  readonly participantNames: readonly string[];
   readonly onBack: () => void;
 }) {
   const { tokens } = useTheme();
   return (
-    <View
-      style={{
-        alignItems: 'center',
-        flexDirection: 'row',
-        minHeight: 64,
-        paddingHorizontal: tokens.space.md,
-      }}
-    >
-      <ServiceIconButton icon="arrow-back" label="Back" onPress={onBack} />
-      <Text
-        style={[
-          tokens.typography.title,
-          { color: tokens.colors.text, flex: 1, marginHorizontal: tokens.space.sm },
-        ]}
-        numberOfLines={1}
+    <View style={{ paddingHorizontal: tokens.space.md, paddingBottom: tokens.space.xs }}>
+      <View
+        style={{
+          alignItems: 'center',
+          flexDirection: 'row',
+          minHeight: 64,
+        }}
       >
-        {tableLabel}
-      </Text>
-      <ServiceStatusPill label={syncLabel} tone={syncTone} />
+        <ServiceIconButton icon="arrow-back" label="Back" onPress={onBack} />
+        <Text
+          style={[
+            tokens.typography.title,
+            { color: tokens.colors.text, flex: 1, marginHorizontal: tokens.space.sm },
+          ]}
+          numberOfLines={1}
+        >
+          {tableLabel}
+        </Text>
+        <ServiceStatusPill label={syncLabel} tone={syncTone} />
+      </View>
+      {participantNames.length > 0 ? (
+        <View
+          accessibilityLabel={participantNames.join(', ')}
+          style={{ alignItems: 'center', flexDirection: 'row', marginLeft: 48 }}
+        >
+          <Ionicons color={tokens.colors.primary} name="people" size={16} />
+          <Text
+            numberOfLines={1}
+            style={[
+              tokens.typography.caption,
+              { color: tokens.colors.textSubtle, marginLeft: tokens.space.xs },
+            ]}
+          >
+            {participantNames.join(' · ')}
+          </Text>
+        </View>
+      ) : null}
     </View>
   );
 }
@@ -742,21 +912,31 @@ function OrderPane({
   checkTotal,
   items,
   modifiers,
+  conflicts,
   waiterNames,
   copy,
   language,
   currencyCode,
   onCancel,
+  onEditNote,
+  onResolveConflict,
 }: {
   readonly checkName: string;
   readonly checkTotal: number;
   readonly items: readonly OrderItem[];
   readonly modifiers: TableWorkspaceSnapshot['orderItemModifiers'];
+  readonly conflicts: TableWorkspaceSnapshot['conflicts'];
   readonly waiterNames: Readonly<Record<string, string>>;
   readonly copy: WorkspaceCopy;
   readonly language: Language;
   readonly currencyCode: string;
   readonly onCancel: (item: OrderItem) => void;
+  readonly onEditNote: (item: OrderItem) => void;
+  readonly onResolveConflict: (
+    item: OrderItem,
+    conflict: TableWorkspaceSnapshot['conflicts'][number],
+    resolution: 'server' | 'local',
+  ) => void;
 }) {
   const { tokens } = useTheme();
   return (
@@ -792,6 +972,12 @@ function OrderPane({
           contentContainerStyle={{ padding: tokens.space.sm }}
           renderItem={({ item }) => {
             const itemModifiers = modifiers.filter((modifier) => modifier.orderItemId === item.id);
+            const conflict = conflicts.find(
+              (candidate) =>
+                candidate.entityId === item.id &&
+                candidate.repository === 'orderItems' &&
+                candidate.status === 'unresolved',
+            );
             return (
               <View
                 style={{
@@ -838,16 +1024,69 @@ function OrderPane({
                       )}
                     </Text>
                     {item.status !== 'cancelled' ? (
-                      <ServiceIconButton
-                        icon="close-circle-outline"
-                        label={`${copy.cancelItem}: ${item.nameSnapshot}`}
-                        onPress={() => onCancel(item)}
-                      />
+                      <View style={{ flexDirection: 'row' }}>
+                        <ServiceIconButton
+                          icon="create-outline"
+                          label={`${copy.editNote}: ${item.nameSnapshot}`}
+                          onPress={() => onEditNote(item)}
+                        />
+                        <ServiceIconButton
+                          icon="close-circle-outline"
+                          label={`${copy.cancelItem}: ${item.nameSnapshot}`}
+                          onPress={() => onCancel(item)}
+                        />
+                      </View>
                     ) : (
                       <ServiceStatusPill label={copy.cancelled} tone="error" />
                     )}
                   </View>
                 </View>
+                {conflict ? (
+                  <View
+                    accessibilityRole="alert"
+                    style={{
+                      backgroundColor: tokens.colors.accentSoft,
+                      borderColor: tokens.colors.warning,
+                      borderRadius: tokens.radius.medium,
+                      borderWidth: 1,
+                      marginTop: tokens.space.sm,
+                      padding: tokens.space.sm,
+                    }}
+                  >
+                    <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}>
+                      {copy.noteConflict}
+                    </Text>
+                    <Text
+                      style={[
+                        tokens.typography.caption,
+                        { color: tokens.colors.textSubtle, marginTop: tokens.space.xxs },
+                      ]}
+                    >
+                      {copy.yourNote}: {conflictNote(conflict.localPayload) || copy.noNote}
+                    </Text>
+                    <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                      {copy.cloudNote}: {conflictNote(conflict.serverPayload) || copy.noNote}
+                    </Text>
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        flexWrap: 'wrap',
+                        gap: tokens.space.xs,
+                        marginTop: tokens.space.sm,
+                      }}
+                    >
+                      <ServiceButton
+                        label={copy.useCloudNote}
+                        onPress={() => onResolveConflict(item, conflict, 'server')}
+                        variant="outline"
+                      />
+                      <ServiceButton
+                        label={copy.keepMyNote}
+                        onPress={() => onResolveConflict(item, conflict, 'local')}
+                      />
+                    </View>
+                  </View>
+                ) : null}
               </View>
             );
           }}
@@ -1124,6 +1363,46 @@ function NameCheckModal({
   );
 }
 
+function ItemNoteModal({
+  item,
+  note,
+  copy,
+  onChange,
+  onClose,
+  onConfirm,
+}: {
+  readonly item?: OrderItem;
+  readonly note: string;
+  readonly copy: WorkspaceCopy;
+  readonly onChange: (value: string) => void;
+  readonly onClose: () => void;
+  readonly onConfirm: () => void;
+}) {
+  return (
+    <WorkspaceModal
+      title={`${copy.editNote}: ${item?.nameSnapshot ?? ''}`}
+      visible={Boolean(item)}
+      onClose={onClose}
+    >
+      <ServiceTextField
+        autoFocus
+        label={copy.note}
+        maxLength={500}
+        multiline
+        onChangeText={onChange}
+        placeholder={copy.noteExample}
+        value={note}
+      />
+      <ModalActions
+        cancel={copy.close}
+        confirm={copy.saveNote}
+        onCancel={onClose}
+        onConfirm={onConfirm}
+      />
+    </WorkspaceModal>
+  );
+}
+
 function ProductConfigurationModal({
   product,
   selected,
@@ -1389,6 +1668,12 @@ function timeOnly(timestamp: string, language: Language): string {
   ).format(new Date(timestamp));
 }
 
+function conflictNote(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const note = (value as { readonly note?: unknown }).note;
+  return typeof note === 'string' && note.trim() ? note.trim() : undefined;
+}
+
 interface WorkspaceCopy {
   readonly loading: string;
   readonly loadFailed: string;
@@ -1435,6 +1720,17 @@ interface WorkspaceCopy {
   readonly askManagerReasons: string;
   readonly manager: string;
   readonly localSafe: string;
+  readonly incomingItems: string;
+  readonly editNote: string;
+  readonly saveNote: string;
+  readonly noteSaveFailed: string;
+  readonly noteConflict: string;
+  readonly yourNote: string;
+  readonly cloudNote: string;
+  readonly noNote: string;
+  readonly useCloudNote: string;
+  readonly keepMyNote: string;
+  readonly conflictFailed: string;
 }
 
 function workspaceCopy(language: Language): WorkspaceCopy {
@@ -1485,6 +1781,17 @@ function workspaceCopy(language: Language): WorkspaceCopy {
       askManagerReasons: 'Yöneticiden şube için iptal nedenlerini tanımlamasını isteyin.',
       manager: 'Yönetici',
       localSafe: 'Bulut yenilenemedi. Yerel siparişler cihazda güvende.',
+      incomingItems: 'yeni ürün ekledi',
+      editNote: 'Notu düzenle',
+      saveNote: 'Notu kaydet',
+      noteSaveFailed: 'Not kaydedilemedi',
+      noteConflict: 'Not başka bir cihazda değişti',
+      yourNote: 'Senin notun',
+      cloudNote: 'Buluttaki not',
+      noNote: 'Not yok',
+      useCloudNote: 'Buluttakini kullan',
+      keepMyNote: 'Benim notumu uygula',
+      conflictFailed: 'Çakışma çözülemedi',
     };
   }
   if (language === 'bg') {
@@ -1534,6 +1841,17 @@ function workspaceCopy(language: Language): WorkspaceCopy {
       askManagerReasons: 'Помолете управителя да добави причини за този обект.',
       manager: 'Управител',
       localSafe: 'Облакът не се обнови. Локалните поръчки са запазени.',
+      incomingItems: 'добави нови продукта',
+      editNote: 'Редактирай бележката',
+      saveNote: 'Запази бележката',
+      noteSaveFailed: 'Бележката не е запазена',
+      noteConflict: 'Бележката е променена на друго устройство',
+      yourNote: 'Вашата бележка',
+      cloudNote: 'Бележката в облака',
+      noNote: 'Няма бележка',
+      useCloudNote: 'Използвай облачната',
+      keepMyNote: 'Запази моята',
+      conflictFailed: 'Конфликтът не е разрешен',
     };
   }
   return {
@@ -1582,5 +1900,16 @@ function workspaceCopy(language: Language): WorkspaceCopy {
     askManagerReasons: 'Ask a manager to configure cancellation reasons for this branch.',
     manager: 'Manager',
     localSafe: 'Cloud refresh failed. Local orders remain safe on this device.',
+    incomingItems: 'added new items',
+    editNote: 'Edit note',
+    saveNote: 'Save note',
+    noteSaveFailed: 'Note could not be saved',
+    noteConflict: 'The note changed on another device',
+    yourNote: 'Your note',
+    cloudNote: 'Cloud note',
+    noNote: 'No note',
+    useCloudNote: 'Use cloud note',
+    keepMyNote: 'Keep my note',
+    conflictFailed: 'Conflict could not be resolved',
   };
 }

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -83,6 +83,13 @@ export type PulledSyncEventRow = Omit<SyncEventRow, 'sequence'> & {
   cursor: string;
 };
 
+export type ActiveSessionParticipantRow = {
+  user_id: string;
+  display_name: string;
+  first_action_at: string;
+  last_action_at: string;
+};
+
 type TableDefinition<Row> = {
   Row: Row;
   Insert: Partial<Row>;
@@ -138,6 +145,38 @@ export type Database = {
           requested_base_version: number | null;
         };
         Returns: Json;
+      };
+      apply_concurrent_order_batch: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_device_id: string;
+          requested_client_mutation_id: string;
+          requested_entity_id: string;
+          requested_payload: Json;
+        };
+        Returns: Json;
+      };
+      apply_order_item_note_command: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_device_id: string;
+          requested_client_mutation_id: string;
+          requested_entity_id: string;
+          requested_payload: Json;
+          requested_base_version: number | null;
+        };
+        Returns: Json;
+      };
+      list_active_session_participants: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_table_session_id: string;
+          active_since?: string;
+        };
+        Returns: ActiveSessionParticipantRow[];
       };
       pull_sync_events: {
         Args: {

--- a/supabase/migrations/20260726233000_concurrent_waiters.sql
+++ b/supabase/migrations/20260726233000_concurrent_waiters.sql
@@ -1,0 +1,495 @@
+-- Concurrent waiter collaboration.
+--
+-- Order appends are reconciled onto the server's active table session instead
+-- of rejecting a second offline device that opened its own provisional
+-- session. Provisional rows are retained as explicit voided records so pull
+-- sync can converge the originating device without silent deletion.
+
+create or replace function public.apply_concurrent_order_batch(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_device_id uuid,
+  requested_client_mutation_id uuid,
+  requested_entity_id uuid,
+  requested_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller_user_id uuid := (select auth.uid());
+  target_table public.restaurant_tables;
+  active_session public.table_sessions;
+  matched_check public.checks;
+  requested_session_id uuid;
+  requested_check_id uuid;
+  adjusted_payload jsonb := requested_payload;
+  mutation_result jsonb;
+  canonical_session_id uuid;
+  canonical_check_id uuid;
+begin
+  if caller_user_id is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if not private.is_active_member(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'branch_access_denied';
+  end if;
+  if not exists (
+    select 1
+    from public.devices as device
+    where device.id = requested_device_id
+      and device.organization_id = requested_organization_id
+      and device.branch_id = requested_branch_id
+      and device.user_id = caller_user_id
+      and device.revoked_at is null
+  ) then
+    raise exception using errcode = '42501', message = 'device_access_denied';
+  end if;
+  if requested_payload is null
+    or jsonb_typeof(requested_payload) is distinct from 'object'
+    or jsonb_typeof(requested_payload -> 'session') is distinct from 'object'
+    or jsonb_typeof(requested_payload -> 'check') is distinct from 'object' then
+    raise exception using errcode = '22023', message = 'invalid_order_payload_shape';
+  end if;
+
+  requested_session_id := (requested_payload #>> '{session,id}')::uuid;
+  requested_check_id := (requested_payload #>> '{check,id}')::uuid;
+
+  select restaurant_table.*
+  into target_table
+  from public.restaurant_tables as restaurant_table
+  where restaurant_table.organization_id = requested_organization_id
+    and restaurant_table.branch_id = requested_branch_id
+    and restaurant_table.id = (requested_payload ->> 'tableId')::uuid
+    and restaurant_table.deleted_at is null
+  for update;
+  if target_table.id is null then
+    raise exception using errcode = '22023', message = 'table_not_found';
+  end if;
+
+  select session.*
+  into active_session
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.table_id = target_table.id
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null
+  order by session.opened_at desc
+  limit 1;
+
+  if active_session.id is not null and active_session.id <> requested_session_id then
+    insert into public.table_sessions (
+      id,
+      organization_id,
+      branch_id,
+      table_id,
+      status,
+      opened_by,
+      opened_at,
+      closed_by,
+      closed_at,
+      note,
+      version
+    )
+    values (
+      requested_session_id,
+      requested_organization_id,
+      requested_branch_id,
+      target_table.id,
+      'voided',
+      caller_user_id,
+      (requested_payload #>> '{session,openedAt}')::timestamptz,
+      caller_user_id,
+      now(),
+      'Reconciled to an already active table session',
+      1
+    )
+    on conflict (id) do nothing;
+
+    adjusted_payload := jsonb_set(
+      adjusted_payload,
+      '{session,id}',
+      to_jsonb(active_session.id)
+    );
+    adjusted_payload := jsonb_set(
+      adjusted_payload,
+      '{session,openedAt}',
+      to_jsonb(active_session.opened_at)
+    );
+
+    select check_row.*
+    into matched_check
+    from public.checks as check_row
+    where check_row.organization_id = requested_organization_id
+      and check_row.branch_id = requested_branch_id
+      and check_row.table_session_id = active_session.id
+      and check_row.status in ('open', 'partially_paid')
+      and check_row.deleted_at is null
+      and lower(trim(check_row.name)) =
+        lower(trim(requested_payload #>> '{check,name}'))
+    order by check_row.opened_at
+    limit 1;
+
+    if matched_check.id is not null and matched_check.id <> requested_check_id then
+      insert into public.checks (
+        id,
+        organization_id,
+        branch_id,
+        table_session_id,
+        name,
+        status,
+        opened_by,
+        opened_at,
+        closed_at,
+        version
+      )
+      values (
+        requested_check_id,
+        requested_organization_id,
+        requested_branch_id,
+        requested_session_id,
+        trim(requested_payload #>> '{check,name}'),
+        'voided',
+        caller_user_id,
+        (requested_payload #>> '{check,openedAt}')::timestamptz,
+        now(),
+        1
+      )
+      on conflict (id) do nothing;
+
+      adjusted_payload := jsonb_set(
+        adjusted_payload,
+        '{check,id}',
+        to_jsonb(matched_check.id)
+      );
+      adjusted_payload := jsonb_set(
+        adjusted_payload,
+        '{check,name}',
+        to_jsonb(matched_check.name)
+      );
+      adjusted_payload := jsonb_set(
+        adjusted_payload,
+        '{check,openedAt}',
+        to_jsonb(matched_check.opened_at)
+      );
+    end if;
+  end if;
+
+  mutation_result := public.apply_client_mutation(
+    requested_organization_id,
+    requested_branch_id,
+    requested_device_id,
+    requested_client_mutation_id,
+    'orders.send_batch',
+    requested_entity_id,
+    adjusted_payload,
+    null
+  );
+  canonical_session_id := (mutation_result ->> 'sessionId')::uuid;
+  canonical_check_id := (mutation_result ->> 'checkId')::uuid;
+
+  insert into public.session_participants (
+    organization_id,
+    branch_id,
+    table_session_id,
+    user_id,
+    first_action_at,
+    last_action_at
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    canonical_session_id,
+    caller_user_id,
+    now(),
+    now()
+  )
+  on conflict (table_session_id, user_id) do update
+  set last_action_at = excluded.last_action_at;
+
+  return mutation_result || jsonb_build_object(
+    'requestedSessionId', requested_session_id,
+    'canonicalSessionId', canonical_session_id,
+    'requestedCheckId', requested_check_id,
+    'canonicalCheckId', canonical_check_id
+  );
+end;
+$$;
+
+create or replace function public.apply_order_item_note_command(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_device_id uuid,
+  requested_client_mutation_id uuid,
+  requested_entity_id uuid,
+  requested_payload jsonb,
+  requested_base_version bigint
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller_user_id uuid := (select auth.uid());
+  fingerprint text;
+  claimed_mutation_id uuid;
+  prior_mutation public.client_mutations;
+  prior_order_item public.order_items;
+  canonical_order_item public.order_items;
+  mutation_result jsonb;
+begin
+  if caller_user_id is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if requested_payload is null or jsonb_typeof(requested_payload) is distinct from 'object' then
+    raise exception using errcode = '22023', message = 'mutation_payload_must_be_an_object';
+  end if;
+  if requested_payload - array['note'] <> '{}'::jsonb
+    or not (requested_payload ? 'note')
+    or jsonb_typeof(requested_payload -> 'note') not in ('string', 'null') then
+    raise exception using errcode = '22023', message = 'invalid_order_note_payload';
+  end if;
+  if char_length(coalesce(requested_payload ->> 'note', '')) > 500 then
+    raise exception using errcode = '22023', message = 'order_note_too_long';
+  end if;
+  if requested_base_version is null or requested_base_version < 1 then
+    raise exception using errcode = '22023', message = 'base_version_required';
+  end if;
+  if not private.is_active_member(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'branch_access_denied';
+  end if;
+  if not exists (
+    select 1
+    from public.devices as device
+    where device.id = requested_device_id
+      and device.organization_id = requested_organization_id
+      and device.branch_id = requested_branch_id
+      and device.user_id = caller_user_id
+      and device.revoked_at is null
+  ) then
+    raise exception using errcode = '42501', message = 'device_access_denied';
+  end if;
+
+  fingerprint := md5(concat_ws(
+    ':',
+    requested_organization_id::text,
+    requested_branch_id::text,
+    requested_device_id::text,
+    requested_client_mutation_id::text,
+    'order_items.update_note',
+    requested_entity_id::text,
+    requested_payload::text,
+    requested_base_version::text
+  ));
+
+  insert into public.client_mutations (
+    organization_id,
+    branch_id,
+    device_id,
+    client_mutation_id,
+    mutation_type,
+    entity_id,
+    request_fingerprint,
+    result_json
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    requested_device_id,
+    requested_client_mutation_id,
+    'order_items.update_note',
+    requested_entity_id,
+    fingerprint,
+    '{}'::jsonb
+  )
+  on conflict (device_id, client_mutation_id) do nothing
+  returning id into claimed_mutation_id;
+
+  if claimed_mutation_id is null then
+    select mutation.*
+    into prior_mutation
+    from public.client_mutations as mutation
+    where mutation.device_id = requested_device_id
+      and mutation.client_mutation_id = requested_client_mutation_id;
+    if prior_mutation.id is null then
+      raise exception using
+        errcode = '40001',
+        message = 'idempotency_result_temporarily_unavailable';
+    end if;
+    if prior_mutation.request_fingerprint <> fingerprint then
+      raise exception using
+        errcode = '22023',
+        message = 'client_mutation_id_reused_with_different_content';
+    end if;
+    return prior_mutation.result_json;
+  end if;
+
+  select order_item.*
+  into prior_order_item
+  from public.order_items as order_item
+  where order_item.organization_id = requested_organization_id
+    and order_item.branch_id = requested_branch_id
+    and order_item.id = requested_entity_id
+    and order_item.deleted_at is null
+  for update;
+  if prior_order_item.id is null then
+    raise exception using errcode = '22023', message = 'order_item_not_found';
+  end if;
+  if prior_order_item.version <> requested_base_version then
+    raise exception using
+      errcode = 'P0001',
+      message = 'version_conflict',
+      detail = jsonb_build_object(
+        'serverVersion', prior_order_item.version,
+        'serverPayload', to_jsonb(prior_order_item)
+      )::text;
+  end if;
+  if prior_order_item.status = 'cancelled' then
+    raise exception using errcode = '22023', message = 'cancelled_item_note_is_immutable';
+  end if;
+
+  update public.order_items
+  set note = nullif(trim(requested_payload ->> 'note'), ''),
+      updated_by = caller_user_id,
+      updated_at = now(),
+      version = prior_order_item.version + 1
+  where id = prior_order_item.id
+  returning * into canonical_order_item;
+
+  mutation_result := jsonb_build_object(
+    'status', 'applied',
+    'repository', 'orderItems',
+    'entityId', canonical_order_item.id,
+    'serverVersion', canonical_order_item.version,
+    'committedAt', now()
+  );
+
+  insert into public.audit_events (
+    organization_id,
+    branch_id,
+    actor_user_id,
+    device_id,
+    entity_type,
+    entity_id,
+    action,
+    before_json,
+    after_json,
+    client_mutation_id,
+    correlation_id
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    caller_user_id,
+    requested_device_id,
+    'order_items',
+    canonical_order_item.id,
+    'order_items.update_note',
+    to_jsonb(prior_order_item),
+    to_jsonb(canonical_order_item),
+    requested_client_mutation_id,
+    requested_client_mutation_id
+  );
+
+  update public.client_mutations
+  set result_json = mutation_result,
+      committed_at = now()
+  where id = claimed_mutation_id;
+
+  return mutation_result;
+end;
+$$;
+
+create or replace function public.list_active_session_participants(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_table_session_id uuid,
+  active_since timestamptz default (now() - interval '15 minutes')
+)
+returns table (
+  user_id uuid,
+  display_name text,
+  first_action_at timestamptz,
+  last_action_at timestamptz
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+begin
+  if (select auth.uid()) is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if not private.is_active_member(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'branch_access_denied';
+  end if;
+
+  return query
+  select
+    participant.user_id,
+    profile.display_name,
+    participant.first_action_at,
+    participant.last_action_at
+  from public.session_participants as participant
+  join public.profiles as profile on profile.id = participant.user_id
+  where participant.organization_id = requested_organization_id
+    and participant.branch_id = requested_branch_id
+    and participant.table_session_id = requested_table_session_id
+    and participant.last_action_at >= active_since
+  order by participant.last_action_at desc;
+end;
+$$;
+
+revoke execute on function public.apply_concurrent_order_batch(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb
+) from public, anon;
+grant execute on function public.apply_concurrent_order_batch(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb
+) to authenticated;
+
+revoke execute on function public.apply_order_item_note_command(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  bigint
+) from public, anon;
+grant execute on function public.apply_order_item_note_command(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  bigint
+) to authenticated;
+
+revoke execute on function public.list_active_session_participants(
+  uuid,
+  uuid,
+  uuid,
+  timestamptz
+) from public, anon;
+grant execute on function public.list_active_session_participants(
+  uuid,
+  uuid,
+  uuid,
+  timestamptz
+) to authenticated;

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(12);
+select plan(21);
 
 insert into auth.users (
   instance_id,
@@ -17,19 +17,33 @@ insert into auth.users (
   created_at,
   updated_at
 )
-values (
-  '00000000-0000-0000-0000-000000000000',
-  '15000000-0000-4000-8000-000000000001',
-  'authenticated',
-  'authenticated',
-  'workspace-waiter@example.com',
-  '',
-  now(),
-  '{"provider":"email","providers":["email"]}',
-  '{"display_name":"Workspace Waiter"}',
-  now(),
-  now()
-);
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-4000-8000-000000000001',
+    'authenticated',
+    'authenticated',
+    'workspace-waiter@example.com',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Workspace Waiter"}',
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '15000000-0000-4000-8000-000000000002',
+    'authenticated',
+    'authenticated',
+    'second-waiter@example.com',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{"display_name":"Second Waiter"}',
+    now(),
+    now()
+  );
 
 insert into public.organizations (id, name, slug, plan, status)
 values (
@@ -76,13 +90,21 @@ insert into public.memberships (
   role,
   status
 )
-values (
-  '25000000-0000-4000-8000-000000000001',
-  '35000000-0000-4000-8000-000000000001',
-  '15000000-0000-4000-8000-000000000001',
-  'waiter',
-  'active'
-);
+values
+  (
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '15000000-0000-4000-8000-000000000001',
+    'waiter',
+    'active'
+  ),
+  (
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '15000000-0000-4000-8000-000000000002',
+    'waiter',
+    'active'
+  );
 
 insert into public.devices (
   id,
@@ -92,14 +114,23 @@ insert into public.devices (
   platform,
   app_version
 )
-values (
-  '45000000-0000-4000-8000-000000000001',
-  '25000000-0000-4000-8000-000000000001',
-  '35000000-0000-4000-8000-000000000001',
-  '15000000-0000-4000-8000-000000000001',
-  'android',
-  '2.0.0'
-);
+values
+  (
+    '45000000-0000-4000-8000-000000000001',
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '15000000-0000-4000-8000-000000000001',
+    'android',
+    '2.0.0'
+  ),
+  (
+    '45000000-0000-4000-8000-000000000002',
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '15000000-0000-4000-8000-000000000002',
+    'ios_web',
+    '2.0.0'
+  );
 
 insert into public.halls (
   id,
@@ -264,12 +295,11 @@ set local role authenticated;
 
 select is(
   (
-    public.apply_client_mutation(
+    public.apply_concurrent_order_batch(
       '25000000-0000-4000-8000-000000000001',
       '35000000-0000-4000-8000-000000000001',
       '45000000-0000-4000-8000-000000000001',
       'c5000000-0000-4000-8000-000000000001',
-      'orders.send_batch',
       'd5000000-0000-4000-8000-000000000001',
       jsonb_build_object(
         'tableId', '65000000-0000-4000-8000-000000000001',
@@ -301,8 +331,7 @@ select is(
             )
           )
         )
-      ),
-      null
+      )
     ) ->> 'status'
   ),
   'applied',
@@ -357,12 +386,11 @@ select is(
 
 select is(
   (
-    public.apply_client_mutation(
+    public.apply_concurrent_order_batch(
       '25000000-0000-4000-8000-000000000001',
       '35000000-0000-4000-8000-000000000001',
       '45000000-0000-4000-8000-000000000001',
       'c5000000-0000-4000-8000-000000000001',
-      'orders.send_batch',
       'd5000000-0000-4000-8000-000000000001',
       jsonb_build_object(
         'tableId', '65000000-0000-4000-8000-000000000001',
@@ -394,8 +422,7 @@ select is(
             )
           )
         )
-      ),
-      null
+      )
     ) ->> 'itemCount'
   ),
   '1',
@@ -453,6 +480,159 @@ select throws_ok(
   '22023',
   'order_item_cannot_be_cancelled',
   'a completed cancellation cannot be silently overwritten'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    public.apply_concurrent_order_batch(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000002',
+      'c5000000-0000-4000-8000-000000000011',
+      'd5000000-0000-4000-8000-000000000101',
+      jsonb_build_object(
+        'tableId', '65000000-0000-4000-8000-000000000001',
+        'session', jsonb_build_object(
+          'id', 'e5000000-0000-4000-8000-000000000101',
+          'openedAt', now()
+        ),
+        'check', jsonb_build_object(
+          'id', 'f5000000-0000-4000-8000-000000000101',
+          'name', 'Pencere tarafı',
+          'openedAt', now()
+        ),
+        'batch', jsonb_build_object(
+          'id', 'd5000000-0000-4000-8000-000000000101',
+          'createdAt', now()
+        ),
+        'items', jsonb_build_array(
+          jsonb_build_object(
+            'id', 'd5000000-0000-4000-8000-000000000111',
+            'menuItemId', '85000000-0000-4000-8000-000000000001',
+            'menuItemVersion', 1,
+            'quantity', 1,
+            'note', 'İkinci cihaz',
+            'modifierSelections', jsonb_build_array(
+              jsonb_build_object(
+                'id', 'd5000000-0000-4000-8000-000000000121',
+                'optionId', 'a5000000-0000-4000-8000-000000000001'
+              )
+            )
+          )
+        )
+      )
+    ) ->> 'status'
+  ),
+  'applied',
+  'a second offline waiter append is preserved'
+);
+select is(
+  (
+    select count(*)
+    from public.table_sessions
+    where table_id = '65000000-0000-4000-8000-000000000001'
+      and status in ('open', 'payment_pending')
+  ),
+  1::bigint,
+  'concurrent appends converge on one active table session'
+);
+select is(
+  (
+    select status
+    from public.table_sessions
+    where id = 'e5000000-0000-4000-8000-000000000101'
+  ),
+  'voided',
+  'the second device provisional session is explicitly reconciled'
+);
+select is(
+  (
+    select status
+    from public.checks
+    where id = 'f5000000-0000-4000-8000-000000000101'
+  ),
+  'voided',
+  'the duplicate provisional named check is explicitly reconciled'
+);
+select ok(
+  (
+    select
+      table_session_id = 'e5000000-0000-4000-8000-000000000001'
+      and check_id = 'f5000000-0000-4000-8000-000000000001'
+    from public.order_items
+    where id = 'd5000000-0000-4000-8000-000000000111'
+  ),
+  'the second waiter item points at the canonical session and check'
+);
+select is(
+  (
+    select count(*)
+    from public.list_active_session_participants(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      'e5000000-0000-4000-8000-000000000001',
+      now() - interval '1 minute'
+    )
+  ),
+  2::bigint,
+  'both recent waiter participants are visible'
+);
+select is(
+  (
+    public.apply_order_item_note_command(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000002',
+      'c5000000-0000-4000-8000-000000000012',
+      'd5000000-0000-4000-8000-000000000111',
+      '{"note":"İkinci garsonun notu"}',
+      1
+    ) ->> 'serverVersion'
+  ),
+  '2',
+  'a matching note base version updates the server item'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select throws_ok(
+  $$
+    select public.apply_order_item_note_command(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000013',
+      'd5000000-0000-4000-8000-000000000111',
+      '{"note":"Eski cihazın notu"}',
+      1
+    )
+  $$,
+  'P0001',
+  'version_conflict',
+  'a stale note edit is surfaced as a conflict instead of overwriting'
+);
+select is(
+  (
+    select note
+    from public.order_items
+    where id = 'd5000000-0000-4000-8000-000000000111'
+  ),
+  'İkinci garsonun notu',
+  'the winning note remains unchanged after the stale edit'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #21

## What changed
- serialize concurrent table appends and reconcile offline provisional sessions/checks onto the canonical active table session
- retain voided provisional records so every device converges without silent deletion
- track and display active waiter participants and waiter-attributed incoming items
- add optimistic order-note editing with durable structured conflicts and explicit cloud/local resolution
- route batch and note commands through purpose-built idempotent Supabase RPCs
- extend unit and pgTAP coverage for concurrent append, attribution, idempotency, and stale note protection

## Validation
- `npm run verify:full`
- 26 Jest suites / 154 tests / 1 snapshot
- Expo web production export
- 2 Chromium Playwright flows
- pgTAP and Supabase lint run in CI (local Docker unavailable)

## Stack
- base: `feat/20-rapid-table-workspace` (#48)