### PR TITLE
feat(payments): add split, partial and mixed payments

### DIFF
--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -10,7 +10,12 @@ import React, {
 } from 'react';
 import { AppState, Platform } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
-import { BranchId, OrganizationId, toDomainId } from '../../domain';
+import { BranchId, DeviceId, MutationId, OrganizationId, toDomainId } from '../../domain';
+import {
+  ConfirmCheckPaymentsCommand,
+  ConfirmCheckPaymentsResult,
+  SupabasePaymentGateway,
+} from '../../features/payments';
 import { ActiveSessionParticipantRow, Database, getSupabaseClient } from '../../services/supabase';
 import { LocalDatabase, RepositoryScope } from '../contracts';
 import {
@@ -42,6 +47,11 @@ export interface OrderiaDataContextValue {
   resolveActiveParticipants(
     tableSessionId: string,
   ): Promise<readonly ActiveSessionParticipantRow[]>;
+  confirmCheckPayments(
+    deviceId: DeviceId,
+    clientMutationId: MutationId,
+    command: ConfirmCheckPaymentsCommand,
+  ): Promise<ConfirmCheckPaymentsResult>;
 }
 
 interface OrderiaDataProviderProps {
@@ -223,6 +233,25 @@ export function OrderiaDataProvider({
     [client, scope],
   );
 
+  const confirmCheckPayments = useCallback(
+    async (
+      deviceId: DeviceId,
+      clientMutationId: MutationId,
+      command: ConfirmCheckPaymentsCommand,
+    ): Promise<ConfirmCheckPaymentsResult> => {
+      if (!client || !scope) throw new Error('Cloud payment service is unavailable');
+      const result = await new SupabasePaymentGateway(client).confirm({
+        ...scope,
+        deviceId,
+        clientMutationId,
+        command,
+      });
+      await refresh();
+      return result;
+    },
+    [client, refresh, scope],
+  );
+
   useEffect(() => {
     if (!database || !scope || !client) return;
 
@@ -313,9 +342,11 @@ export function OrderiaDataProvider({
       refresh,
       resolveProfileNames,
       resolveActiveParticipants,
+      confirmCheckPayments,
     }),
     [
       client,
+      confirmCheckPayments,
       database,
       errorMessage,
       lastSuccessfulSyncAt,

--- a/src/features/payments/PaymentSheet.tsx
+++ b/src/features/payments/PaymentSheet.tsx
@@ -1,0 +1,733 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceButton, ServiceSurface, ServiceTextField } from '../../design-system';
+import { Check, OrderItem, OrderItemModifier, Payment, PaymentAllocation } from '../../domain';
+import { Language } from '../../i18n';
+import {
+  ConfirmCheckPaymentsCommand,
+  PaymentSelection,
+  PaymentSelectionMode,
+  buildConfirmCheckPaymentsCommand,
+  buildPayableOrderItems,
+  splitMinorEqually,
+} from './paymentPlanner';
+
+type TenderMode = 'cash' | 'card' | 'mixed';
+
+export interface PaymentSheetProps {
+  readonly visible: boolean;
+  readonly check: Check;
+  readonly orderItems: readonly OrderItem[];
+  readonly modifiers: readonly OrderItemModifier[];
+  readonly payments: readonly Payment[];
+  readonly allocations: readonly PaymentAllocation[];
+  readonly language: Language;
+  readonly online: boolean;
+  readonly busy: boolean;
+  readonly onClose: () => void;
+  readonly onConfirm: (command: ConfirmCheckPaymentsCommand) => Promise<void>;
+}
+
+export function PaymentSheet({
+  visible,
+  check,
+  orderItems,
+  modifiers,
+  payments,
+  allocations,
+  language,
+  online,
+  busy,
+  onClose,
+  onConfirm,
+}: PaymentSheetProps) {
+  const { tokens } = useTheme();
+  const copy = paymentCopy(language);
+  const payable = useMemo(
+    () => buildPayableOrderItems(check, orderItems, modifiers, payments, allocations),
+    [allocations, check, modifiers, orderItems, payments],
+  );
+  const currencyCode =
+    orderItems.find((item) => item.checkId === check.id && item.status !== 'cancelled')
+      ?.currencyCode ?? ('EUR' as never);
+  const [selectionMode, setSelectionMode] = useState<PaymentSelectionMode>('amount');
+  const [tenderMode, setTenderMode] = useState<TenderMode>('card');
+  const [amountInput, setAmountInput] = useState('');
+  const [cashAmountInput, setCashAmountInput] = useState('');
+  const [tenderedInput, setTenderedInput] = useState('');
+  const [partCount, setPartCount] = useState(2);
+  const [itemQuantities, setItemQuantities] = useState<Readonly<Record<string, number>>>({});
+  const [reviewing, setReviewing] = useState(false);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!visible) return;
+    const remaining = minorToInput(payable.balance.remainingMinor);
+    setSelectionMode('amount');
+    setTenderMode('card');
+    setAmountInput(remaining);
+    setCashAmountInput('');
+    setTenderedInput(remaining);
+    setPartCount(2);
+    setItemQuantities({});
+    setReviewing(false);
+    setError(undefined);
+  }, [check.id, payable.balance.remainingMinor, visible]);
+
+  const selections = useMemo<readonly PaymentSelection[]>(() => {
+    if (selectionMode === 'amount') {
+      const amountMinor = inputToMinor(amountInput);
+      return amountMinor > 0 ? [{ checkId: check.id, amountMinor }] : [];
+    }
+    if (selectionMode === 'equal') {
+      const amountMinor = splitMinorEqually(payable.balance.remainingMinor, partCount)[0];
+      return [{ checkId: check.id, amountMinor }];
+    }
+    return payable.items.flatMap<PaymentSelection>((option) => {
+      const quantity = itemQuantities[option.item.id] ?? 0;
+      if (quantity <= 0) return [];
+      return [
+        {
+          checkId: check.id,
+          orderItemId: option.item.id,
+          quantity,
+          amountMinor: option.unitTotalMinor * quantity,
+        },
+      ];
+    });
+  }, [
+    amountInput,
+    check.id,
+    itemQuantities,
+    partCount,
+    payable.balance.remainingMinor,
+    payable.items,
+    selectionMode,
+  ]);
+  const selectedMinor = selections.reduce((total, selection) => total + selection.amountMinor, 0);
+  const mixedCashMinor = inputToMinor(cashAmountInput);
+  const cashPaymentMinor = tenderMode === 'mixed' ? mixedCashMinor : selectedMinor;
+  const tenderedMinor = inputToMinor(tenderedInput);
+  const changeMinor = tenderMode === 'card' ? 0 : Math.max(0, tenderedMinor - cashPaymentMinor);
+  const canReview =
+    online &&
+    selectedMinor > 0 &&
+    selectedMinor <= payable.balance.remainingMinor &&
+    (tenderMode !== 'mixed' || (mixedCashMinor > 0 && mixedCashMinor < selectedMinor)) &&
+    (tenderMode === 'card' || tenderedMinor >= cashPaymentMinor);
+
+  const changeItemQuantity = (itemId: string, delta: number, maximum: number) => {
+    setItemQuantities((current) => {
+      const next = Math.max(0, Math.min(maximum, (current[itemId] ?? 0) + delta));
+      return { ...current, [itemId]: next };
+    });
+    setReviewing(false);
+    setError(undefined);
+  };
+
+  const submit = async () => {
+    try {
+      setError(undefined);
+      const tenders =
+        tenderMode === 'mixed'
+          ? [
+              {
+                method: 'cash' as const,
+                amountMinor: mixedCashMinor,
+                tenderedMinor,
+              },
+              { method: 'card' as const, amountMinor: selectedMinor - mixedCashMinor },
+            ]
+          : tenderMode === 'cash'
+            ? [{ method: 'cash' as const, amountMinor: selectedMinor, tenderedMinor }]
+            : [{ method: 'card' as const, amountMinor: selectedMinor }];
+      await onConfirm(
+        buildConfirmCheckPaymentsCommand({
+          checkId: check.id,
+          expectedCheckVersion: check.serverVersion ?? check.version,
+          currencyCode,
+          selections,
+          tenders,
+        }),
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : copy.paymentFailed);
+      setReviewing(false);
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="pageSheet"
+      transparent
+      visible={visible}
+    >
+      <View
+        style={{
+          backgroundColor: tokens.colors.overlay,
+          flex: 1,
+          justifyContent: 'flex-end',
+        }}
+      >
+        <View
+          style={{
+            alignSelf: 'center',
+            backgroundColor: tokens.colors.bg,
+            borderTopLeftRadius: tokens.radius.large,
+            borderTopRightRadius: tokens.radius.large,
+            maxHeight: '94%',
+            maxWidth: 760,
+            padding: tokens.space.lg,
+            width: '100%',
+          }}
+        >
+          <View
+            style={{
+              alignItems: 'center',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              marginBottom: tokens.space.md,
+            }}
+          >
+            <View style={{ flex: 1 }}>
+              <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+                {reviewing ? copy.reviewPayment : copy.takePayment}
+              </Text>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {check.name} · {copy.remaining}{' '}
+                {formatMoney(payable.balance.remainingMinor, currencyCode, language)}
+              </Text>
+            </View>
+            <Pressable
+              accessibilityLabel={copy.close}
+              accessibilityRole="button"
+              disabled={busy}
+              hitSlop={8}
+              onPress={onClose}
+              style={{ padding: tokens.space.sm }}
+            >
+              <Ionicons color={tokens.colors.text} name="close" size={26} />
+            </Pressable>
+          </View>
+
+          {!online ? (
+            <ServiceSurface
+              style={{
+                backgroundColor: tokens.colors.state.pending.bg,
+                marginBottom: tokens.space.md,
+                padding: tokens.space.md,
+              }}
+            >
+              <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.warning }]}>
+                {copy.onlineRequired}
+              </Text>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {copy.onlineRequiredDetail}
+              </Text>
+            </ServiceSurface>
+          ) : null}
+
+          <ScrollView
+            contentContainerStyle={{ gap: tokens.space.md, paddingBottom: tokens.space.lg }}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            {!reviewing ? (
+              <>
+                <SegmentedRow
+                  options={[
+                    ['amount', copy.amount],
+                    ['items', copy.items],
+                    ['equal', copy.equal],
+                  ]}
+                  selected={selectionMode}
+                  onSelect={(mode) => {
+                    setSelectionMode(mode);
+                    setError(undefined);
+                  }}
+                />
+
+                {selectionMode === 'amount' ? (
+                  <ServiceTextField
+                    keyboardType="decimal-pad"
+                    label={copy.paymentAmount}
+                    onChangeText={(value) => {
+                      setAmountInput(value);
+                      setError(undefined);
+                    }}
+                    value={amountInput}
+                  />
+                ) : null}
+
+                {selectionMode === 'equal' ? (
+                  <ServiceSurface style={{ gap: tokens.space.sm, padding: tokens.space.md }}>
+                    <Text style={[tokens.typography.label, { color: tokens.colors.text }]}>
+                      {copy.people}
+                    </Text>
+                    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+                      {[2, 3, 4, 5, 6, 8].map((count) => (
+                        <ChoiceChip
+                          key={count}
+                          label={String(count)}
+                          selected={partCount === count}
+                          onPress={() => setPartCount(count)}
+                        />
+                      ))}
+                    </View>
+                    <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.primary }]}>
+                      {copy.oneShare}{' '}
+                      {formatMoney(
+                        splitMinorEqually(payable.balance.remainingMinor, partCount)[0],
+                        currencyCode,
+                        language,
+                      )}
+                    </Text>
+                  </ServiceSurface>
+                ) : null}
+
+                {selectionMode === 'items' ? (
+                  <View style={{ gap: tokens.space.sm }}>
+                    {payable.items.map((option) => {
+                      const selected = itemQuantities[option.item.id] ?? 0;
+                      return (
+                        <ServiceSurface
+                          key={option.item.id}
+                          style={{
+                            alignItems: 'center',
+                            flexDirection: 'row',
+                            gap: tokens.space.md,
+                            padding: tokens.space.md,
+                          }}
+                        >
+                          <View style={{ flex: 1 }}>
+                            <Text
+                              numberOfLines={2}
+                              style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}
+                            >
+                              {option.item.nameSnapshot}
+                            </Text>
+                            <Text
+                              style={[
+                                tokens.typography.caption,
+                                { color: tokens.colors.textSubtle },
+                              ]}
+                            >
+                              {formatMoney(option.unitTotalMinor, currencyCode, language)} ·{' '}
+                              {copy.available} {option.remainingQuantity}
+                            </Text>
+                          </View>
+                          <QuantityPicker
+                            maximum={option.remainingQuantity}
+                            value={selected}
+                            onChange={(delta) =>
+                              changeItemQuantity(option.item.id, delta, option.remainingQuantity)
+                            }
+                          />
+                        </ServiceSurface>
+                      );
+                    })}
+                  </View>
+                ) : null}
+
+                <ServiceSurface style={{ gap: tokens.space.sm, padding: tokens.space.md }}>
+                  <Text style={[tokens.typography.label, { color: tokens.colors.text }]}>
+                    {copy.method}
+                  </Text>
+                  <SegmentedRow
+                    options={[
+                      ['card', copy.card],
+                      ['cash', copy.cash],
+                      ['mixed', copy.mixed],
+                    ]}
+                    selected={tenderMode}
+                    onSelect={(mode) => {
+                      setTenderMode(mode);
+                      const selectedInput = minorToInput(selectedMinor);
+                      setTenderedInput(selectedInput);
+                      if (mode === 'mixed' && !cashAmountInput) {
+                        const half = minorToInput(Math.floor(selectedMinor / 2));
+                        setCashAmountInput(half);
+                        setTenderedInput(half);
+                      }
+                      setError(undefined);
+                    }}
+                  />
+                  {tenderMode === 'mixed' ? (
+                    <ServiceTextField
+                      keyboardType="decimal-pad"
+                      label={copy.cashPart}
+                      onChangeText={setCashAmountInput}
+                      value={cashAmountInput}
+                    />
+                  ) : null}
+                  {tenderMode !== 'card' ? (
+                    <ServiceTextField
+                      helperText={`${copy.change}: ${formatMoney(
+                        changeMinor,
+                        currencyCode,
+                        language,
+                      )}`}
+                      keyboardType="decimal-pad"
+                      label={copy.cashReceived}
+                      onChangeText={setTenderedInput}
+                      value={tenderedInput}
+                    />
+                  ) : null}
+                </ServiceSurface>
+              </>
+            ) : (
+              <ServiceSurface style={{ gap: tokens.space.md, padding: tokens.space.lg }}>
+                <ReviewLine label={copy.check} value={check.name} />
+                <ReviewLine
+                  label={copy.selected}
+                  value={formatMoney(selectedMinor, currencyCode, language)}
+                />
+                <ReviewLine
+                  label={copy.method}
+                  value={
+                    tenderMode === 'mixed'
+                      ? `${copy.cash} + ${copy.card}`
+                      : tenderMode === 'cash'
+                        ? copy.cash
+                        : copy.card
+                  }
+                />
+                {tenderMode !== 'card' ? (
+                  <ReviewLine
+                    label={copy.change}
+                    value={formatMoney(changeMinor, currencyCode, language)}
+                  />
+                ) : null}
+                <View style={{ height: 1, backgroundColor: tokens.colors.border }} />
+                <ReviewLine
+                  emphasis
+                  label={copy.afterPayment}
+                  value={formatMoney(
+                    payable.balance.remainingMinor - selectedMinor,
+                    currencyCode,
+                    language,
+                  )}
+                />
+                <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                  {copy.serverNotice}
+                </Text>
+              </ServiceSurface>
+            )}
+
+            {selectedMinor > payable.balance.remainingMinor ? (
+              <Text style={[tokens.typography.caption, { color: tokens.colors.error }]}>
+                {copy.exceedsRemaining}
+              </Text>
+            ) : null}
+            {error ? (
+              <Text
+                accessibilityLiveRegion="assertive"
+                style={[tokens.typography.caption, { color: tokens.colors.error }]}
+              >
+                {error}
+              </Text>
+            ) : null}
+          </ScrollView>
+
+          <View style={{ flexDirection: 'row', gap: tokens.space.sm }}>
+            <ServiceButton
+              disabled={busy}
+              label={reviewing ? copy.back : copy.close}
+              onPress={() => (reviewing ? setReviewing(false) : onClose())}
+              style={{ flex: 1 }}
+              variant="ghost"
+            />
+            <ServiceButton
+              disabled={busy || (!reviewing && !canReview)}
+              label={reviewing ? copy.confirmPayment : copy.reviewPayment}
+              loading={busy}
+              onPress={() => (reviewing ? void submit() : setReviewing(true))}
+              style={{ flex: 2 }}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function SegmentedRow<Value extends string>({
+  options,
+  selected,
+  onSelect,
+}: {
+  readonly options: readonly (readonly [Value, string])[];
+  readonly selected: Value;
+  readonly onSelect: (value: Value) => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View
+      style={{
+        backgroundColor: tokens.colors.surfaceAlt,
+        borderRadius: tokens.radius.medium,
+        flexDirection: 'row',
+        gap: tokens.space.xs,
+        padding: tokens.space.xs,
+      }}
+    >
+      {options.map(([value, label]) => (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityState={{ selected: selected === value }}
+          key={value}
+          onPress={() => onSelect(value)}
+          style={{
+            alignItems: 'center',
+            backgroundColor: selected === value ? tokens.colors.surface : 'transparent',
+            borderRadius: tokens.radius.small,
+            flex: 1,
+            minHeight: tokens.sizing.minimumTarget,
+            justifyContent: 'center',
+            paddingHorizontal: tokens.space.sm,
+            paddingVertical: tokens.space.sm,
+          }}
+        >
+          <Text
+            style={[
+              tokens.typography.label,
+              { color: selected === value ? tokens.colors.primary : tokens.colors.textSubtle },
+            ]}
+          >
+            {label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+function ChoiceChip({
+  label,
+  selected,
+  onPress,
+}: {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onPress: () => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected }}
+      onPress={onPress}
+      style={{
+        alignItems: 'center',
+        backgroundColor: selected ? tokens.colors.primary : tokens.colors.surfaceAlt,
+        borderRadius: tokens.radius.full,
+        minHeight: tokens.sizing.minimumTarget,
+        minWidth: tokens.sizing.minimumTarget,
+        justifyContent: 'center',
+        paddingHorizontal: tokens.space.md,
+      }}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: selected ? tokens.colors.primaryContrast : tokens.colors.text },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function QuantityPicker({
+  value,
+  maximum,
+  onChange,
+}: {
+  readonly value: number;
+  readonly maximum: number;
+  readonly onChange: (delta: number) => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ alignItems: 'center', flexDirection: 'row', gap: tokens.space.xs }}>
+      <ChoiceChip label="−" selected={false} onPress={() => onChange(-1)} />
+      <Text
+        style={[
+          tokens.typography.bodyStrong,
+          { color: tokens.colors.text, minWidth: 24, textAlign: 'center' },
+        ]}
+      >
+        {value}
+      </Text>
+      <Pressable
+        accessibilityLabel="+"
+        accessibilityRole="button"
+        disabled={value >= maximum}
+        onPress={() => onChange(1)}
+        style={{
+          alignItems: 'center',
+          backgroundColor: tokens.colors.primary,
+          borderRadius: tokens.radius.full,
+          minHeight: tokens.sizing.minimumTarget,
+          minWidth: tokens.sizing.minimumTarget,
+          justifyContent: 'center',
+          opacity: value >= maximum ? 0.4 : 1,
+        }}
+      >
+        <Text style={[tokens.typography.label, { color: tokens.colors.primaryContrast }]}>+</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+function ReviewLine({
+  label,
+  value,
+  emphasis = false,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly emphasis?: boolean;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: tokens.space.md }}>
+      <Text
+        style={[
+          emphasis ? tokens.typography.bodyStrong : tokens.typography.body,
+          { color: tokens.colors.textSubtle },
+        ]}
+      >
+        {label}
+      </Text>
+      <Text
+        style={[
+          emphasis ? tokens.typography.subtitle : tokens.typography.bodyStrong,
+          { color: emphasis ? tokens.colors.primary : tokens.colors.text },
+        ]}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function inputToMinor(value: string): number {
+  const normalized = value.trim().replace(',', '.');
+  if (!/^\d+([.]\d{0,2})?$/.test(normalized)) return 0;
+  const [whole, fractional = ''] = normalized.split('.');
+  const amount = Number(whole) * 100 + Number(fractional.padEnd(2, '0'));
+  return Number.isSafeInteger(amount) ? amount : 0;
+}
+
+function minorToInput(value: number): string {
+  return (value / 100).toFixed(2);
+}
+
+function formatMoney(amountMinor: number, currencyCode: string, language: Language): string {
+  return new Intl.NumberFormat(
+    language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-US',
+    { style: 'currency', currency: currencyCode },
+  ).format(amountMinor / 100);
+}
+
+function paymentCopy(language: Language) {
+  const translations = {
+    tr: {
+      takePayment: 'Ödeme al',
+      reviewPayment: 'Ödemeyi gözden geçir',
+      close: 'Kapat',
+      remaining: 'Kalan',
+      onlineRequired: 'Ödeme için bağlantı gerekli',
+      onlineRequiredDetail: 'Çift tahsilatı önlemek için ödeme sunucuda kesinleştirilir.',
+      amount: 'Tutar',
+      items: 'Ürün / adet',
+      equal: 'Eşit böl',
+      paymentAmount: 'Ödenecek tutar',
+      people: 'Kişi sayısı',
+      oneShare: 'Bir pay:',
+      available: 'Kalan adet',
+      method: 'Yöntem',
+      card: 'Kart',
+      cash: 'Nakit',
+      mixed: 'Karışık',
+      cashPart: 'Nakit kısmı',
+      cashReceived: 'Alınan nakit',
+      change: 'Para üstü',
+      check: 'Hesap',
+      selected: 'Tahsil edilecek',
+      afterPayment: 'İşlem sonrası kalan',
+      serverNotice: 'Tutar sunucuda tekrar hesaplanır ve tek işlem olarak kesinleşir.',
+      exceedsRemaining: 'Seçilen tutar kalan hesaptan fazla.',
+      back: 'Geri',
+      confirmPayment: 'Ödemeyi kesinleştir',
+      paymentFailed: 'Ödeme kesinleştirilemedi.',
+    },
+    bg: {
+      takePayment: 'Плащане',
+      reviewPayment: 'Преглед на плащането',
+      close: 'Затвори',
+      remaining: 'Остава',
+      onlineRequired: 'Нужна е връзка',
+      onlineRequiredDetail: 'Плащането се потвърждава на сървъра, за да няма двойно плащане.',
+      amount: 'Сума',
+      items: 'Артикули',
+      equal: 'По равно',
+      paymentAmount: 'Сума за плащане',
+      people: 'Брой хора',
+      oneShare: 'Един дял:',
+      available: 'Оставащо количество',
+      method: 'Метод',
+      card: 'Карта',
+      cash: 'В брой',
+      mixed: 'Смесено',
+      cashPart: 'Част в брой',
+      cashReceived: 'Получени пари',
+      change: 'Ресто',
+      check: 'Сметка',
+      selected: 'За плащане',
+      afterPayment: 'Остава след плащане',
+      serverNotice: 'Сумата се преизчислява и потвърждава атомарно на сървъра.',
+      exceedsRemaining: 'Избраната сума е по-голяма от остатъка.',
+      back: 'Назад',
+      confirmPayment: 'Потвърди плащането',
+      paymentFailed: 'Плащането не бе потвърдено.',
+    },
+    en: {
+      takePayment: 'Take payment',
+      reviewPayment: 'Review payment',
+      close: 'Close',
+      remaining: 'Remaining',
+      onlineRequired: 'Connection required',
+      onlineRequiredDetail: 'Payments are confirmed on the server to prevent double charging.',
+      amount: 'Amount',
+      items: 'Items / qty',
+      equal: 'Equal split',
+      paymentAmount: 'Amount to pay',
+      people: 'Number of people',
+      oneShare: 'One share:',
+      available: 'Available quantity',
+      method: 'Method',
+      card: 'Card',
+      cash: 'Cash',
+      mixed: 'Mixed',
+      cashPart: 'Cash part',
+      cashReceived: 'Cash received',
+      change: 'Change',
+      check: 'Check',
+      selected: 'Charge now',
+      afterPayment: 'Remaining after payment',
+      serverNotice: 'The server recalculates and confirms the amount atomically.',
+      exceedsRemaining: 'The selected amount exceeds the remaining balance.',
+      back: 'Back',
+      confirmPayment: 'Confirm payment',
+      paymentFailed: 'Payment could not be confirmed.',
+    },
+  };
+  return translations[language] ?? translations.en;
+}

--- a/src/features/payments/__tests__/PaymentSheet.test.tsx
+++ b/src/features/payments/__tests__/PaymentSheet.test.tsx
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- Jest native component factories are hoisted. */
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { ThemeProvider } from '../../../contexts/ThemeContext';
+import { PaymentSheet } from '../PaymentSheet';
+
+jest.mock('react-native/Libraries/Components/ActivityIndicator/ActivityIndicator', () => ({
+  __esModule: true,
+  default: 'ActivityIndicator',
+}));
+jest.mock('react-native/Libraries/Modal/Modal', () => {
+  const ReactModule = require('react') as typeof React;
+  function MockModal({
+    children,
+    visible,
+  }: {
+    readonly children: React.ReactNode;
+    readonly visible: boolean;
+  }) {
+    return visible ? ReactModule.createElement('Modal', null, children) : null;
+  }
+  return { __esModule: true, default: MockModal };
+});
+jest.mock('react-native/Libraries/Components/ScrollView/ScrollView', () => {
+  const ReactModule = require('react') as typeof React;
+  function MockScrollView({ children }: { readonly children: React.ReactNode }) {
+    return ReactModule.createElement('ScrollView', null, children);
+  }
+  return { __esModule: true, default: MockScrollView };
+});
+
+describe('PaymentSheet', () => {
+  it('reviews and confirms the exact remaining amount with a 48px-first action flow', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    const screen = await render(
+      <ThemeProvider>
+        <PaymentSheet
+          allocations={[]}
+          busy={false}
+          check={check}
+          language="en"
+          modifiers={[]}
+          onClose={jest.fn()}
+          onConfirm={onConfirm}
+          online
+          orderItems={[item]}
+          payments={[]}
+          visible
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Take payment')).toBeTruthy();
+    expect(screen.getByText(/€10.00/)).toBeTruthy();
+    const review = screen.getByRole('button', { name: 'Review payment' });
+    expect(review.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ minHeight: 48 })]),
+    );
+
+    fireEvent.press(review);
+    expect(await screen.findByText('Remaining after payment')).toBeTruthy();
+    fireEvent.press(screen.getByRole('button', { name: 'Confirm payment' }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(onConfirm.mock.calls[0][0]).toMatchObject({
+      checkId: 'check-1',
+      expectedCheckVersion: 1,
+      payments: [{ method: 'card', amountMinor: 1_000 }],
+    });
+  });
+
+  it('blocks confirmation while offline', async () => {
+    const screen = await render(
+      <ThemeProvider>
+        <PaymentSheet
+          allocations={[]}
+          busy={false}
+          check={check}
+          language="en"
+          modifiers={[]}
+          onClose={jest.fn()}
+          onConfirm={jest.fn()}
+          online={false}
+          orderItems={[item]}
+          payments={[]}
+          visible
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Connection required')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Review payment' }).props.accessibilityState).toEqual(
+      {
+        busy: false,
+        disabled: true,
+      },
+    );
+  });
+});
+
+const common = {
+  organizationId: 'organization-1',
+  branchId: 'branch-1',
+  tableSessionId: 'session-1',
+} as const;
+
+const check = {
+  ...common,
+  id: 'check-1',
+  name: 'General',
+  status: 'open',
+  openedBy: 'waiter-1',
+  openedAt: '2026-07-26T10:00:00.000Z',
+  version: 1,
+  serverVersion: 1,
+  createdAt: '2026-07-26T10:00:00.000Z',
+  updatedAt: '2026-07-26T10:00:00.000Z',
+  syncStatus: 'synced',
+} as never;
+
+const item = {
+  ...common,
+  id: 'item-1',
+  checkId: 'check-1',
+  orderBatchId: 'batch-1',
+  nameSnapshot: 'Fries',
+  unitPriceMinor: 500,
+  currencyCode: 'EUR',
+  taxRateBasisPoints: 0,
+  quantity: 2,
+  status: 'ordered',
+  createdBy: 'waiter-1',
+  updatedBy: 'waiter-1',
+  originalTableId: 'table-1',
+  originalTableSessionId: 'session-1',
+  version: 1,
+  createdAt: '2026-07-26T10:00:00.000Z',
+  updatedAt: '2026-07-26T10:00:00.000Z',
+  syncStatus: 'synced',
+} as never;

--- a/src/features/payments/__tests__/paymentGateway.test.ts
+++ b/src/features/payments/__tests__/paymentGateway.test.ts
@@ -1,0 +1,86 @@
+import { BranchId, DeviceId, MutationId, OrganizationId, toDomainId } from '../../../domain';
+import { SupabasePaymentGateway } from '../paymentGateway';
+
+describe('SupabasePaymentGateway', () => {
+  it('returns the server-authoritative balance', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        status: 'confirmed',
+        checkId: 'check-1',
+        checkStatus: 'partially_paid',
+        checkVersion: 2,
+        totalMinor: 1_000,
+        paidMinor: 400,
+        remainingMinor: 600,
+        paymentIds: ['payment-1'],
+      },
+      error: null,
+    });
+    const gateway = new SupabasePaymentGateway({ rpc } as never);
+
+    await expect(
+      gateway.confirm({
+        organizationId: toDomainId<OrganizationId>('organization-1'),
+        branchId: toDomainId<BranchId>('branch-1'),
+        deviceId: toDomainId<DeviceId>('device-1'),
+        clientMutationId: toDomainId<MutationId>('mutation-1'),
+        command: {
+          checkId: 'check-1' as never,
+          expectedCheckVersion: 1,
+          currencyCode: 'EUR' as never,
+          payments: [
+            {
+              id: 'payment-1' as never,
+              method: 'cash',
+              amountMinor: 400,
+              tenderedMinor: 500,
+              allocations: [{ id: 'allocation-1' as never, amountMinor: 400 }],
+            },
+          ],
+        },
+      }),
+    ).resolves.toMatchObject({
+      checkVersion: 2,
+      paidMinor: 400,
+      remainingMinor: 600,
+    });
+    expect(rpc).toHaveBeenCalledWith(
+      'confirm_check_payments',
+      expect.objectContaining({
+        requested_client_mutation_id: 'mutation-1',
+        requested_device_id: 'device-1',
+      }),
+    );
+  });
+
+  it('does not hide a stale-check response', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: null,
+      error: {
+        code: 'P0001',
+        message: 'payment_check_version_conflict',
+        details: '{"serverVersion":2}',
+      },
+    });
+    const gateway = new SupabasePaymentGateway({ rpc } as never);
+
+    await expect(
+      gateway.confirm({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        deviceId: 'device-1' as never,
+        clientMutationId: 'mutation-1' as never,
+        command: {
+          checkId: 'check-1' as never,
+          expectedCheckVersion: 1,
+          currencyCode: 'EUR' as never,
+          payments: [],
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'PaymentCommandError',
+      message: 'payment_check_version_conflict',
+      code: 'P0001',
+    });
+  });
+});

--- a/src/features/payments/__tests__/paymentPlanner.test.ts
+++ b/src/features/payments/__tests__/paymentPlanner.test.ts
@@ -1,0 +1,168 @@
+import { CheckId, CurrencyCode, OrderItemId, toDomainId } from '../../../domain';
+import {
+  buildPayableOrderItems,
+  buildConfirmCheckPaymentsCommand,
+  splitMinorEqually,
+} from '../paymentPlanner';
+
+const checkId = toDomainId<CheckId>('check-1');
+const currencyCode = 'EUR' as CurrencyCode;
+
+describe('payment planner', () => {
+  it('distributes remainder pennies without losing the total', () => {
+    expect(splitMinorEqually(1_001, 3)).toEqual([334, 334, 333]);
+    expect(splitMinorEqually(1_001, 3).reduce((total, part) => total + part, 0)).toBe(1_001);
+  });
+
+  it('keeps full item quantities when a tender consumes the whole item selection', () => {
+    const command = buildConfirmCheckPaymentsCommand({
+      checkId,
+      expectedCheckVersion: 3,
+      currencyCode,
+      selections: [
+        {
+          checkId,
+          orderItemId: toDomainId<OrderItemId>('item-1'),
+          quantity: 2,
+          amountMinor: 800,
+        },
+      ],
+      tenders: [{ method: 'card', amountMinor: 800 }],
+      createUuid: uuidSequence(),
+    });
+
+    expect(command.payments).toHaveLength(1);
+    expect(command.payments[0]).toMatchObject({
+      method: 'card',
+      amountMinor: 800,
+      allocations: [{ orderItemId: 'item-1', quantity: 2, amountMinor: 800 }],
+    });
+  });
+
+  it('atomically divides a selection across cash and card without inventing quantity', () => {
+    const command = buildConfirmCheckPaymentsCommand({
+      checkId,
+      expectedCheckVersion: 1,
+      currencyCode,
+      selections: [
+        {
+          checkId,
+          orderItemId: toDomainId<OrderItemId>('item-1'),
+          quantity: 2,
+          amountMinor: 1_000,
+        },
+      ],
+      tenders: [
+        { method: 'cash', amountMinor: 400, tenderedMinor: 500 },
+        { method: 'card', amountMinor: 600 },
+      ],
+      createUuid: uuidSequence(),
+    });
+
+    expect(command.payments.map((payment) => payment.amountMinor)).toEqual([400, 600]);
+    expect(command.payments[0].allocations[0]).toMatchObject({
+      orderItemId: 'item-1',
+      amountMinor: 400,
+    });
+    expect(command.payments[0].allocations[0].quantity).toBeUndefined();
+    expect(command.payments[1].allocations[0]).toMatchObject({
+      orderItemId: 'item-1',
+      amountMinor: 600,
+    });
+    expect(command.payments[1].allocations[0].quantity).toBeUndefined();
+  });
+
+  it('rejects tender totals that do not reconcile with the selection', () => {
+    expect(() =>
+      buildConfirmCheckPaymentsCommand({
+        checkId,
+        expectedCheckVersion: 1,
+        currencyCode,
+        selections: [{ checkId, amountMinor: 500 }],
+        tenders: [{ method: 'card', amountMinor: 499 }],
+      }),
+    ).toThrow(/must equal/);
+  });
+
+  it('keeps quantity mode inside the amount left by previous item payments', () => {
+    const base = {
+      organizationId: 'organization-1',
+      branchId: 'branch-1',
+      tableSessionId: 'session-1',
+    } as const;
+    const itemId = toDomainId<OrderItemId>('item-1');
+    const paymentId = 'payment-1' as never;
+    const item = {
+      ...base,
+      id: itemId,
+      checkId,
+      orderBatchId: 'batch-1',
+      nameSnapshot: 'Fries',
+      unitPriceMinor: 400,
+      currencyCode,
+      taxRateBasisPoints: 0,
+      quantity: 2,
+      status: 'ordered',
+      createdBy: 'waiter-1',
+      updatedBy: 'waiter-1',
+      originalTableId: 'table-1',
+      originalTableSessionId: 'session-1',
+      version: 1,
+      createdAt: '2026-07-26T10:00:00.000Z',
+      updatedAt: '2026-07-26T10:00:00.000Z',
+      syncStatus: 'synced',
+    } as never;
+    const payment = {
+      ...base,
+      id: paymentId,
+      method: 'card',
+      status: 'confirmed',
+      amountMinor: 500,
+      currencyCode,
+      createdBy: 'waiter-1',
+      createdAt: '2026-07-26T10:01:00.000Z',
+      confirmedAt: '2026-07-26T10:01:00.000Z',
+      idempotencyKey: 'payment-1',
+      deviceId: 'device-1',
+      syncStatus: 'synced',
+    } as never;
+    const result = buildPayableOrderItems(
+      {
+        ...base,
+        id: checkId,
+        name: 'General',
+        status: 'partially_paid',
+        openedBy: 'waiter-1',
+        openedAt: '2026-07-26T10:00:00.000Z',
+        version: 2,
+        createdAt: '2026-07-26T10:00:00.000Z',
+        updatedAt: '2026-07-26T10:01:00.000Z',
+        syncStatus: 'synced',
+      } as never,
+      [item],
+      [],
+      [payment],
+      [
+        {
+          id: 'allocation-1',
+          paymentId,
+          checkId,
+          orderItemId: itemId,
+          amountMinor: 500,
+        } as never,
+      ],
+    );
+
+    expect(result.balance).toEqual({ totalMinor: 800, paidMinor: 500, remainingMinor: 300 });
+    expect(result.items[0]).toMatchObject({
+      unitTotalMinor: 400,
+      remainingQuantity: 0,
+      remainingMinor: 300,
+    });
+  });
+});
+
+function uuidSequence(): () => string {
+  let index = 0;
+  return () => `00000000-0000-4000-8000-${String(++index).padStart(12, '0')}`;
+}

--- a/src/features/payments/index.ts
+++ b/src/features/payments/index.ts
@@ -1,0 +1,3 @@
+export * from './PaymentSheet';
+export * from './paymentGateway';
+export * from './paymentPlanner';

--- a/src/features/payments/paymentGateway.ts
+++ b/src/features/payments/paymentGateway.ts
@@ -1,0 +1,88 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { BranchId, DeviceId, MutationId, OrganizationId } from '../../domain';
+import { Database, Json } from '../../services/supabase';
+import { ConfirmCheckPaymentsCommand } from './paymentPlanner';
+
+export interface ConfirmCheckPaymentsRequest {
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly deviceId: DeviceId;
+  readonly clientMutationId: MutationId;
+  readonly command: ConfirmCheckPaymentsCommand;
+}
+
+export interface ConfirmCheckPaymentsResult {
+  readonly status: 'confirmed';
+  readonly checkId: string;
+  readonly checkStatus: 'partially_paid' | 'paid';
+  readonly checkVersion: number;
+  readonly totalMinor: number;
+  readonly paidMinor: number;
+  readonly remainingMinor: number;
+  readonly paymentIds: readonly string[];
+}
+
+export class PaymentCommandError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+    readonly details?: string,
+  ) {
+    super(message);
+    this.name = 'PaymentCommandError';
+  }
+}
+
+export class SupabasePaymentGateway {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async confirm(request: ConfirmCheckPaymentsRequest): Promise<ConfirmCheckPaymentsResult> {
+    const { data, error } = await this.client.rpc('confirm_check_payments', {
+      requested_organization_id: request.organizationId,
+      requested_branch_id: request.branchId,
+      requested_device_id: request.deviceId,
+      requested_client_mutation_id: request.clientMutationId,
+      requested_payload: request.command as unknown as Json,
+    });
+    if (error) {
+      throw new PaymentCommandError(error.message, error.code, error.details);
+    }
+    return parseResult(data);
+  }
+}
+
+function parseResult(value: Json): ConfirmCheckPaymentsResult {
+  if (!isRecord(value)) throw new Error('Payment RPC returned a non-object result');
+  const paymentIds = value.paymentIds;
+  if (
+    value.status !== 'confirmed' ||
+    typeof value.checkId !== 'string' ||
+    (value.checkStatus !== 'partially_paid' && value.checkStatus !== 'paid') ||
+    !isSafeInteger(value.checkVersion) ||
+    !isSafeInteger(value.totalMinor) ||
+    !isSafeInteger(value.paidMinor) ||
+    !isSafeInteger(value.remainingMinor) ||
+    !Array.isArray(paymentIds) ||
+    !paymentIds.every((id) => typeof id === 'string')
+  ) {
+    throw new Error('Payment RPC returned an invalid result');
+  }
+  return {
+    status: value.status,
+    checkId: value.checkId,
+    checkStatus: value.checkStatus,
+    checkVersion: value.checkVersion,
+    totalMinor: value.totalMinor,
+    paidMinor: value.paidMinor,
+    remainingMinor: value.remainingMinor,
+    paymentIds,
+  };
+}
+
+function isRecord(value: Json): value is { readonly [key: string]: Json | undefined } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSafeInteger(value: Json | undefined): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value);
+}

--- a/src/features/payments/paymentPlanner.ts
+++ b/src/features/payments/paymentPlanner.ts
@@ -1,0 +1,261 @@
+import {
+  Check,
+  CheckId,
+  CurrencyCode,
+  OrderItem,
+  OrderItemId,
+  OrderItemModifier,
+  Payment,
+  PaymentAllocation,
+  PaymentAllocationId,
+  PaymentId,
+  calculateCheckBalance,
+  calculateOrderItemTotal,
+  toDomainId,
+} from '../../domain';
+
+export type PaymentSelectionMode = 'amount' | 'items' | 'equal';
+export type PaymentTenderMethod = 'cash' | 'card';
+
+export interface PaymentSelection {
+  readonly checkId: CheckId;
+  readonly orderItemId?: OrderItemId;
+  readonly quantity?: number;
+  readonly amountMinor: number;
+}
+
+export interface PaymentTenderDraft {
+  readonly method: PaymentTenderMethod;
+  readonly amountMinor: number;
+  readonly tenderedMinor?: number;
+}
+
+export interface ConfirmPaymentAllocationPayload {
+  readonly id: PaymentAllocationId;
+  readonly orderItemId?: OrderItemId;
+  readonly quantity?: number;
+  readonly amountMinor: number;
+}
+
+export interface ConfirmPaymentPayload {
+  readonly id: PaymentId;
+  readonly method: PaymentTenderMethod;
+  readonly amountMinor: number;
+  readonly tenderedMinor?: number;
+  readonly allocations: readonly ConfirmPaymentAllocationPayload[];
+}
+
+export interface ConfirmCheckPaymentsCommand {
+  readonly checkId: CheckId;
+  readonly expectedCheckVersion: number;
+  readonly currencyCode: CurrencyCode;
+  readonly payments: readonly ConfirmPaymentPayload[];
+}
+
+export interface BuildPaymentCommandInput {
+  readonly checkId: CheckId;
+  readonly expectedCheckVersion: number;
+  readonly currencyCode: CurrencyCode;
+  readonly selections: readonly PaymentSelection[];
+  readonly tenders: readonly PaymentTenderDraft[];
+  readonly createUuid?: () => string;
+}
+
+export interface PayableOrderItem {
+  readonly item: OrderItem;
+  readonly unitTotalMinor: number;
+  readonly remainingQuantity: number;
+  readonly remainingMinor: number;
+}
+
+export function buildPayableOrderItems(
+  check: Check,
+  items: readonly OrderItem[],
+  modifiers: readonly OrderItemModifier[],
+  payments: readonly Payment[],
+  allocations: readonly PaymentAllocation[],
+): {
+  readonly balance: ReturnType<typeof calculateCheckBalance>;
+  readonly items: readonly PayableOrderItem[];
+} {
+  const balance = calculateCheckBalance(check, items, modifiers, payments, allocations);
+  const confirmedIds = new Set(
+    payments.filter((payment) => payment.status === 'confirmed').map((payment) => payment.id),
+  );
+
+  return {
+    balance,
+    items: items
+      .filter((item) => item.checkId === check.id && item.status !== 'cancelled')
+      .map((item) => {
+        const totalMinor = calculateOrderItemTotal(item, modifiers);
+        const itemAllocations = allocations.filter(
+          (allocation) =>
+            allocation.orderItemId === item.id && confirmedIds.has(allocation.paymentId),
+        );
+        const paidMinor = itemAllocations.reduce(
+          (total, allocation) => safeAdd(total, allocation.amountMinor),
+          0,
+        );
+        const paidQuantity = itemAllocations.reduce(
+          (total, allocation) => total + (allocation.quantity ?? 0),
+          0,
+        );
+        const unitTotalMinor = totalMinor / item.quantity;
+        if (!Number.isSafeInteger(unitTotalMinor)) {
+          throw new Error(`order item ${item.id} does not have an integral unit total`);
+        }
+        const quantityByAmount = Math.floor((totalMinor - paidMinor) / unitTotalMinor);
+        return {
+          item,
+          unitTotalMinor,
+          remainingQuantity: Math.max(0, Math.min(item.quantity - paidQuantity, quantityByAmount)),
+          remainingMinor: totalMinor - paidMinor,
+        };
+      })
+      .filter((item) => item.remainingMinor > 0),
+  };
+}
+
+export function splitMinorEqually(totalMinor: number, partCount: number): readonly number[] {
+  assertPositiveMinor(totalMinor, 'split total');
+  if (!Number.isSafeInteger(partCount) || partCount < 2 || partCount > 100) {
+    throw new Error('part count must be an integer from 2 to 100');
+  }
+
+  const base = Math.floor(totalMinor / partCount);
+  const remainder = totalMinor % partCount;
+  return Array.from({ length: partCount }, (_, index) => base + (index < remainder ? 1 : 0));
+}
+
+export function buildConfirmCheckPaymentsCommand(
+  input: BuildPaymentCommandInput,
+): ConfirmCheckPaymentsCommand {
+  if (!Number.isSafeInteger(input.expectedCheckVersion) || input.expectedCheckVersion < 1) {
+    throw new Error('expected check version must be a positive safe integer');
+  }
+  if (input.selections.length === 0) {
+    throw new Error('at least one payment selection is required');
+  }
+  if (input.tenders.length === 0 || input.tenders.length > 2) {
+    throw new Error('one or two payment tenders are required');
+  }
+
+  input.selections.forEach((selection) => validateSelection(input.checkId, selection));
+  input.tenders.forEach(validateTender);
+
+  const selectionTotal = input.selections.reduce(
+    (total, selection) => safeAdd(total, selection.amountMinor),
+    0,
+  );
+  const tenderTotal = input.tenders.reduce(
+    (total, tender) => safeAdd(total, tender.amountMinor),
+    0,
+  );
+  if (selectionTotal !== tenderTotal) {
+    throw new Error('payment tenders must equal the selected amount');
+  }
+
+  const createUuid = input.createUuid ?? defaultUuid;
+  const remainingSelections = input.selections.map((selection) => ({
+    ...selection,
+    remainingMinor: selection.amountMinor,
+    wasSplit: false,
+  }));
+  let selectionIndex = 0;
+
+  const payments = input.tenders.map<ConfirmPaymentPayload>((tender) => {
+    let remainingTender = tender.amountMinor;
+    const allocations: ConfirmPaymentAllocationPayload[] = [];
+
+    while (remainingTender > 0) {
+      const selection = remainingSelections[selectionIndex];
+      if (!selection) {
+        throw new Error('payment allocation distribution exhausted unexpectedly');
+      }
+      const amountMinor = Math.min(remainingTender, selection.remainingMinor);
+      const consumesWholeSelection = amountMinor === selection.remainingMinor;
+      const preservesQuantity =
+        consumesWholeSelection && !selection.wasSplit && amountMinor === selection.amountMinor;
+      allocations.push({
+        id: toDomainId<PaymentAllocationId>(createUuid()),
+        ...(selection.orderItemId ? { orderItemId: selection.orderItemId } : {}),
+        ...(preservesQuantity && selection.quantity !== undefined
+          ? { quantity: selection.quantity }
+          : {}),
+        amountMinor,
+      });
+      if (!consumesWholeSelection) selection.wasSplit = true;
+      remainingTender -= amountMinor;
+      selection.remainingMinor -= amountMinor;
+      if (selection.remainingMinor === 0) selectionIndex += 1;
+    }
+
+    return {
+      id: toDomainId<PaymentId>(createUuid()),
+      method: tender.method,
+      amountMinor: tender.amountMinor,
+      ...(tender.tenderedMinor === undefined ? {} : { tenderedMinor: tender.tenderedMinor }),
+      allocations,
+    };
+  });
+
+  return {
+    checkId: input.checkId,
+    expectedCheckVersion: input.expectedCheckVersion,
+    currencyCode: input.currencyCode,
+    payments,
+  };
+}
+
+function validateSelection(checkId: CheckId, selection: PaymentSelection): void {
+  if (selection.checkId !== checkId) {
+    throw new Error('payment selection belongs to another check');
+  }
+  assertPositiveMinor(selection.amountMinor, 'selection amount');
+  if (selection.quantity !== undefined) {
+    if (!selection.orderItemId) {
+      throw new Error('selection quantity requires an order item');
+    }
+    if (!Number.isSafeInteger(selection.quantity) || selection.quantity <= 0) {
+      throw new Error('selection quantity must be a positive safe integer');
+    }
+  }
+}
+
+function validateTender(tender: PaymentTenderDraft): void {
+  assertPositiveMinor(tender.amountMinor, 'tender amount');
+  if (tender.method === 'cash') {
+    if (
+      tender.tenderedMinor === undefined ||
+      !Number.isSafeInteger(tender.tenderedMinor) ||
+      tender.tenderedMinor < tender.amountMinor
+    ) {
+      throw new Error('cash tendered amount cannot be lower than the payment amount');
+    }
+    return;
+  }
+  if (tender.tenderedMinor !== undefined && tender.tenderedMinor !== tender.amountMinor) {
+    throw new Error('card tendered amount must equal the payment amount');
+  }
+}
+
+function assertPositiveMinor(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive safe integer`);
+  }
+}
+
+function safeAdd(left: number, right: number): number {
+  const total = left + right;
+  if (!Number.isSafeInteger(total)) {
+    throw new Error('payment total exceeds safe integer range');
+  }
+  return total;
+}
+
+function defaultUuid(): string {
+  const value = globalThis.crypto?.randomUUID?.();
+  if (!value) throw new Error('Secure UUID generation is unavailable');
+  return value;
+}

--- a/src/features/table-workspace/workspaceModel.ts
+++ b/src/features/table-workspace/workspaceModel.ts
@@ -7,6 +7,8 @@ import {
   ModifierOption,
   OrderItem,
   OrderItemModifier,
+  Payment,
+  PaymentAllocation,
   RestaurantTable,
   RestaurantTableId,
   TableSession,
@@ -34,6 +36,8 @@ export interface TableWorkspaceSnapshot {
   readonly checks: readonly Check[];
   readonly orderItems: readonly OrderItem[];
   readonly orderItemModifiers: readonly OrderItemModifier[];
+  readonly payments: readonly Payment[];
+  readonly paymentAllocations: readonly PaymentAllocation[];
   readonly categories: readonly MenuCategory[];
   readonly products: readonly WorkspaceProduct[];
   readonly cancellationReasons: readonly CancellationReason[];
@@ -51,6 +55,8 @@ export async function loadTableWorkspace(
     checks,
     orderItems,
     orderItemModifiers,
+    payments,
+    paymentAllocations,
     categories,
     menuItems,
     modifierGroups,
@@ -63,6 +69,8 @@ export async function loadTableWorkspace(
     loadAll(database, 'checks', scope),
     loadAll(database, 'orderItems', scope),
     loadAll(database, 'orderItemModifiers', scope),
+    loadAll(database, 'payments', scope),
+    loadAll(database, 'paymentAllocations', scope),
     loadAll(database, 'menuCategories', scope),
     loadAll(database, 'menuItems', scope),
     loadAll(database, 'modifierGroups', scope),
@@ -95,6 +103,10 @@ export async function loadTableWorkspace(
     .filter((item) => checkIds.has(item.checkId) && !item.deletedAt)
     .sort((left, right) => left.createdAt.localeCompare(right.createdAt));
   const itemIds = new Set(activeItems.map((item) => item.id));
+  const activePayments = session
+    ? payments.filter((payment) => payment.tableSessionId === session.id)
+    : [];
+  const paymentIds = new Set(activePayments.map((payment) => payment.id));
   const categoryById = new Map(
     categories
       .filter((category) => category.isActive && !category.deletedAt)
@@ -128,6 +140,10 @@ export async function loadTableWorkspace(
     checks: activeChecks,
     orderItems: activeItems,
     orderItemModifiers: orderItemModifiers.filter((modifier) => itemIds.has(modifier.orderItemId)),
+    payments: activePayments,
+    paymentAllocations: paymentAllocations.filter((allocation) =>
+      paymentIds.has(allocation.paymentId),
+    ),
     categories: [...categoryById.values()].sort(compareSortOrder),
     products,
     cancellationReasons: cancellationReasons

--- a/src/screens/TableDetailScreen.tsx
+++ b/src/screens/TableDetailScreen.tsx
@@ -32,6 +32,7 @@ import {
   CheckId,
   DeviceId,
   ModifierOptionId,
+  MutationId,
   OrderItem,
   RestaurantTableId,
   UserId,
@@ -50,6 +51,7 @@ import {
   resolveOrderItemNoteConflict,
   updateOrderItemNote,
 } from '../features/table-workspace';
+import { ConfirmCheckPaymentsCommand, PaymentSheet } from '../features/payments';
 import { Language, useLocalization } from '../i18n';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { createTextMatcher } from '../utils/searchUtils';
@@ -101,6 +103,7 @@ function CloudTableWorkspace({
   const layout = useAdaptiveLayout();
   const {
     database,
+    confirmCheckPayments,
     errorMessage: runtimeError,
     refresh,
     resolveActiveParticipants,
@@ -129,6 +132,8 @@ function CloudTableWorkspace({
   const [cancellingItem, setCancellingItem] = useState<OrderItem>();
   const [editingNoteItem, setEditingNoteItem] = useState<OrderItem>();
   const [editingNote, setEditingNote] = useState('');
+  const [payingCheck, setPayingCheck] = useState<Check>();
+  const [paymentBusy, setPaymentBusy] = useState(false);
   const [waiterNames, setWaiterNames] = useState<Readonly<Record<string, string>>>({});
   const [participantNames, setParticipantNames] = useState<readonly string[]>([]);
   const [incomingMessage, setIncomingMessage] = useState<string>();
@@ -224,8 +229,9 @@ function CloudTableWorkspace({
   }, [incomingMessage]);
 
   useEffect(() => {
-    if (!snapshot || selectedCheckId || pendingCheckName) return;
-    if (snapshot.checks[0]) setSelectedCheckId(snapshot.checks[0].id);
+    if (!snapshot || pendingCheckName) return;
+    if (selectedCheckId && snapshot.checks.some((check) => check.id === selectedCheckId)) return;
+    setSelectedCheckId(snapshot.checks[0]?.id);
   }, [pendingCheckName, selectedCheckId, snapshot]);
 
   const recentProductIds = useMemo(
@@ -431,6 +437,33 @@ function CloudTableWorkspace({
     }
   };
 
+  const confirmPayment = async (command: ConfirmCheckPaymentsCommand) => {
+    if (!payingCheck) return;
+    setPaymentBusy(true);
+    try {
+      const clientMutationId = toDomainId<MutationId>(secureUuid());
+      const result = await confirmCheckPayments(deviceId, clientMutationId, command);
+      setPayingCheck(undefined);
+      Alert.alert(
+        copy.paymentConfirmed,
+        `${copy.remaining}: ${formatMoney(result.remainingMinor, command.currencyCode, language)}`,
+      );
+      await reload();
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message === 'payment_check_version_conflict'
+          ? copy.paymentChanged
+          : error instanceof Error
+            ? error.message
+            : copy.tryAgain;
+      await refresh().catch(() => undefined);
+      await reload();
+      throw new Error(message);
+    } finally {
+      setPaymentBusy(false);
+    }
+  };
+
   const toggleFavorite = (productId: string) => {
     const next = favoriteIds.includes(productId)
       ? favoriteIds.filter((id) => id !== productId)
@@ -594,6 +627,9 @@ function CloudTableWorkspace({
               setEditingNote(item.note ?? '');
               setEditingNoteItem(item);
             }}
+            onPay={() => {
+              if (selectedCheck) setPayingCheck(selectedCheck);
+            }}
             onResolveConflict={resolveNoteConflict}
             waiterNames={waiterNames}
           />
@@ -687,6 +723,23 @@ function CloudTableWorkspace({
         onClose={() => setEditingNoteItem(undefined)}
         onConfirm={() => void saveItemNote()}
       />
+      {payingCheck ? (
+        <PaymentSheet
+          allocations={snapshot.paymentAllocations}
+          busy={paymentBusy}
+          check={payingCheck}
+          language={language}
+          modifiers={snapshot.orderItemModifiers}
+          onClose={() => {
+            if (!paymentBusy) setPayingCheck(undefined);
+          }}
+          onConfirm={confirmPayment}
+          online={sync.online}
+          orderItems={snapshot.orderItems.filter((item) => item.checkId === payingCheck.id)}
+          payments={snapshot.payments}
+          visible
+        />
+      ) : null}
 
       {runtimeError ? (
         <View
@@ -919,6 +972,7 @@ function OrderPane({
   currencyCode,
   onCancel,
   onEditNote,
+  onPay,
   onResolveConflict,
 }: {
   readonly checkName: string;
@@ -932,6 +986,7 @@ function OrderPane({
   readonly currencyCode: string;
   readonly onCancel: (item: OrderItem) => void;
   readonly onEditNote: (item: OrderItem) => void;
+  readonly onPay: () => void;
   readonly onResolveConflict: (
     item: OrderItem,
     conflict: TableWorkspaceSnapshot['conflicts'][number],
@@ -959,9 +1014,14 @@ function OrderPane({
             {items.length} {copy.lines}
           </Text>
         </View>
-        <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
-          {formatMoney(checkTotal, currencyCode, language)}
-        </Text>
+        <View style={{ alignItems: 'flex-end', gap: tokens.space.xs }}>
+          <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+            {formatMoney(checkTotal, currencyCode, language)}
+          </Text>
+          {items.some((item) => item.status !== 'cancelled') ? (
+            <ServiceButton icon="card-outline" label={copy.takePayment} onPress={onPay} />
+          ) : null}
+        </View>
       </View>
       {items.length === 0 ? (
         <ServiceEmptyState body={copy.tapProduct} icon="restaurant-outline" title={copy.noOrders} />
@@ -1658,6 +1718,12 @@ function formatMoney(amountMinor: number, currencyCode: string, language: Langua
   ).format(amountMinor / 100);
 }
 
+function secureUuid(): string {
+  const value = globalThis.crypto?.randomUUID?.();
+  if (!value) throw new Error('Secure UUID generation is unavailable');
+  return value;
+}
+
 function timeOnly(timestamp: string, language: Language): string {
   return new Intl.DateTimeFormat(
     language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-GB',
@@ -1731,6 +1797,11 @@ interface WorkspaceCopy {
   readonly useCloudNote: string;
   readonly keepMyNote: string;
   readonly conflictFailed: string;
+  readonly takePayment: string;
+  readonly paymentConfirmed: string;
+  readonly paymentFailed: string;
+  readonly paymentChanged: string;
+  readonly remaining: string;
 }
 
 function workspaceCopy(language: Language): WorkspaceCopy {
@@ -1792,6 +1863,11 @@ function workspaceCopy(language: Language): WorkspaceCopy {
       useCloudNote: 'Buluttakini kullan',
       keepMyNote: 'Benim notumu uygula',
       conflictFailed: 'Çakışma çözülemedi',
+      takePayment: 'Ödeme al',
+      paymentConfirmed: 'Ödeme kesinleşti',
+      paymentFailed: 'Ödeme kesinleştirilemedi',
+      paymentChanged: 'Hesap başka bir cihazda değişti. Güncel kalan tutarı kontrol edin.',
+      remaining: 'Kalan',
     };
   }
   if (language === 'bg') {
@@ -1852,6 +1928,11 @@ function workspaceCopy(language: Language): WorkspaceCopy {
       useCloudNote: 'Използвай облачната',
       keepMyNote: 'Запази моята',
       conflictFailed: 'Конфликтът не е разрешен',
+      takePayment: 'Плащане',
+      paymentConfirmed: 'Плащането е потвърдено',
+      paymentFailed: 'Плащането не бе потвърдено',
+      paymentChanged: 'Сметката е променена на друго устройство. Проверете остатъка.',
+      remaining: 'Остава',
     };
   }
   return {
@@ -1911,5 +1992,10 @@ function workspaceCopy(language: Language): WorkspaceCopy {
     useCloudNote: 'Use cloud note',
     keepMyNote: 'Keep my note',
     conflictFailed: 'Conflict could not be resolved',
+    takePayment: 'Take payment',
+    paymentConfirmed: 'Payment confirmed',
+    paymentFailed: 'Payment could not be confirmed',
+    paymentChanged: 'The check changed on another device. Review the current balance.',
+    remaining: 'Remaining',
   };
 }

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -169,6 +169,16 @@ export type Database = {
         };
         Returns: Json;
       };
+      confirm_check_payments: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_device_id: string;
+          requested_client_mutation_id: string;
+          requested_payload: Json;
+        };
+        Returns: Json;
+      };
       list_active_session_participants: {
         Args: {
           requested_organization_id: string;

--- a/supabase/migrations/20260727001000_split_partial_payments.sql
+++ b/supabase/migrations/20260727001000_split_partial_payments.sql
@@ -1,0 +1,565 @@
+-- Server-authoritative split, partial, and mixed payments.
+--
+-- A payment command is intentionally not sent through the retrying outbox.
+-- The client submits it while online and the database protects explicit
+-- replays with the client mutation ID. Every command locks its check, so two
+-- devices cannot both consume the same remaining balance.
+
+create or replace function public.confirm_check_payments(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_device_id uuid,
+  requested_client_mutation_id uuid,
+  requested_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller_user_id uuid := (select auth.uid());
+  fingerprint text;
+  claimed_mutation_id uuid;
+  prior_mutation public.client_mutations;
+  prior_check public.checks;
+  canonical_check public.checks;
+  target_session public.table_sessions;
+  payment_payload jsonb;
+  allocation_payload jsonb;
+  target_item public.order_items;
+  requested_check_id uuid;
+  requested_payment_id uuid;
+  requested_allocation_id uuid;
+  expected_check_version bigint;
+  payment_amount_minor bigint;
+  payment_allocation_total bigint;
+  payment_tendered_minor bigint;
+  payment_method text;
+  allocation_amount_minor bigint;
+  allocation_quantity numeric;
+  check_total_numeric numeric;
+  check_total_minor bigint;
+  confirmed_paid_minor bigint;
+  requested_total_minor bigint := 0;
+  final_paid_minor bigint;
+  item_total_numeric numeric;
+  item_total_minor bigint;
+  item_paid_minor bigint;
+  item_paid_quantity numeric;
+  item_unit_total_numeric numeric;
+  currency_count integer;
+  canonical_currency_code text;
+  mutation_result jsonb;
+  payment_ids jsonb := '[]'::jsonb;
+begin
+  if caller_user_id is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if requested_payload is null
+    or jsonb_typeof(requested_payload) is distinct from 'object'
+    or requested_payload - array[
+      'checkId',
+      'expectedCheckVersion',
+      'currencyCode',
+      'payments'
+    ] <> '{}'::jsonb
+    or not (requested_payload ?& array[
+      'checkId',
+      'expectedCheckVersion',
+      'currencyCode',
+      'payments'
+    ])
+    or jsonb_typeof(requested_payload -> 'payments') is distinct from 'array'
+    or jsonb_array_length(requested_payload -> 'payments') not between 1 and 2 then
+    raise exception using errcode = '22023', message = 'invalid_payment_payload_shape';
+  end if;
+  if octet_length(requested_payload::text) > 65536 then
+    raise exception using errcode = '22023', message = 'payment_payload_too_large';
+  end if;
+  if not private.is_active_member(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'branch_access_denied';
+  end if;
+  if not exists (
+    select 1
+    from public.devices as device
+    where device.id = requested_device_id
+      and device.organization_id = requested_organization_id
+      and device.branch_id = requested_branch_id
+      and device.user_id = caller_user_id
+      and device.revoked_at is null
+  ) then
+    raise exception using errcode = '42501', message = 'device_access_denied';
+  end if;
+
+  requested_check_id := (requested_payload ->> 'checkId')::uuid;
+  expected_check_version := (requested_payload ->> 'expectedCheckVersion')::bigint;
+  if expected_check_version < 1 then
+    raise exception using errcode = '22023', message = 'invalid_expected_check_version';
+  end if;
+  if coalesce(requested_payload ->> 'currencyCode', '') !~ '^[A-Z]{3}$' then
+    raise exception using errcode = '22023', message = 'invalid_payment_currency';
+  end if;
+
+  fingerprint := md5(concat_ws(
+    ':',
+    requested_organization_id::text,
+    requested_branch_id::text,
+    requested_device_id::text,
+    requested_client_mutation_id::text,
+    'checks.confirm_payments',
+    requested_check_id::text,
+    requested_payload::text
+  ));
+
+  insert into public.client_mutations (
+    organization_id,
+    branch_id,
+    device_id,
+    client_mutation_id,
+    mutation_type,
+    entity_id,
+    request_fingerprint,
+    result_json
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    requested_device_id,
+    requested_client_mutation_id,
+    'checks.confirm_payments',
+    requested_check_id,
+    fingerprint,
+    '{}'::jsonb
+  )
+  on conflict (device_id, client_mutation_id) do nothing
+  returning id into claimed_mutation_id;
+
+  if claimed_mutation_id is null then
+    select mutation.*
+    into prior_mutation
+    from public.client_mutations as mutation
+    where mutation.device_id = requested_device_id
+      and mutation.client_mutation_id = requested_client_mutation_id;
+    if prior_mutation.id is null then
+      raise exception using
+        errcode = '40001',
+        message = 'idempotency_result_temporarily_unavailable';
+    end if;
+    if prior_mutation.request_fingerprint <> fingerprint then
+      raise exception using
+        errcode = '22023',
+        message = 'client_mutation_id_reused_with_different_content';
+    end if;
+    return prior_mutation.result_json;
+  end if;
+
+  select check_row.*
+  into prior_check
+  from public.checks as check_row
+  where check_row.organization_id = requested_organization_id
+    and check_row.branch_id = requested_branch_id
+    and check_row.id = requested_check_id
+    and check_row.deleted_at is null
+  for update;
+  if prior_check.id is null then
+    raise exception using errcode = '22023', message = 'payment_check_not_found';
+  end if;
+  if prior_check.status not in ('open', 'partially_paid') then
+    raise exception using errcode = '22023', message = 'payment_check_not_open';
+  end if;
+  if prior_check.version <> expected_check_version then
+    raise exception using
+      errcode = 'P0001',
+      message = 'payment_check_version_conflict',
+      detail = jsonb_build_object(
+        'serverVersion', prior_check.version,
+        'serverPayload', to_jsonb(prior_check)
+      )::text;
+  end if;
+
+  select session.*
+  into target_session
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.id = prior_check.table_session_id
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null
+  for update;
+  if target_session.id is null then
+    raise exception using errcode = '22023', message = 'payment_session_not_open';
+  end if;
+
+  perform 1
+  from public.order_items as item
+  where item.organization_id = requested_organization_id
+    and item.branch_id = requested_branch_id
+    and item.check_id = prior_check.id
+    and item.deleted_at is null
+  order by item.id
+  for update;
+
+  select
+    coalesce(sum(
+      case
+        when item.status = 'cancelled' then 0
+        else (
+          item.unit_price_minor
+          + coalesce((
+            select sum(modifier.price_delta_minor * modifier.quantity)
+            from public.order_item_modifiers as modifier
+            where modifier.organization_id = item.organization_id
+              and modifier.branch_id = item.branch_id
+              and modifier.order_item_id = item.id
+          ), 0)
+        ) * item.quantity
+      end
+    ), 0),
+    count(distinct item.currency_code) filter (where item.status <> 'cancelled'),
+    min(item.currency_code) filter (where item.status <> 'cancelled')
+  into check_total_numeric, currency_count, canonical_currency_code
+  from public.order_items as item
+  where item.organization_id = requested_organization_id
+    and item.branch_id = requested_branch_id
+    and item.check_id = prior_check.id
+    and item.deleted_at is null;
+
+  if check_total_numeric <= 0 or trunc(check_total_numeric) <> check_total_numeric then
+    raise exception using errcode = '22023', message = 'invalid_payable_check_total';
+  end if;
+  if currency_count <> 1
+    or canonical_currency_code <> requested_payload ->> 'currencyCode' then
+    raise exception using errcode = '22023', message = 'payment_currency_mismatch';
+  end if;
+  check_total_minor := check_total_numeric::bigint;
+
+  select coalesce(sum(allocation.amount_minor), 0)
+  into confirmed_paid_minor
+  from public.payment_allocations as allocation
+  join public.payments as payment
+    on payment.organization_id = allocation.organization_id
+   and payment.branch_id = allocation.branch_id
+   and payment.id = allocation.payment_id
+  where allocation.organization_id = requested_organization_id
+    and allocation.branch_id = requested_branch_id
+    and allocation.check_id = prior_check.id
+    and payment.status = 'confirmed';
+
+  for payment_payload in
+    select value from jsonb_array_elements(requested_payload -> 'payments')
+  loop
+    if jsonb_typeof(payment_payload) is distinct from 'object'
+      or payment_payload - array[
+        'id',
+        'method',
+        'amountMinor',
+        'tenderedMinor',
+        'allocations'
+      ] <> '{}'::jsonb
+      or not (payment_payload ?& array['id', 'method', 'amountMinor', 'allocations'])
+      or jsonb_typeof(payment_payload -> 'allocations') is distinct from 'array'
+      or jsonb_array_length(payment_payload -> 'allocations') not between 1 and 100 then
+      raise exception using errcode = '22023', message = 'invalid_payment_entry';
+    end if;
+
+    requested_payment_id := (payment_payload ->> 'id')::uuid;
+    payment_method := payment_payload ->> 'method';
+    payment_amount_minor := (payment_payload ->> 'amountMinor')::bigint;
+    if payment_method not in ('cash', 'card') or payment_amount_minor <= 0 then
+      raise exception using errcode = '22023', message = 'invalid_payment_tender';
+    end if;
+    if payment_method = 'cash' then
+      if not (payment_payload ? 'tenderedMinor') then
+        raise exception using errcode = '22023', message = 'cash_tender_required';
+      end if;
+      payment_tendered_minor := (payment_payload ->> 'tenderedMinor')::bigint;
+      if payment_tendered_minor < payment_amount_minor then
+        raise exception using errcode = '22023', message = 'cash_tender_too_low';
+      end if;
+    else
+      payment_tendered_minor := coalesce(
+        (payment_payload ->> 'tenderedMinor')::bigint,
+        payment_amount_minor
+      );
+      if payment_tendered_minor <> payment_amount_minor then
+        raise exception using errcode = '22023', message = 'card_tender_mismatch';
+      end if;
+    end if;
+
+    select coalesce(sum((allocation ->> 'amountMinor')::bigint), 0)
+    into payment_allocation_total
+    from jsonb_array_elements(payment_payload -> 'allocations') as allocation;
+    if payment_allocation_total <> payment_amount_minor then
+      raise exception using errcode = '22023', message = 'payment_allocation_total_mismatch';
+    end if;
+
+    requested_total_minor := requested_total_minor + payment_amount_minor;
+    if requested_total_minor > check_total_minor - confirmed_paid_minor then
+      raise exception using errcode = '22023', message = 'payment_exceeds_remaining';
+    end if;
+
+    insert into public.payments (
+      id,
+      organization_id,
+      branch_id,
+      table_session_id,
+      method,
+      status,
+      amount_minor,
+      tendered_minor,
+      change_minor,
+      currency_code,
+      created_by,
+      created_at,
+      confirmed_at,
+      idempotency_key,
+      device_id
+    )
+    values (
+      requested_payment_id,
+      requested_organization_id,
+      requested_branch_id,
+      prior_check.table_session_id,
+      payment_method,
+      'confirmed',
+      payment_amount_minor,
+      payment_tendered_minor,
+      case
+        when payment_method = 'cash' then payment_tendered_minor - payment_amount_minor
+        else 0
+      end,
+      canonical_currency_code,
+      caller_user_id,
+      now(),
+      now(),
+      concat(requested_client_mutation_id::text, ':', requested_payment_id::text),
+      requested_device_id
+    );
+
+    for allocation_payload in
+      select value from jsonb_array_elements(payment_payload -> 'allocations')
+    loop
+      if jsonb_typeof(allocation_payload) is distinct from 'object'
+        or allocation_payload - array[
+          'id',
+          'orderItemId',
+          'quantity',
+          'amountMinor'
+        ] <> '{}'::jsonb
+        or not (allocation_payload ?& array['id', 'amountMinor']) then
+        raise exception using errcode = '22023', message = 'invalid_payment_allocation';
+      end if;
+      requested_allocation_id := (allocation_payload ->> 'id')::uuid;
+      allocation_amount_minor := (allocation_payload ->> 'amountMinor')::bigint;
+      if allocation_amount_minor <= 0 then
+        raise exception using errcode = '22023', message = 'invalid_allocation_amount';
+      end if;
+      allocation_quantity := case
+        when allocation_payload ? 'quantity'
+          then (allocation_payload ->> 'quantity')::numeric
+        else null
+      end;
+      if allocation_quantity is not null and allocation_quantity <= 0 then
+        raise exception using errcode = '22023', message = 'invalid_allocation_quantity';
+      end if;
+      if allocation_quantity is not null and not (allocation_payload ? 'orderItemId') then
+        raise exception using errcode = '22023', message = 'allocation_quantity_requires_item';
+      end if;
+
+      if allocation_payload ? 'orderItemId' then
+        select item.*
+        into target_item
+        from public.order_items as item
+        where item.organization_id = requested_organization_id
+          and item.branch_id = requested_branch_id
+          and item.id = (allocation_payload ->> 'orderItemId')::uuid
+          and item.check_id = prior_check.id
+          and item.status <> 'cancelled'
+          and item.deleted_at is null;
+        if target_item.id is null then
+          raise exception using errcode = '22023', message = 'allocation_item_not_payable';
+        end if;
+
+        select
+          (
+            target_item.unit_price_minor
+            + coalesce(sum(modifier.price_delta_minor * modifier.quantity), 0)
+          ),
+          (
+            target_item.unit_price_minor
+            + coalesce(sum(modifier.price_delta_minor * modifier.quantity), 0)
+          ) * target_item.quantity
+        into item_unit_total_numeric, item_total_numeric
+        from public.order_item_modifiers as modifier
+        where modifier.organization_id = requested_organization_id
+          and modifier.branch_id = requested_branch_id
+          and modifier.order_item_id = target_item.id;
+        if trunc(item_total_numeric) <> item_total_numeric then
+          raise exception using errcode = '22023', message = 'invalid_payable_item_total';
+        end if;
+        item_total_minor := item_total_numeric::bigint;
+
+        select
+          coalesce(sum(allocation.amount_minor), 0),
+          coalesce(sum(allocation.quantity), 0)
+        into item_paid_minor, item_paid_quantity
+        from public.payment_allocations as allocation
+        join public.payments as payment
+          on payment.organization_id = allocation.organization_id
+         and payment.branch_id = allocation.branch_id
+         and payment.id = allocation.payment_id
+        where allocation.organization_id = requested_organization_id
+          and allocation.branch_id = requested_branch_id
+          and allocation.order_item_id = target_item.id
+          and payment.status = 'confirmed';
+
+        if item_paid_minor + allocation_amount_minor > item_total_minor then
+          raise exception using errcode = '22023', message = 'allocation_exceeds_item_amount';
+        end if;
+        if allocation_quantity is not null then
+          if item_paid_quantity + allocation_quantity > target_item.quantity then
+            raise exception using errcode = '22023', message = 'allocation_exceeds_item_quantity';
+          end if;
+          if item_unit_total_numeric * allocation_quantity <> allocation_amount_minor then
+            raise exception using errcode = '22023', message = 'allocation_quantity_amount_mismatch';
+          end if;
+        end if;
+      end if;
+
+      insert into public.payment_allocations (
+        id,
+        organization_id,
+        branch_id,
+        payment_id,
+        check_id,
+        order_item_id,
+        quantity,
+        amount_minor
+      )
+      values (
+        requested_allocation_id,
+        requested_organization_id,
+        requested_branch_id,
+        requested_payment_id,
+        prior_check.id,
+        case
+          when allocation_payload ? 'orderItemId'
+            then (allocation_payload ->> 'orderItemId')::uuid
+          else null
+        end,
+        allocation_quantity,
+        allocation_amount_minor
+      );
+    end loop;
+
+    payment_ids := payment_ids || jsonb_build_array(requested_payment_id);
+  end loop;
+
+  final_paid_minor := confirmed_paid_minor + requested_total_minor;
+  update public.checks
+  set status = case
+        when final_paid_minor = check_total_minor then 'paid'
+        else 'partially_paid'
+      end,
+      closed_at = case
+        when final_paid_minor = check_total_minor then now()
+        else null
+      end,
+      updated_at = now(),
+      version = prior_check.version + 1
+  where id = prior_check.id
+  returning * into canonical_check;
+
+  update public.table_sessions
+  set status = 'payment_pending',
+      updated_at = now(),
+      version = target_session.version + 1
+  where id = target_session.id;
+
+  insert into public.session_participants (
+    organization_id,
+    branch_id,
+    table_session_id,
+    user_id,
+    first_action_at,
+    last_action_at
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    target_session.id,
+    caller_user_id,
+    now(),
+    now()
+  )
+  on conflict (table_session_id, user_id) do update
+  set last_action_at = excluded.last_action_at;
+
+  mutation_result := jsonb_build_object(
+    'status', 'confirmed',
+    'checkId', canonical_check.id,
+    'checkStatus', canonical_check.status,
+    'checkVersion', canonical_check.version,
+    'totalMinor', check_total_minor,
+    'paidMinor', final_paid_minor,
+    'remainingMinor', check_total_minor - final_paid_minor,
+    'paymentIds', payment_ids
+  );
+
+  insert into public.audit_events (
+    organization_id,
+    branch_id,
+    actor_user_id,
+    device_id,
+    entity_type,
+    entity_id,
+    action,
+    before_json,
+    after_json,
+    client_mutation_id,
+    correlation_id
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    caller_user_id,
+    requested_device_id,
+    'checks',
+    canonical_check.id,
+    'checks.confirm_payments',
+    to_jsonb(prior_check),
+    jsonb_build_object(
+      'check', to_jsonb(canonical_check),
+      'paymentIds', payment_ids,
+      'totalMinor', check_total_minor,
+      'paidMinor', final_paid_minor,
+      'remainingMinor', check_total_minor - final_paid_minor
+    ),
+    requested_client_mutation_id,
+    requested_client_mutation_id
+  );
+
+  update public.client_mutations
+  set result_json = mutation_result,
+      committed_at = now()
+  where id = claimed_mutation_id;
+
+  return mutation_result;
+end;
+$$;
+
+revoke execute on function public.confirm_check_payments(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb
+) from public, anon;
+grant execute on function public.confirm_check_payments(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb
+) to authenticated;

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(21);
+select plan(34);
 
 insert into auth.users (
   instance_id,
@@ -633,6 +633,244 @@ select is(
   ),
   'İkinci garsonun notu',
   'the winning note remains unchanged after the stale edit'
+);
+
+select is(
+  (
+    public.confirm_check_payments(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000021',
+      jsonb_build_object(
+        'checkId', 'f5000000-0000-4000-8000-000000000001',
+        'expectedCheckVersion', 1,
+        'currencyCode', 'EUR',
+        'payments', jsonb_build_array(
+          jsonb_build_object(
+            'id', 'd5000000-0000-4000-8000-000000000201',
+            'method', 'cash',
+            'amountMinor', 100,
+            'tenderedMinor', 200,
+            'allocations', jsonb_build_array(
+              jsonb_build_object(
+                'id', 'd5000000-0000-4000-8000-000000000211',
+                'amountMinor', 100
+              )
+            )
+          ),
+          jsonb_build_object(
+            'id', 'd5000000-0000-4000-8000-000000000202',
+            'method', 'card',
+            'amountMinor', 100,
+            'allocations', jsonb_build_array(
+              jsonb_build_object(
+                'id', 'd5000000-0000-4000-8000-000000000212',
+                'amountMinor', 100
+              )
+            )
+          )
+        )
+      )
+    ) ->> 'status'
+  ),
+  'confirmed',
+  'cash and card parts confirm atomically as one mixed payment command'
+);
+select is(
+  (
+    select count(*)
+    from public.payments
+    where table_session_id = 'e5000000-0000-4000-8000-000000000001'
+  ),
+  2::bigint,
+  'a mixed command records distinct auditable cash and card payments'
+);
+select is(
+  (
+    select change_minor
+    from public.payments
+    where id = 'd5000000-0000-4000-8000-000000000201'
+  ),
+  100::bigint,
+  'cash change is derived and excluded from paid revenue'
+);
+select is(
+  (
+    select status
+    from public.checks
+    where id = 'f5000000-0000-4000-8000-000000000001'
+  ),
+  'partially_paid',
+  'a partial payment leaves the check explicitly partially paid'
+);
+select is(
+  (
+    select sum(allocation.amount_minor)
+    from public.payment_allocations as allocation
+    join public.payments as payment on payment.id = allocation.payment_id
+    where allocation.check_id = 'f5000000-0000-4000-8000-000000000001'
+      and payment.status = 'confirmed'
+  ),
+  200::numeric,
+  'confirmed allocation ledger reports the exact partial paid amount'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select throws_ok(
+  $$
+    select public.confirm_check_payments(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000002',
+      'c5000000-0000-4000-8000-000000000022',
+      jsonb_build_object(
+        'checkId', 'f5000000-0000-4000-8000-000000000001',
+        'expectedCheckVersion', 1,
+        'currencyCode', 'EUR',
+        'payments', jsonb_build_array(
+          jsonb_build_object(
+            'id', 'd5000000-0000-4000-8000-000000000203',
+            'method', 'card',
+            'amountMinor', 300,
+            'allocations', jsonb_build_array(
+              jsonb_build_object(
+                'id', 'd5000000-0000-4000-8000-000000000213',
+                'amountMinor', 300
+              )
+            )
+          )
+        )
+      )
+    )
+  $$,
+  'P0001',
+  'payment_check_version_conflict',
+  'a second device cannot consume a stale remaining balance'
+);
+select is(
+  (
+    select count(*)
+    from public.payments
+    where table_session_id = 'e5000000-0000-4000-8000-000000000001'
+  ),
+  2::bigint,
+  'the rejected stale payment creates no financial rows'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    public.confirm_check_payments(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000023',
+      jsonb_build_object(
+        'checkId', 'f5000000-0000-4000-8000-000000000001',
+        'expectedCheckVersion', 2,
+        'currencyCode', 'EUR',
+        'payments', jsonb_build_array(
+          jsonb_build_object(
+            'id', 'd5000000-0000-4000-8000-000000000204',
+            'method', 'card',
+            'amountMinor', 300,
+            'allocations', jsonb_build_array(
+              jsonb_build_object(
+                'id', 'd5000000-0000-4000-8000-000000000214',
+                'orderItemId', 'd5000000-0000-4000-8000-000000000111',
+                'amountMinor', 300
+              )
+            )
+          )
+        )
+      )
+    ) ->> 'checkStatus'
+  ),
+  'paid',
+  'the final partial payment closes the remaining balance'
+);
+select ok(
+  (
+    select closed_at is not null
+    from public.checks
+    where id = 'f5000000-0000-4000-8000-000000000001'
+  ),
+  'a fully allocated check receives an immutable close timestamp'
+);
+select is(
+  (
+    select sum(allocation.amount_minor)
+    from public.payment_allocations as allocation
+    join public.payments as payment on payment.id = allocation.payment_id
+    where allocation.check_id = 'f5000000-0000-4000-8000-000000000001'
+      and payment.status = 'confirmed'
+  ),
+  500::numeric,
+  'the final confirmed allocation total equals the server-derived check total'
+);
+select is(
+  (
+    public.confirm_check_payments(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000023',
+      jsonb_build_object(
+        'checkId', 'f5000000-0000-4000-8000-000000000001',
+        'expectedCheckVersion', 2,
+        'currencyCode', 'EUR',
+        'payments', jsonb_build_array(
+          jsonb_build_object(
+            'id', 'd5000000-0000-4000-8000-000000000204',
+            'method', 'card',
+            'amountMinor', 300,
+            'allocations', jsonb_build_array(
+              jsonb_build_object(
+                'id', 'd5000000-0000-4000-8000-000000000214',
+                'orderItemId', 'd5000000-0000-4000-8000-000000000111',
+                'amountMinor', 300
+              )
+            )
+          )
+        )
+      )
+    ) ->> 'checkStatus'
+  ),
+  'paid',
+  'an exact payment replay returns its stored server result'
+);
+select is(
+  (
+    select count(*)
+    from public.payments
+    where table_session_id = 'e5000000-0000-4000-8000-000000000001'
+  ),
+  3::bigint,
+  'an idempotent replay never duplicates a payment'
+);
+select is(
+  (
+    select count(*)
+    from public.payment_allocations
+    where check_id = 'f5000000-0000-4000-8000-000000000001'
+  ),
+  3::bigint,
+  'an idempotent replay never duplicates allocations'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #22

## What changed
- add a high-tempo two-step payment sheet with amount, item/quantity, and equal-share selection
- support cash, card, and atomic mixed cash+card tenders with visible change and remaining balance
- add pure minor-unit payment planning and allocation distribution with unit/component tests
- add an online-only direct payment gateway so uncertain payment attempts are never auto-retried by the sync outbox
- add a server-authoritative `confirm_check_payments` RPC with check/session/item locks, idempotency, tenant/device checks, server-derived totals, and allocation invariants
- update local workspace projections with confirmed payments and allocations
- extend pgTAP coverage for mixed/partial/final payments, change, stale-device protection, and exact replay

## Validation
- `npm run verify:full`
- 29 Jest suites / 163 tests / 1 snapshot
- Expo web production export
- 2 Chromium Playwright flows
- Supabase migration/lint/34 pgTAP assertions run in CI

## Stack
- base: `feat/21-concurrent-waiters` (#49)