### PR TITLE
feat(tables): add transactional table transfer and merge

### DIFF
--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -16,6 +16,11 @@ import {
   ConfirmCheckPaymentsResult,
   SupabasePaymentGateway,
 } from '../../features/payments';
+import {
+  SupabaseTableOperationGateway,
+  TransferTableSessionCommand,
+  TransferTableSessionResult,
+} from '../../features/table-operations';
 import { ActiveSessionParticipantRow, Database, getSupabaseClient } from '../../services/supabase';
 import { LocalDatabase, RepositoryScope } from '../contracts';
 import {
@@ -52,6 +57,11 @@ export interface OrderiaDataContextValue {
     clientMutationId: MutationId,
     command: ConfirmCheckPaymentsCommand,
   ): Promise<ConfirmCheckPaymentsResult>;
+  transferOrMergeTableSession(
+    deviceId: DeviceId,
+    clientMutationId: MutationId,
+    command: TransferTableSessionCommand,
+  ): Promise<TransferTableSessionResult>;
 }
 
 interface OrderiaDataProviderProps {
@@ -252,6 +262,25 @@ export function OrderiaDataProvider({
     [client, refresh, scope],
   );
 
+  const transferOrMergeTableSession = useCallback(
+    async (
+      deviceId: DeviceId,
+      clientMutationId: MutationId,
+      command: TransferTableSessionCommand,
+    ): Promise<TransferTableSessionResult> => {
+      if (!client || !scope) throw new Error('Cloud table operation service is unavailable');
+      const result = await new SupabaseTableOperationGateway(client).transferOrMerge({
+        ...scope,
+        deviceId,
+        clientMutationId,
+        command,
+      });
+      await refresh();
+      return result;
+    },
+    [client, refresh, scope],
+  );
+
   useEffect(() => {
     if (!database || !scope || !client) return;
 
@@ -343,6 +372,7 @@ export function OrderiaDataProvider({
       resolveProfileNames,
       resolveActiveParticipants,
       confirmCheckPayments,
+      transferOrMergeTableSession,
     }),
     [
       client,
@@ -357,6 +387,7 @@ export function OrderiaDataProvider({
       revision,
       scope,
       sync,
+      transferOrMergeTableSession,
     ],
   );
 

--- a/src/features/table-operations/TableOperationSheet.tsx
+++ b/src/features/table-operations/TableOperationSheet.tsx
@@ -1,0 +1,434 @@
+import { Ionicons } from '@expo/vector-icons';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import {
+  ServiceButton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+} from '../../design-system';
+import { Check, RestaurantTable, TableSession } from '../../domain';
+import { Language } from '../../i18n';
+import { createTextMatcher } from '../../utils/searchUtils';
+import { TransferTableSessionCommand } from './tableOperationGateway';
+
+export interface TableOperationTarget {
+  readonly table: RestaurantTable;
+  readonly session?: TableSession;
+}
+
+export interface TableOperationSheetProps {
+  readonly visible: boolean;
+  readonly sourceTable: RestaurantTable;
+  readonly sourceSession: TableSession;
+  readonly sourceChecks: readonly Check[];
+  readonly targets: readonly TableOperationTarget[];
+  readonly language: Language;
+  readonly online: boolean;
+  readonly busy: boolean;
+  readonly onClose: () => void;
+  readonly onConfirm: (
+    command: TransferTableSessionCommand,
+    target: TableOperationTarget,
+  ) => Promise<void>;
+}
+
+export function TableOperationSheet({
+  visible,
+  sourceTable,
+  sourceSession,
+  sourceChecks,
+  targets,
+  language,
+  online,
+  busy,
+  onClose,
+  onConfirm,
+}: TableOperationSheetProps) {
+  const { tokens } = useTheme();
+  const copy = operationCopy(language);
+  const [query, setQuery] = useState('');
+  const [selectedTableId, setSelectedTableId] = useState<string>();
+  const [reviewing, setReviewing] = useState(false);
+  const [error, setError] = useState<string>();
+  const selected = targets.find((target) => target.table.id === selectedTableId);
+  const filtered = useMemo(() => {
+    const matcher = createTextMatcher(query);
+    return targets.filter((target) => matcher(target.table.label));
+  }, [query, targets]);
+
+  useEffect(() => {
+    if (!visible) return;
+    setQuery('');
+    setSelectedTableId(undefined);
+    setReviewing(false);
+    setError(undefined);
+  }, [sourceSession.id, visible]);
+
+  const submit = async () => {
+    if (!selected) return;
+    try {
+      setError(undefined);
+      await onConfirm(
+        {
+          sourceSessionId: sourceSession.id,
+          targetTableId: selected.table.id,
+          expectedSourceVersion: sourceSession.serverVersion ?? sourceSession.version,
+          expectedTargetVersion: selected.session
+            ? (selected.session.serverVersion ?? selected.session.version)
+            : null,
+        },
+        selected,
+      );
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : copy.failed);
+      setReviewing(false);
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="pageSheet"
+      transparent
+      visible={visible}
+    >
+      <View
+        style={{
+          backgroundColor: tokens.colors.overlay,
+          flex: 1,
+          justifyContent: 'flex-end',
+        }}
+      >
+        <View
+          style={{
+            alignSelf: 'center',
+            backgroundColor: tokens.colors.bg,
+            borderTopLeftRadius: tokens.radius.large,
+            borderTopRightRadius: tokens.radius.large,
+            maxHeight: '92%',
+            maxWidth: 720,
+            padding: tokens.space.lg,
+            width: '100%',
+          }}
+        >
+          <View
+            style={{
+              alignItems: 'center',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              marginBottom: tokens.space.md,
+            }}
+          >
+            <View style={{ flex: 1 }}>
+              <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+                {reviewing ? copy.review : copy.moveTable}
+              </Text>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {sourceTable.label} · {sourceChecks.length} {copy.checks}
+              </Text>
+            </View>
+            <Pressable
+              accessibilityLabel={copy.close}
+              accessibilityRole="button"
+              disabled={busy}
+              onPress={onClose}
+              style={{ padding: tokens.space.sm }}
+            >
+              <Ionicons color={tokens.colors.text} name="close" size={26} />
+            </Pressable>
+          </View>
+
+          {!online ? (
+            <ServiceSurface
+              style={{
+                backgroundColor: tokens.colors.state.pending.bg,
+                marginBottom: tokens.space.md,
+                padding: tokens.space.md,
+              }}
+            >
+              <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.warning }]}>
+                {copy.onlineRequired}
+              </Text>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {copy.onlineDetail}
+              </Text>
+            </ServiceSurface>
+          ) : null}
+
+          <ScrollView
+            contentContainerStyle={{ gap: tokens.space.md, paddingBottom: tokens.space.lg }}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            {!reviewing ? (
+              <>
+                <ServiceTextField
+                  label={copy.search}
+                  onChangeText={setQuery}
+                  placeholder={copy.searchHint}
+                  value={query}
+                />
+                <View style={{ gap: tokens.space.sm }}>
+                  {filtered.map((target) => {
+                    const selectedTarget = target.table.id === selectedTableId;
+                    return (
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: selectedTarget }}
+                        key={target.table.id}
+                        onPress={() => {
+                          setSelectedTableId(target.table.id);
+                          setError(undefined);
+                        }}
+                      >
+                        <ServiceSurface
+                          style={{
+                            alignItems: 'center',
+                            borderColor: selectedTarget
+                              ? tokens.colors.primary
+                              : tokens.colors.border,
+                            borderWidth: selectedTarget ? 2 : 1,
+                            flexDirection: 'row',
+                            gap: tokens.space.md,
+                            minHeight: 72,
+                            padding: tokens.space.md,
+                          }}
+                        >
+                          <Ionicons
+                            color={
+                              selectedTarget ? tokens.colors.primary : tokens.colors.textSubtle
+                            }
+                            name={target.session ? 'people-outline' : 'checkmark-circle-outline'}
+                            size={24}
+                          />
+                          <View style={{ flex: 1 }}>
+                            <Text
+                              style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}
+                            >
+                              {target.table.label}
+                            </Text>
+                            <Text
+                              style={[
+                                tokens.typography.caption,
+                                { color: tokens.colors.textSubtle },
+                              ]}
+                            >
+                              {target.session ? copy.occupied : copy.empty}
+                            </Text>
+                          </View>
+                          <ServiceStatusPill
+                            label={target.session ? copy.merge : copy.move}
+                            tone={target.session ? 'warning' : 'success'}
+                          />
+                        </ServiceSurface>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </>
+            ) : selected ? (
+              <>
+                <ServiceSurface style={{ gap: tokens.space.md, padding: tokens.space.lg }}>
+                  <RouteLine label={copy.source} value={sourceTable.label} icon="exit-outline" />
+                  <View
+                    style={{
+                      alignItems: 'center',
+                      borderLeftColor: tokens.colors.border,
+                      borderLeftWidth: 2,
+                      height: 32,
+                      marginLeft: 11,
+                    }}
+                  />
+                  <RouteLine
+                    label={selected.session ? copy.mergeInto : copy.target}
+                    value={selected.table.label}
+                    icon="enter-outline"
+                  />
+                </ServiceSurface>
+                <ServiceSurface
+                  style={{
+                    backgroundColor: selected.session
+                      ? tokens.colors.state.pending.bg
+                      : tokens.colors.state.delivered.bg,
+                    gap: tokens.space.sm,
+                    padding: tokens.space.md,
+                  }}
+                >
+                  <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}>
+                    {selected.session ? copy.mergeExplanation : copy.moveExplanation}
+                  </Text>
+                  <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                    {copy.atomicNotice}
+                  </Text>
+                </ServiceSurface>
+                <View>
+                  <Text
+                    style={[
+                      tokens.typography.label,
+                      { color: tokens.colors.text, marginBottom: tokens.space.xs },
+                    ]}
+                  >
+                    {copy.preservedChecks}
+                  </Text>
+                  <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+                    {sourceChecks.map((check) => (
+                      <View
+                        key={check.id}
+                        style={{
+                          backgroundColor: tokens.colors.surfaceAlt,
+                          borderRadius: tokens.radius.full,
+                          paddingHorizontal: tokens.space.md,
+                          paddingVertical: tokens.space.xs,
+                        }}
+                      >
+                        <Text style={[tokens.typography.label, { color: tokens.colors.text }]}>
+                          {check.name}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                </View>
+              </>
+            ) : null}
+
+            {error ? (
+              <Text
+                accessibilityLiveRegion="assertive"
+                style={[tokens.typography.caption, { color: tokens.colors.error }]}
+              >
+                {error}
+              </Text>
+            ) : null}
+          </ScrollView>
+
+          <View style={{ flexDirection: 'row', gap: tokens.space.sm }}>
+            <ServiceButton
+              disabled={busy}
+              label={reviewing ? copy.back : copy.close}
+              onPress={() => (reviewing ? setReviewing(false) : onClose())}
+              style={{ flex: 1 }}
+              variant="ghost"
+            />
+            <ServiceButton
+              disabled={busy || !online || !selected}
+              label={
+                reviewing ? (selected?.session ? copy.confirmMerge : copy.confirmMove) : copy.review
+              }
+              loading={busy}
+              onPress={() => (reviewing ? void submit() : setReviewing(true))}
+              style={{ flex: 2 }}
+              variant={selected?.session && reviewing ? 'accent' : 'primary'}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function RouteLine({
+  label,
+  value,
+  icon,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly icon: keyof typeof Ionicons.glyphMap;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ alignItems: 'center', flexDirection: 'row', gap: tokens.space.md }}>
+      <Ionicons color={tokens.colors.primary} name={icon} size={24} />
+      <View>
+        <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+          {label}
+        </Text>
+        <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>{value}</Text>
+      </View>
+    </View>
+  );
+}
+
+function operationCopy(language: Language) {
+  const translations = {
+    tr: {
+      moveTable: 'Masayı taşı / birleştir',
+      review: 'İşlemi gözden geçir',
+      close: 'Kapat',
+      checks: 'hesap',
+      onlineRequired: 'Bu işlem için bağlantı gerekli',
+      onlineDetail: 'Kaynak ve hedef masa sunucuda tek transaction içinde kilitlenir.',
+      search: 'Hedef masa ara',
+      searchHint: 'Masa adı veya numarası',
+      occupied: 'Açık servis var',
+      empty: 'Boş masa',
+      merge: 'Birleştir',
+      move: 'Taşı',
+      source: 'Kaynak',
+      target: 'Yeni masa',
+      mergeInto: 'Birleşeceği masa',
+      mergeExplanation: 'İki servis birleşir; isimli hesaplar ayrı kalır.',
+      moveExplanation: 'Tüm servis ve hesaplar bu boş masaya taşınır.',
+      atomicNotice: 'Sipariş kökeni korunur; işlem tamamen uygulanır veya tamamen geri alınır.',
+      preservedChecks: 'Ayrı kalacak hesaplar',
+      back: 'Geri',
+      confirmMerge: 'Birleştirmeyi onayla',
+      confirmMove: 'Taşımayı onayla',
+      failed: 'Masa işlemi tamamlanamadı.',
+    },
+    bg: {
+      moveTable: 'Премести / обедини маса',
+      review: 'Преглед',
+      close: 'Затвори',
+      checks: 'сметки',
+      onlineRequired: 'Нужна е връзка',
+      onlineDetail: 'Двете маси се заключват в една сървърна транзакция.',
+      search: 'Търси целева маса',
+      searchHint: 'Име или номер',
+      occupied: 'Има активна сесия',
+      empty: 'Свободна маса',
+      merge: 'Обедини',
+      move: 'Премести',
+      source: 'Източник',
+      target: 'Нова маса',
+      mergeInto: 'Обедини в',
+      mergeExplanation: 'Сесиите се обединяват, а именуваните сметки остават отделни.',
+      moveExplanation: 'Цялата сесия се премества на свободната маса.',
+      atomicNotice: 'Произходът се пази; операцията се изпълнява изцяло или се отменя.',
+      preservedChecks: 'Сметки, които остават отделни',
+      back: 'Назад',
+      confirmMerge: 'Потвърди обединяването',
+      confirmMove: 'Потвърди преместването',
+      failed: 'Операцията не бе завършена.',
+    },
+    en: {
+      moveTable: 'Move / merge table',
+      review: 'Review operation',
+      close: 'Close',
+      checks: 'checks',
+      onlineRequired: 'Connection required',
+      onlineDetail: 'Source and target tables are locked in one server transaction.',
+      search: 'Find target table',
+      searchHint: 'Table name or number',
+      occupied: 'Active service',
+      empty: 'Empty table',
+      merge: 'Merge',
+      move: 'Move',
+      source: 'Source',
+      target: 'New table',
+      mergeInto: 'Merge into',
+      mergeExplanation: 'Sessions merge while every named check remains separate.',
+      moveExplanation: 'The complete service and its checks move to this empty table.',
+      atomicNotice: 'Order origin is preserved; the operation fully applies or fully rolls back.',
+      preservedChecks: 'Checks kept separate',
+      back: 'Back',
+      confirmMerge: 'Confirm merge',
+      confirmMove: 'Confirm move',
+      failed: 'Table operation could not be completed.',
+    },
+  };
+  return translations[language] ?? translations.en;
+}

--- a/src/features/table-operations/__tests__/TableOperationSheet.test.tsx
+++ b/src/features/table-operations/__tests__/TableOperationSheet.test.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-require-imports -- Jest native component factories are hoisted. */
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { ThemeProvider } from '../../../contexts/ThemeContext';
+import { TableOperationSheet } from '../TableOperationSheet';
+
+jest.mock('react-native/Libraries/Components/ActivityIndicator/ActivityIndicator', () => ({
+  __esModule: true,
+  default: 'ActivityIndicator',
+}));
+jest.mock('react-native/Libraries/Modal/Modal', () => {
+  const ReactModule = require('react') as typeof React;
+  function MockModal({
+    children,
+    visible,
+  }: {
+    readonly children: React.ReactNode;
+    readonly visible: boolean;
+  }) {
+    return visible ? ReactModule.createElement('Modal', null, children) : null;
+  }
+  return { __esModule: true, default: MockModal };
+});
+jest.mock('react-native/Libraries/Components/ScrollView/ScrollView', () => {
+  const ReactModule = require('react') as typeof React;
+  function MockScrollView({ children }: { readonly children: React.ReactNode }) {
+    return ReactModule.createElement('ScrollView', null, children);
+  }
+  return { __esModule: true, default: MockScrollView };
+});
+
+describe('TableOperationSheet', () => {
+  it('makes an occupied target explicit and preserves named checks in review', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    const target = {
+      table: table('table-2', 'Patio 2'),
+      session: session('session-2', 'table-2', 3),
+    };
+    const screen = await render(
+      <ThemeProvider>
+        <TableOperationSheet
+          busy={false}
+          language="en"
+          onClose={jest.fn()}
+          onConfirm={onConfirm}
+          online
+          sourceChecks={[check('check-1', 'General'), check('check-2', 'Children')]}
+          sourceSession={session('session-1', 'table-1', 2)}
+          sourceTable={table('table-1', 'Patio 1')}
+          targets={[target, { table: table('table-3', 'Patio 3') }]}
+          visible
+        />
+      </ThemeProvider>,
+    );
+
+    fireEvent.press(screen.getByRole('button', { name: /Patio 2/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'Review operation' }).props.accessibilityState.disabled,
+      ).toBe(false),
+    );
+    fireEvent.press(screen.getByRole('button', { name: 'Review operation' }));
+    expect(
+      await screen.findByText('Sessions merge while every named check remains separate.'),
+    ).toBeTruthy();
+    expect(screen.getByText('General')).toBeTruthy();
+    expect(screen.getByText('Children')).toBeTruthy();
+    fireEvent.press(screen.getByRole('button', { name: 'Confirm merge' }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(onConfirm.mock.calls[0][0]).toEqual({
+      sourceSessionId: 'session-1',
+      targetTableId: 'table-2',
+      expectedSourceVersion: 2,
+      expectedTargetVersion: 3,
+    });
+  });
+});
+
+function table(id: string, label: string) {
+  return {
+    id,
+    organizationId: 'organization-1',
+    branchId: 'branch-1',
+    hallId: 'hall-1',
+    label,
+    sequenceNumber: Number(id.at(-1)),
+    sortOrder: Number(id.at(-1)),
+    version: 1,
+    createdAt: '2026-07-26T10:00:00.000Z',
+    updatedAt: '2026-07-26T10:00:00.000Z',
+    syncStatus: 'synced',
+  } as never;
+}
+
+function session(id: string, tableId: string, version: number) {
+  return {
+    id,
+    organizationId: 'organization-1',
+    branchId: 'branch-1',
+    tableId,
+    status: 'open',
+    openedBy: 'waiter-1',
+    openedAt: '2026-07-26T10:00:00.000Z',
+    version,
+    serverVersion: version,
+    createdAt: '2026-07-26T10:00:00.000Z',
+    updatedAt: '2026-07-26T10:00:00.000Z',
+    syncStatus: 'synced',
+  } as never;
+}
+
+function check(id: string, name: string) {
+  return {
+    id,
+    organizationId: 'organization-1',
+    branchId: 'branch-1',
+    tableSessionId: 'session-1',
+    name,
+    status: 'open',
+    openedBy: 'waiter-1',
+    openedAt: '2026-07-26T10:00:00.000Z',
+    version: 1,
+    createdAt: '2026-07-26T10:00:00.000Z',
+    updatedAt: '2026-07-26T10:00:00.000Z',
+    syncStatus: 'synced',
+  } as never;
+}

--- a/src/features/table-operations/__tests__/tableOperationGateway.test.ts
+++ b/src/features/table-operations/__tests__/tableOperationGateway.test.ts
@@ -1,0 +1,45 @@
+import { SupabaseTableOperationGateway } from '../tableOperationGateway';
+
+describe('SupabaseTableOperationGateway', () => {
+  it('returns the canonical target after a merge', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: {
+        status: 'applied',
+        mode: 'merged',
+        sourceTableId: 'table-1',
+        targetTableId: 'table-2',
+        sourceSessionId: 'session-1',
+        canonicalSessionId: 'session-2',
+        canonicalSessionVersion: 4,
+        movedCheckCount: 2,
+      },
+      error: null,
+    });
+    const gateway = new SupabaseTableOperationGateway({ rpc } as never);
+
+    await expect(
+      gateway.transferOrMerge({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        deviceId: 'device-1' as never,
+        clientMutationId: 'mutation-1' as never,
+        command: {
+          sourceSessionId: 'session-1' as never,
+          targetTableId: 'table-2' as never,
+          expectedSourceVersion: 2,
+          expectedTargetVersion: 3,
+        },
+      }),
+    ).resolves.toMatchObject({
+      mode: 'merged',
+      canonicalSessionId: 'session-2',
+      movedCheckCount: 2,
+    });
+    expect(rpc).toHaveBeenCalledWith(
+      'transfer_or_merge_table_session',
+      expect.objectContaining({
+        requested_client_mutation_id: 'mutation-1',
+      }),
+    );
+  });
+});

--- a/src/features/table-operations/index.ts
+++ b/src/features/table-operations/index.ts
@@ -1,0 +1,2 @@
+export * from './TableOperationSheet';
+export * from './tableOperationGateway';

--- a/src/features/table-operations/tableOperationGateway.ts
+++ b/src/features/table-operations/tableOperationGateway.ts
@@ -1,0 +1,97 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import {
+  BranchId,
+  DeviceId,
+  MutationId,
+  OrganizationId,
+  RestaurantTableId,
+  TableSessionId,
+} from '../../domain';
+import { Database, Json } from '../../services/supabase';
+
+export interface TransferTableSessionCommand {
+  readonly sourceSessionId: TableSessionId;
+  readonly targetTableId: RestaurantTableId;
+  readonly expectedSourceVersion: number;
+  readonly expectedTargetVersion: number | null;
+}
+
+export interface TransferTableSessionRequest {
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly deviceId: DeviceId;
+  readonly clientMutationId: MutationId;
+  readonly command: TransferTableSessionCommand;
+}
+
+export interface TransferTableSessionResult {
+  readonly status: 'applied';
+  readonly mode: 'moved' | 'merged';
+  readonly sourceTableId: string;
+  readonly targetTableId: string;
+  readonly sourceSessionId: string;
+  readonly canonicalSessionId: string;
+  readonly canonicalSessionVersion: number;
+  readonly movedCheckCount: number;
+}
+
+export class TableOperationError extends Error {
+  constructor(
+    message: string,
+    readonly code?: string,
+    readonly details?: string,
+  ) {
+    super(message);
+    this.name = 'TableOperationError';
+  }
+}
+
+export class SupabaseTableOperationGateway {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async transferOrMerge(request: TransferTableSessionRequest): Promise<TransferTableSessionResult> {
+    const { data, error } = await this.client.rpc('transfer_or_merge_table_session', {
+      requested_organization_id: request.organizationId,
+      requested_branch_id: request.branchId,
+      requested_device_id: request.deviceId,
+      requested_client_mutation_id: request.clientMutationId,
+      requested_payload: request.command as unknown as Json,
+    });
+    if (error) throw new TableOperationError(error.message, error.code, error.details);
+    return parseResult(data);
+  }
+}
+
+function parseResult(value: Json): TransferTableSessionResult {
+  if (
+    !isRecord(value) ||
+    value.status !== 'applied' ||
+    (value.mode !== 'moved' && value.mode !== 'merged') ||
+    typeof value.sourceTableId !== 'string' ||
+    typeof value.targetTableId !== 'string' ||
+    typeof value.sourceSessionId !== 'string' ||
+    typeof value.canonicalSessionId !== 'string' ||
+    !isSafeInteger(value.canonicalSessionVersion) ||
+    !isSafeInteger(value.movedCheckCount)
+  ) {
+    throw new Error('Table operation RPC returned an invalid result');
+  }
+  return {
+    status: value.status,
+    mode: value.mode,
+    sourceTableId: value.sourceTableId,
+    targetTableId: value.targetTableId,
+    sourceSessionId: value.sourceSessionId,
+    canonicalSessionId: value.canonicalSessionId,
+    canonicalSessionVersion: value.canonicalSessionVersion,
+    movedCheckCount: value.movedCheckCount,
+  };
+}
+
+function isRecord(value: Json): value is { readonly [key: string]: Json | undefined } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSafeInteger(value: Json | undefined): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value);
+}

--- a/src/features/table-workspace/workspaceModel.ts
+++ b/src/features/table-workspace/workspaceModel.ts
@@ -32,7 +32,10 @@ export interface WorkspaceProduct extends MenuItem {
 
 export interface TableWorkspaceSnapshot {
   readonly table: RestaurantTable;
+  readonly tables: readonly RestaurantTable[];
+  readonly activeSessions: readonly TableSession[];
   readonly session?: TableSession;
+  readonly sessionChecks: readonly Check[];
   readonly checks: readonly Check[];
   readonly orderItems: readonly OrderItem[];
   readonly orderItemModifiers: readonly OrderItemModifier[];
@@ -50,7 +53,7 @@ export async function loadTableWorkspace(
   tableId: RestaurantTableId,
 ): Promise<TableWorkspaceSnapshot | null> {
   const [
-    table,
+    restaurantTables,
     sessions,
     checks,
     orderItems,
@@ -64,7 +67,7 @@ export async function loadTableWorkspace(
     cancellationReasons,
     conflicts,
   ] = await Promise.all([
-    database.repository('restaurantTables').getById(scope, tableId),
+    loadAll(database, 'restaurantTables', scope),
     loadAll(database, 'tableSessions', scope),
     loadAll(database, 'checks', scope),
     loadAll(database, 'orderItems', scope),
@@ -78,26 +81,25 @@ export async function loadTableWorkspace(
     loadAll(database, 'cancellationReasons', scope),
     database.syncState.listConflicts(scope, ['unresolved']),
   ]);
+  const table = restaurantTables.find((candidate) => candidate.id === tableId);
   if (!table || table.deletedAt) return null;
 
-  const session = sessions
-    .filter(
-      (candidate) =>
-        candidate.tableId === table.id &&
-        (candidate.status === 'open' || candidate.status === 'payment_pending') &&
-        !candidate.deletedAt,
-    )
+  const activeSessions = sessions.filter(
+    (candidate) =>
+      (candidate.status === 'open' || candidate.status === 'payment_pending') &&
+      !candidate.deletedAt,
+  );
+  const session = activeSessions
+    .filter((candidate) => candidate.tableId === table.id)
     .sort((left, right) => right.openedAt.localeCompare(left.openedAt))[0];
-  const activeChecks = session
+  const sessionChecks = session
     ? checks
-        .filter(
-          (check) =>
-            check.tableSessionId === session.id &&
-            (check.status === 'open' || check.status === 'partially_paid') &&
-            !check.deletedAt,
-        )
+        .filter((check) => check.tableSessionId === session.id && !check.deletedAt)
         .sort((left, right) => left.openedAt.localeCompare(right.openedAt))
     : [];
+  const activeChecks = sessionChecks.filter(
+    (check) => check.status === 'open' || check.status === 'partially_paid',
+  );
   const checkIds = new Set(activeChecks.map((check) => check.id));
   const activeItems = orderItems
     .filter((item) => checkIds.has(item.checkId) && !item.deletedAt)
@@ -136,7 +138,14 @@ export async function loadTableWorkspace(
 
   return {
     table,
+    tables: restaurantTables
+      .filter((candidate) => !candidate.deletedAt)
+      .sort(
+        (left, right) => left.sortOrder - right.sortOrder || left.label.localeCompare(right.label),
+      ),
+    activeSessions,
     ...(session ? { session } : {}),
+    sessionChecks,
     checks: activeChecks,
     orderItems: activeItems,
     orderItemModifiers: orderItemModifiers.filter((modifier) => itemIds.has(modifier.orderItemId)),

--- a/src/screens/TableDetailScreen.tsx
+++ b/src/screens/TableDetailScreen.tsx
@@ -52,6 +52,11 @@ import {
   updateOrderItemNote,
 } from '../features/table-workspace';
 import { ConfirmCheckPaymentsCommand, PaymentSheet } from '../features/payments';
+import {
+  TableOperationSheet,
+  TableOperationTarget,
+  TransferTableSessionCommand,
+} from '../features/table-operations';
 import { Language, useLocalization } from '../i18n';
 import { RootStackParamList } from '../navigation/AppNavigator';
 import { createTextMatcher } from '../utils/searchUtils';
@@ -111,6 +116,7 @@ function CloudTableWorkspace({
     revision,
     scope,
     sync,
+    transferOrMergeTableSession,
   } = useOrderiaData();
   const [snapshot, setSnapshot] = useState<TableWorkspaceSnapshot | null>(null);
   const [loading, setLoading] = useState(true);
@@ -134,6 +140,8 @@ function CloudTableWorkspace({
   const [editingNote, setEditingNote] = useState('');
   const [payingCheck, setPayingCheck] = useState<Check>();
   const [paymentBusy, setPaymentBusy] = useState(false);
+  const [showTableOperation, setShowTableOperation] = useState(false);
+  const [tableOperationBusy, setTableOperationBusy] = useState(false);
   const [waiterNames, setWaiterNames] = useState<Readonly<Record<string, string>>>({});
   const [participantNames, setParticipantNames] = useState<readonly string[]>([]);
   const [incomingMessage, setIncomingMessage] = useState<string>();
@@ -280,6 +288,18 @@ function CloudTableWorkspace({
         0,
       )
     : 0;
+  const tableOperationTargets: readonly TableOperationTarget[] = snapshot
+    ? snapshot.tables
+        .filter((candidate) => candidate.id !== snapshot.table.id)
+        .map((table) => ({
+          table,
+          ...(snapshot.activeSessions.find((session) => session.tableId === table.id)
+            ? {
+                session: snapshot.activeSessions.find((session) => session.tableId === table.id)!,
+              }
+            : {}),
+        }))
+    : [];
 
   const rememberDraft = (next: readonly DraftOrderLine[]) => {
     setUndoStack((history) => [...history.slice(-19), draft]);
@@ -464,6 +484,41 @@ function CloudTableWorkspace({
     }
   };
 
+  const performTableOperation = async (
+    command: TransferTableSessionCommand,
+    target: TableOperationTarget,
+  ) => {
+    setTableOperationBusy(true);
+    try {
+      const clientMutationId = toDomainId<MutationId>(secureUuid());
+      const result = await transferOrMergeTableSession(deviceId, clientMutationId, command);
+      setShowTableOperation(false);
+      Alert.alert(
+        result.mode === 'merged' ? copy.tablesMerged : copy.tableMoved,
+        `${snapshot?.table.label ?? ''} → ${target.table.label}`,
+      );
+      navigation.replace('TableDetail', { tableId: target.table.id });
+    } catch (error) {
+      const message =
+        error instanceof Error &&
+        [
+          'source_session_changed',
+          'source_session_version_conflict',
+          'target_session_changed',
+          'target_session_version_conflict',
+        ].includes(error.message)
+          ? copy.tableChanged
+          : error instanceof Error
+            ? error.message
+            : copy.tryAgain;
+      await refresh().catch(() => undefined);
+      await reload();
+      throw new Error(message);
+    } finally {
+      setTableOperationBusy(false);
+    }
+  };
+
   const toggleFavorite = (productId: string) => {
     const next = favoriteIds.includes(productId)
       ? favoriteIds.filter((id) => id !== productId)
@@ -521,7 +576,9 @@ function CloudTableWorkspace({
       style={{ flex: 1, backgroundColor: tokens.colors.bg }}
     >
       <WorkspaceHeader
+        moveLabel={copy.moveTable}
         onBack={navigation.goBack}
+        onMove={snapshot.session ? () => setShowTableOperation(true) : undefined}
         participantNames={participantNames}
         syncLabel={
           sync.online
@@ -740,6 +797,22 @@ function CloudTableWorkspace({
           visible
         />
       ) : null}
+      {showTableOperation && snapshot.session ? (
+        <TableOperationSheet
+          busy={tableOperationBusy}
+          language={language}
+          onClose={() => {
+            if (!tableOperationBusy) setShowTableOperation(false);
+          }}
+          onConfirm={performTableOperation}
+          online={sync.online}
+          sourceChecks={snapshot.sessionChecks}
+          sourceSession={snapshot.session}
+          sourceTable={snapshot.table}
+          targets={tableOperationTargets}
+          visible
+        />
+      ) : null}
 
       {runtimeError ? (
         <View
@@ -766,12 +839,16 @@ function WorkspaceHeader({
   syncTone,
   participantNames,
   onBack,
+  onMove,
+  moveLabel,
 }: {
   readonly tableLabel: string;
   readonly syncLabel: string;
   readonly syncTone: 'success' | 'warning' | 'error';
   readonly participantNames: readonly string[];
   readonly onBack: () => void;
+  readonly onMove?: () => void;
+  readonly moveLabel: string;
 }) {
   const { tokens } = useTheme();
   return (
@@ -793,6 +870,9 @@ function WorkspaceHeader({
         >
           {tableLabel}
         </Text>
+        {onMove ? (
+          <ServiceIconButton icon="swap-horizontal-outline" label={moveLabel} onPress={onMove} />
+        ) : null}
         <ServiceStatusPill label={syncLabel} tone={syncTone} />
       </View>
       {participantNames.length > 0 ? (
@@ -1802,6 +1882,10 @@ interface WorkspaceCopy {
   readonly paymentFailed: string;
   readonly paymentChanged: string;
   readonly remaining: string;
+  readonly moveTable: string;
+  readonly tableMoved: string;
+  readonly tablesMerged: string;
+  readonly tableChanged: string;
 }
 
 function workspaceCopy(language: Language): WorkspaceCopy {
@@ -1868,6 +1952,10 @@ function workspaceCopy(language: Language): WorkspaceCopy {
       paymentFailed: 'Ödeme kesinleştirilemedi',
       paymentChanged: 'Hesap başka bir cihazda değişti. Güncel kalan tutarı kontrol edin.',
       remaining: 'Kalan',
+      moveTable: 'Masayı taşı veya birleştir',
+      tableMoved: 'Masa taşındı',
+      tablesMerged: 'Masalar birleştirildi',
+      tableChanged: 'Kaynak veya hedef masa başka bir cihazda değişti. Güncel durumu kontrol edin.',
     };
   }
   if (language === 'bg') {
@@ -1933,6 +2021,10 @@ function workspaceCopy(language: Language): WorkspaceCopy {
       paymentFailed: 'Плащането не бе потвърдено',
       paymentChanged: 'Сметката е променена на друго устройство. Проверете остатъка.',
       remaining: 'Остава',
+      moveTable: 'Премести или обедини маса',
+      tableMoved: 'Масата е преместена',
+      tablesMerged: 'Масите са обединени',
+      tableChanged: 'Източникът или целта са променени. Проверете текущото състояние.',
     };
   }
   return {
@@ -1997,5 +2089,9 @@ function workspaceCopy(language: Language): WorkspaceCopy {
     paymentFailed: 'Payment could not be confirmed',
     paymentChanged: 'The check changed on another device. Review the current balance.',
     remaining: 'Remaining',
+    moveTable: 'Move or merge table',
+    tableMoved: 'Table moved',
+    tablesMerged: 'Tables merged',
+    tableChanged: 'The source or target changed on another device. Review the current state.',
   };
 }

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -188,6 +188,16 @@ export type Database = {
         };
         Returns: ActiveSessionParticipantRow[];
       };
+      transfer_or_merge_table_session: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_device_id: string;
+          requested_client_mutation_id: string;
+          requested_payload: Json;
+        };
+        Returns: Json;
+      };
       pull_sync_events: {
         Args: {
           requested_organization_id: string;

--- a/supabase/migrations/20260727003000_table_transfer_merge.sql
+++ b/supabase/migrations/20260727003000_table_transfer_merge.sql
@@ -1,0 +1,463 @@
+-- Atomic table transfer and merge.
+--
+-- Composite foreign keys are made explicitly deferrable so a complete session
+-- graph can move to another active session inside one transaction. They remain
+-- immediate by default everywhere else.
+
+alter table public.order_batches
+  alter constraint order_batches_check_scope_fkey
+  deferrable initially immediate;
+alter table public.order_items
+  alter constraint order_items_batch_scope_fkey
+  deferrable initially immediate;
+alter table public.receipts
+  alter constraint receipts_check_scope_fkey
+  deferrable initially immediate;
+
+create or replace function public.transfer_or_merge_table_session(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_device_id uuid,
+  requested_client_mutation_id uuid,
+  requested_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  caller_user_id uuid := (select auth.uid());
+  fingerprint text;
+  claimed_mutation_id uuid;
+  prior_mutation public.client_mutations;
+  source_table public.restaurant_tables;
+  target_table public.restaurant_tables;
+  source_session public.table_sessions;
+  target_session public.table_sessions;
+  canonical_session public.table_sessions;
+  requested_source_session_id uuid;
+  requested_target_table_id uuid;
+  expected_source_version bigint;
+  expected_target_version bigint;
+  operation_mode text;
+  moved_check_count bigint := 0;
+  mutation_result jsonb;
+begin
+  if caller_user_id is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if requested_payload is null
+    or jsonb_typeof(requested_payload) is distinct from 'object'
+    or requested_payload - array[
+      'sourceSessionId',
+      'targetTableId',
+      'expectedSourceVersion',
+      'expectedTargetVersion'
+    ] <> '{}'::jsonb
+    or not (requested_payload ?& array[
+      'sourceSessionId',
+      'targetTableId',
+      'expectedSourceVersion',
+      'expectedTargetVersion'
+    ]) then
+    raise exception using errcode = '22023', message = 'invalid_table_transfer_payload';
+  end if;
+  if not private.is_active_member(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'branch_access_denied';
+  end if;
+  if not exists (
+    select 1
+    from public.devices as device
+    where device.id = requested_device_id
+      and device.organization_id = requested_organization_id
+      and device.branch_id = requested_branch_id
+      and device.user_id = caller_user_id
+      and device.revoked_at is null
+  ) then
+    raise exception using errcode = '42501', message = 'device_access_denied';
+  end if;
+
+  requested_source_session_id := (requested_payload ->> 'sourceSessionId')::uuid;
+  requested_target_table_id := (requested_payload ->> 'targetTableId')::uuid;
+  expected_source_version := (requested_payload ->> 'expectedSourceVersion')::bigint;
+  expected_target_version := (requested_payload ->> 'expectedTargetVersion')::bigint;
+  if expected_source_version is null or expected_source_version < 1 then
+    raise exception using errcode = '22023', message = 'invalid_source_session_version';
+  end if;
+
+  fingerprint := md5(concat_ws(
+    ':',
+    requested_organization_id::text,
+    requested_branch_id::text,
+    requested_device_id::text,
+    requested_client_mutation_id::text,
+    'table_sessions.transfer_or_merge',
+    requested_source_session_id::text,
+    requested_payload::text
+  ));
+
+  insert into public.client_mutations (
+    organization_id,
+    branch_id,
+    device_id,
+    client_mutation_id,
+    mutation_type,
+    entity_id,
+    request_fingerprint,
+    result_json
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    requested_device_id,
+    requested_client_mutation_id,
+    'table_sessions.transfer_or_merge',
+    requested_source_session_id,
+    fingerprint,
+    '{}'::jsonb
+  )
+  on conflict (device_id, client_mutation_id) do nothing
+  returning id into claimed_mutation_id;
+
+  if claimed_mutation_id is null then
+    select mutation.*
+    into prior_mutation
+    from public.client_mutations as mutation
+    where mutation.device_id = requested_device_id
+      and mutation.client_mutation_id = requested_client_mutation_id;
+    if prior_mutation.id is null then
+      raise exception using
+        errcode = '40001',
+        message = 'idempotency_result_temporarily_unavailable';
+    end if;
+    if prior_mutation.request_fingerprint <> fingerprint then
+      raise exception using
+        errcode = '22023',
+        message = 'client_mutation_id_reused_with_different_content';
+    end if;
+    return prior_mutation.result_json;
+  end if;
+
+  select session.*
+  into source_session
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.id = requested_source_session_id
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null;
+  if source_session.id is null then
+    raise exception using errcode = '22023', message = 'source_session_not_active';
+  end if;
+  if source_session.table_id = requested_target_table_id then
+    raise exception using errcode = '22023', message = 'source_and_target_table_match';
+  end if;
+
+  perform 1
+  from public.restaurant_tables as restaurant_table
+  where restaurant_table.organization_id = requested_organization_id
+    and restaurant_table.branch_id = requested_branch_id
+    and restaurant_table.id in (source_session.table_id, requested_target_table_id)
+    and restaurant_table.deleted_at is null
+  order by restaurant_table.id
+  for update;
+
+  select restaurant_table.*
+  into source_table
+  from public.restaurant_tables as restaurant_table
+  where restaurant_table.organization_id = requested_organization_id
+    and restaurant_table.branch_id = requested_branch_id
+    and restaurant_table.id = source_session.table_id
+    and restaurant_table.deleted_at is null;
+  select restaurant_table.*
+  into target_table
+  from public.restaurant_tables as restaurant_table
+  where restaurant_table.organization_id = requested_organization_id
+    and restaurant_table.branch_id = requested_branch_id
+    and restaurant_table.id = requested_target_table_id
+    and restaurant_table.deleted_at is null;
+  if source_table.id is null or target_table.id is null then
+    raise exception using errcode = '22023', message = 'transfer_table_not_found';
+  end if;
+
+  select session.*
+  into target_session
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.table_id = target_table.id
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null
+  order by session.opened_at desc
+  limit 1;
+
+  -- Payments lock check -> session. Match that order here to avoid a transfer
+  -- deadlock while a waiter is confirming a payment.
+  perform 1
+  from public.checks as check_row
+  where check_row.organization_id = requested_organization_id
+    and check_row.branch_id = requested_branch_id
+    and check_row.table_session_id in (
+      source_session.id,
+      coalesce(target_session.id, source_session.id)
+    )
+    and check_row.deleted_at is null
+  order by check_row.id
+  for update;
+
+  perform 1
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.table_id in (source_table.id, target_table.id)
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null
+  order by session.id
+  for update;
+
+  select session.*
+  into source_session
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.id = requested_source_session_id
+    and session.table_id = source_table.id
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null;
+  if source_session.id is null then
+    raise exception using errcode = 'P0001', message = 'source_session_changed';
+  end if;
+  if source_session.version <> expected_source_version then
+    raise exception using
+      errcode = 'P0001',
+      message = 'source_session_version_conflict',
+      detail = jsonb_build_object(
+        'serverVersion', source_session.version,
+        'serverPayload', to_jsonb(source_session)
+      )::text;
+  end if;
+
+  select session.*
+  into target_session
+  from public.table_sessions as session
+  where session.organization_id = requested_organization_id
+    and session.branch_id = requested_branch_id
+    and session.table_id = target_table.id
+    and session.status in ('open', 'payment_pending')
+    and session.deleted_at is null
+  order by session.opened_at desc
+  limit 1;
+
+  select count(*)
+  into moved_check_count
+  from public.checks as check_row
+  where check_row.organization_id = requested_organization_id
+    and check_row.branch_id = requested_branch_id
+    and check_row.table_session_id = source_session.id
+    and check_row.deleted_at is null;
+
+  if target_session.id is null then
+    if expected_target_version is not null then
+      raise exception using errcode = 'P0001', message = 'target_session_changed';
+    end if;
+    update public.table_sessions
+    set table_id = target_table.id,
+        transferred_from_table_id = source_table.id,
+        updated_at = now(),
+        version = source_session.version + 1
+    where id = source_session.id
+    returning * into canonical_session;
+    operation_mode := 'moved';
+  else
+    if expected_target_version is null or target_session.version <> expected_target_version then
+      raise exception using
+        errcode = 'P0001',
+        message = 'target_session_version_conflict',
+        detail = jsonb_build_object(
+          'serverVersion', target_session.version,
+          'serverPayload', to_jsonb(target_session)
+        )::text;
+    end if;
+
+    set constraints
+      public.order_batches_check_scope_fkey,
+      public.order_items_batch_scope_fkey,
+      public.receipts_check_scope_fkey
+    deferred;
+
+    update public.checks
+    set table_session_id = target_session.id,
+        updated_at = now(),
+        version = version + 1
+    where organization_id = requested_organization_id
+      and branch_id = requested_branch_id
+      and table_session_id = source_session.id;
+    update public.order_batches
+    set table_session_id = target_session.id
+    where organization_id = requested_organization_id
+      and branch_id = requested_branch_id
+      and table_session_id = source_session.id;
+
+    update public.order_items
+    set table_session_id = target_session.id,
+        updated_at = now(),
+        updated_by = caller_user_id,
+        version = version + 1
+    where organization_id = requested_organization_id
+      and branch_id = requested_branch_id
+      and table_session_id = source_session.id;
+
+    update public.payments
+    set table_session_id = target_session.id
+    where organization_id = requested_organization_id
+      and branch_id = requested_branch_id
+      and table_session_id = source_session.id;
+
+    update public.receipts
+    set table_session_id = target_session.id
+    where organization_id = requested_organization_id
+      and branch_id = requested_branch_id
+      and table_session_id = source_session.id;
+
+    insert into public.session_participants (
+      organization_id,
+      branch_id,
+      table_session_id,
+      user_id,
+      first_action_at,
+      last_action_at
+    )
+    select
+      participant.organization_id,
+      participant.branch_id,
+      target_session.id,
+      participant.user_id,
+      participant.first_action_at,
+      participant.last_action_at
+    from public.session_participants as participant
+    where participant.organization_id = requested_organization_id
+      and participant.branch_id = requested_branch_id
+      and participant.table_session_id = source_session.id
+    on conflict (table_session_id, user_id) do update
+    set first_action_at = least(
+          public.session_participants.first_action_at,
+          excluded.first_action_at
+        ),
+        last_action_at = greatest(
+          public.session_participants.last_action_at,
+          excluded.last_action_at
+        );
+
+    delete from public.session_participants
+    where organization_id = requested_organization_id
+      and branch_id = requested_branch_id
+      and table_session_id = source_session.id;
+
+    update public.table_sessions
+    set status = 'voided',
+        closed_by = caller_user_id,
+        closed_at = now(),
+        transferred_from_table_id = source_table.id,
+        note = concat_ws(
+          E'\n',
+          nullif(trim(note), ''),
+          concat('Merged into session ', target_session.id::text)
+        ),
+        updated_at = now(),
+        version = source_session.version + 1
+    where id = source_session.id;
+
+    update public.table_sessions
+    set status = case
+          when status = 'payment_pending' or source_session.status = 'payment_pending'
+            then 'payment_pending'
+          else 'open'
+        end,
+        updated_at = now(),
+        version = target_session.version + 1
+    where id = target_session.id
+    returning * into canonical_session;
+    operation_mode := 'merged';
+  end if;
+
+  insert into public.session_participants (
+    organization_id,
+    branch_id,
+    table_session_id,
+    user_id,
+    first_action_at,
+    last_action_at
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    canonical_session.id,
+    caller_user_id,
+    now(),
+    now()
+  )
+  on conflict (table_session_id, user_id) do update
+  set last_action_at = excluded.last_action_at;
+
+  mutation_result := jsonb_build_object(
+    'status', 'applied',
+    'mode', operation_mode,
+    'sourceTableId', source_table.id,
+    'targetTableId', target_table.id,
+    'sourceSessionId', source_session.id,
+    'canonicalSessionId', canonical_session.id,
+    'canonicalSessionVersion', canonical_session.version,
+    'movedCheckCount', moved_check_count
+  );
+
+  insert into public.audit_events (
+    organization_id,
+    branch_id,
+    actor_user_id,
+    device_id,
+    entity_type,
+    entity_id,
+    action,
+    before_json,
+    after_json,
+    client_mutation_id,
+    correlation_id
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    caller_user_id,
+    requested_device_id,
+    'table_sessions',
+    source_session.id,
+    concat('table_sessions.', operation_mode),
+    to_jsonb(source_session),
+    mutation_result,
+    requested_client_mutation_id,
+    requested_client_mutation_id
+  );
+
+  update public.client_mutations
+  set result_json = mutation_result,
+      committed_at = now()
+  where id = claimed_mutation_id;
+
+  return mutation_result;
+end;
+$$;
+
+revoke execute on function public.transfer_or_merge_table_session(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb
+) from public, anon;
+grant execute on function public.transfer_or_merge_table_session(
+  uuid,
+  uuid,
+  uuid,
+  uuid,
+  jsonb
+) to authenticated;

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(34);
+select plan(49);
 
 insert into auth.users (
   instance_id,
@@ -156,15 +156,34 @@ insert into public.restaurant_tables (
   sequence_number,
   sort_order
 )
-values (
-  '65000000-0000-4000-8000-000000000001',
-  '25000000-0000-4000-8000-000000000001',
-  '35000000-0000-4000-8000-000000000001',
-  '55000000-0000-4000-8000-000000000001',
-  'Masa 4',
-  4,
-  4
-);
+values
+  (
+    '65000000-0000-4000-8000-000000000001',
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'Masa 4',
+    4,
+    4
+  ),
+  (
+    '65000000-0000-4000-8000-000000000002',
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'Masa 5',
+    5,
+    5
+  ),
+  (
+    '65000000-0000-4000-8000-000000000003',
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    '55000000-0000-4000-8000-000000000001',
+    'Masa 6',
+    6,
+    6
+  );
 
 insert into public.menu_categories (
   id,
@@ -871,6 +890,230 @@ select is(
   ),
   3::bigint,
   'an idempotent replay never duplicates allocations'
+);
+
+select is(
+  (
+    public.transfer_or_merge_table_session(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000031',
+      jsonb_build_object(
+        'sourceSessionId', 'e5000000-0000-4000-8000-000000000001',
+        'targetTableId', '65000000-0000-4000-8000-000000000002',
+        'expectedSourceVersion', 3,
+        'expectedTargetVersion', null
+      )
+    ) ->> 'mode'
+  ),
+  'moved',
+  'an active session moves atomically to an empty table'
+);
+select is(
+  (
+    select table_id
+    from public.table_sessions
+    where id = 'e5000000-0000-4000-8000-000000000001'
+  ),
+  '65000000-0000-4000-8000-000000000002'::uuid,
+  'the moved session now belongs to the target table'
+);
+select is(
+  (
+    select transferred_from_table_id
+    from public.table_sessions
+    where id = 'e5000000-0000-4000-8000-000000000001'
+  ),
+  '65000000-0000-4000-8000-000000000001'::uuid,
+  'the moved session retains its source table attribution'
+);
+select is(
+  (
+    select original_table_id
+    from public.order_items
+    where id = 'd5000000-0000-4000-8000-000000000111'
+  ),
+  '65000000-0000-4000-8000-000000000001'::uuid,
+  'moving a table never rewrites the order item origin'
+);
+select is(
+  (
+    public.transfer_or_merge_table_session(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000031',
+      jsonb_build_object(
+        'sourceSessionId', 'e5000000-0000-4000-8000-000000000001',
+        'targetTableId', '65000000-0000-4000-8000-000000000002',
+        'expectedSourceVersion', 3,
+        'expectedTargetVersion', null
+      )
+    ) ->> 'mode'
+  ),
+  'moved',
+  'an exact empty-table transfer replay returns its stored result'
+);
+
+reset role;
+insert into public.table_sessions (
+  id,
+  organization_id,
+  branch_id,
+  table_id,
+  status,
+  opened_by,
+  opened_at,
+  version
+)
+values (
+  'e5000000-0000-4000-8000-000000000301',
+  '25000000-0000-4000-8000-000000000001',
+  '35000000-0000-4000-8000-000000000001',
+  '65000000-0000-4000-8000-000000000003',
+  'open',
+  '15000000-0000-4000-8000-000000000001',
+  now(),
+  1
+);
+insert into public.checks (
+  id,
+  organization_id,
+  branch_id,
+  table_session_id,
+  name,
+  status,
+  opened_by,
+  opened_at,
+  version
+)
+values (
+  'f5000000-0000-4000-8000-000000000301',
+  '25000000-0000-4000-8000-000000000001',
+  '35000000-0000-4000-8000-000000000001',
+  'e5000000-0000-4000-8000-000000000301',
+  'Bahçe',
+  'open',
+  '15000000-0000-4000-8000-000000000001',
+  now(),
+  1
+);
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    public.transfer_or_merge_table_session(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000032',
+      jsonb_build_object(
+        'sourceSessionId', 'e5000000-0000-4000-8000-000000000001',
+        'targetTableId', '65000000-0000-4000-8000-000000000003',
+        'expectedSourceVersion', 4,
+        'expectedTargetVersion', 1
+      )
+    ) ->> 'mode'
+  ),
+  'merged',
+  'a transfer into an occupied table merges the sessions atomically'
+);
+select is(
+  (
+    select status
+    from public.table_sessions
+    where id = 'e5000000-0000-4000-8000-000000000001'
+  ),
+  'voided',
+  'the merged source session is retained as an explicit voided record'
+);
+select is(
+  (
+    select count(*)
+    from public.table_sessions
+    where table_id = '65000000-0000-4000-8000-000000000003'
+      and status in ('open', 'payment_pending')
+  ),
+  1::bigint,
+  'the occupied target keeps exactly one active canonical session'
+);
+select is(
+  (
+    select count(*)
+    from public.checks
+    where table_session_id = 'e5000000-0000-4000-8000-000000000301'
+  ),
+  2::bigint,
+  'all named checks are preserved separately on the merged session'
+);
+select is(
+  (
+    select string_agg(name, ',' order by name)
+    from public.checks
+    where table_session_id = 'e5000000-0000-4000-8000-000000000301'
+  ),
+  'Bahçe,Pencere tarafı',
+  'a merge preserves every check name without mixing their contents'
+);
+select is(
+  (
+    select table_session_id
+    from public.order_items
+    where id = 'd5000000-0000-4000-8000-000000000111'
+  ),
+  'e5000000-0000-4000-8000-000000000301'::uuid,
+  'order items follow their named check to the canonical target session'
+);
+select is(
+  (
+    select original_table_session_id
+    from public.order_items
+    where id = 'd5000000-0000-4000-8000-000000000111'
+  ),
+  'e5000000-0000-4000-8000-000000000001'::uuid,
+  'merged order items retain their immutable original session'
+);
+select is(
+  (
+    select count(*)
+    from public.payments
+    where table_session_id = 'e5000000-0000-4000-8000-000000000301'
+  ),
+  3::bigint,
+  'the confirmed payment ledger follows the merged checks'
+);
+select is(
+  (
+    public.transfer_or_merge_table_session(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      '45000000-0000-4000-8000-000000000001',
+      'c5000000-0000-4000-8000-000000000032',
+      jsonb_build_object(
+        'sourceSessionId', 'e5000000-0000-4000-8000-000000000001',
+        'targetTableId', '65000000-0000-4000-8000-000000000003',
+        'expectedSourceVersion', 4,
+        'expectedTargetVersion', 1
+      )
+    ) ->> 'mode'
+  ),
+  'merged',
+  'an exact occupied-table merge replay returns its stored result'
+);
+select is(
+  (
+    select count(*)
+    from public.checks
+    where table_session_id = 'e5000000-0000-4000-8000-000000000301'
+  ),
+  2::bigint,
+  'an idempotent merge replay never duplicates named checks'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes #23

## What changed
- add a fast target-table picker and explicit source-to-target review sheet
- distinguish empty-table moves from occupied-table merges before confirmation
- preserve and display every named check that will remain separate
- add a direct online table-operation gateway with explicit stale-session errors
- add an idempotent Supabase transaction that locks source/target tables, checks, and sessions in deterministic order
- move the full session graph to empty tables or merge checks/orders/payments/receipts into the canonical occupied session
- preserve immutable order origin fields and retain merged source sessions as voided audit records
- make the three composite graph constraints deferrable only for the atomic merge transaction
- extend pgTAP coverage for empty moves, occupied merges, attribution, graph integrity, and exact replay

## Validation
- `npm run verify:full`
- 31 Jest suites / 165 tests / 1 snapshot
- Expo web production export
- 2 Chromium Playwright flows
- Supabase migration/lint/49 pgTAP assertions run in CI

## Stack
- base: `feat/22-split-partial-payments` (#50)