### PR TITLE
feat(receipts): build searchable receipt archive

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -64,3 +64,23 @@ test('uses the rapid table workspace at phone speed', async ({ page }) => {
 
   await expect(page.getByText(/1× Çay/i)).toBeVisible();
 });
+
+test('opens the searchable receipt archive with explicit offline recovery', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  await page
+    .getByText(/Fişler|Разписки|Receipts/i)
+    .last()
+    .click();
+  await expect(
+    page.getByText(/Fiş arşivi|Архив на разписките|Receipt archive/i).first(),
+  ).toBeVisible();
+  await expect(page.getByLabel(/Hızlı arama|Бързо търсене|Quick search/i)).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /^(Filtreler|Филтри|Filters) \(\d+\)$/i }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(/Arşiv şu anda kullanılamıyor|Архивът не е достъпен|Archive unavailable/i),
+  ).toBeVisible();
+});

--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -17,6 +17,12 @@ import {
   SupabasePaymentGateway,
 } from '../../features/payments';
 import {
+  ReceiptArchiveCursor,
+  ReceiptArchiveFilters,
+  ReceiptArchiveGateway,
+  ReceiptArchivePage,
+} from '../../features/receipt-archive';
+import {
   SupabaseTableOperationGateway,
   TransferTableSessionCommand,
   TransferTableSessionResult,
@@ -64,6 +70,11 @@ export interface OrderiaDataContextValue {
     command: TransferTableSessionCommand,
   ): Promise<TransferTableSessionResult>;
   prepareReceiptPdf(receipt: Receipt): Promise<PreparedReceiptPdf>;
+  searchReceiptArchive(
+    filters: ReceiptArchiveFilters,
+    cursor?: ReceiptArchiveCursor,
+    pageSize?: number,
+  ): Promise<ReceiptArchivePage>;
 }
 
 interface OrderiaDataProviderProps {
@@ -296,6 +307,23 @@ export function OrderiaDataProvider({
     [client, refresh, scope],
   );
 
+  const searchReceiptArchive = useCallback(
+    async (
+      filters: ReceiptArchiveFilters,
+      cursor?: ReceiptArchiveCursor,
+      pageSize?: number,
+    ): Promise<ReceiptArchivePage> => {
+      if (!client || !scope) throw new Error('Cloud receipt archive is unavailable');
+      return new ReceiptArchiveGateway(client).search({
+        ...scope,
+        filters,
+        ...(cursor ? { cursor } : {}),
+        ...(pageSize ? { pageSize } : {}),
+      });
+    },
+    [client, scope],
+  );
+
   useEffect(() => {
     if (!database || !scope || !client) return;
 
@@ -389,6 +417,7 @@ export function OrderiaDataProvider({
       confirmCheckPayments,
       transferOrMergeTableSession,
       prepareReceiptPdf,
+      searchReceiptArchive,
     }),
     [
       client,
@@ -402,6 +431,7 @@ export function OrderiaDataProvider({
       resolveActiveParticipants,
       resolveProfileNames,
       revision,
+      searchReceiptArchive,
       scope,
       sync,
       transferOrMergeTableSession,

--- a/src/features/receipt-archive/ReceiptArchiveCard.tsx
+++ b/src/features/receipt-archive/ReceiptArchiveCard.tsx
@@ -1,0 +1,192 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceButton, ServiceStatusPill, ServiceSurface } from '../../design-system';
+import { Language } from '../../i18n';
+import { ReceiptArchiveEntry } from './receiptArchiveGateway';
+
+export interface ReceiptArchiveCardProps {
+  readonly entry: ReceiptArchiveEntry;
+  readonly language: Language;
+  readonly busy?: boolean;
+  readonly onDetail: () => void;
+  readonly onDownload: () => void;
+  readonly onShare: () => void;
+}
+
+export function ReceiptArchiveCard({
+  entry,
+  language,
+  busy = false,
+  onDetail,
+  onDownload,
+  onShare,
+}: ReceiptArchiveCardProps) {
+  const { tokens } = useTheme();
+  const copy = cardCopy(language);
+  const { receipt } = entry;
+  const checkNames = receipt.snapshot.checks.map((check) => check.name).join(', ');
+  const waiters = receipt.snapshot.waiterDisplayNames.join(', ') || copy.unknownWaiter;
+
+  return (
+    <ServiceSurface
+      style={{
+        gap: tokens.space.md,
+        marginBottom: tokens.space.sm,
+        padding: tokens.space.md,
+      }}
+      variant="outlined"
+    >
+      <View
+        style={{
+          alignItems: 'flex-start',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <View style={{ flex: 1, paddingRight: tokens.space.sm }}>
+          <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}>
+            {receipt.snapshot.tableLabel} · {checkNames}
+          </Text>
+          <Text
+            style={[
+              tokens.typography.caption,
+              { color: tokens.colors.textSubtle, marginTop: tokens.space.xxs },
+            ]}
+          >
+            {formatIssuedAt(receipt.issuedAt, entry.branchTimezone, language)}
+          </Text>
+        </View>
+        <Text style={[tokens.typography.money, { color: tokens.colors.primary }]}>
+          {formatMoney(receipt.totalMinor, receipt.currencyCode, language)}
+        </Text>
+      </View>
+
+      <View style={{ gap: tokens.space.xs }}>
+        <MetaRow icon="receipt-outline" value={receipt.receiptNumber} />
+        <MetaRow icon="person-outline" value={waiters} />
+        <MetaRow
+          icon="card-outline"
+          value={[
+            ...new Set(receipt.snapshot.payments.map((payment) => copy[payment.method])),
+          ].join(' + ')}
+        />
+      </View>
+
+      {entry.hasAdjustment || receipt.status !== 'issued' ? (
+        <ServiceStatusPill icon="alert-circle-outline" label={copy.adjusted} tone="warning" />
+      ) : null}
+
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+        <ServiceButton
+          disabled={busy}
+          icon="eye-outline"
+          label={copy.detail}
+          onPress={onDetail}
+          style={{ flexGrow: 1 }}
+          variant="ghost"
+        />
+        <ServiceButton
+          disabled={busy || !receipt.pdfStoragePath}
+          icon="download-outline"
+          label={copy.download}
+          loading={busy}
+          onPress={onDownload}
+          style={{ flexGrow: 1 }}
+          variant="outline"
+        />
+        <ServiceButton
+          disabled={busy || !receipt.pdfStoragePath}
+          icon="share-social-outline"
+          label={copy.share}
+          onPress={onShare}
+          style={{ flexGrow: 1 }}
+          variant="outline"
+        />
+      </View>
+    </ServiceSurface>
+  );
+}
+
+function MetaRow({
+  icon,
+  value,
+}: {
+  readonly icon: keyof typeof Ionicons.glyphMap;
+  readonly value: string;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ alignItems: 'center', flexDirection: 'row' }}>
+      <Ionicons color={tokens.colors.textMuted} name={icon} size={16} />
+      <Text
+        numberOfLines={2}
+        style={[
+          tokens.typography.caption,
+          { color: tokens.colors.textSubtle, marginLeft: tokens.space.xs },
+        ]}
+      >
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+function formatIssuedAt(value: string, timeZone: string, language: Language): string {
+  return new Intl.DateTimeFormat(locale(language), {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone,
+  }).format(new Date(value));
+}
+
+function formatMoney(amountMinor: number, currency: string, language: Language): string {
+  const formatter = new Intl.NumberFormat(locale(language), {
+    currency,
+    style: 'currency',
+  });
+  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+  return formatter.format(amountMinor / 10 ** fractionDigits);
+}
+
+function locale(language: Language): string {
+  return language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-US';
+}
+
+function cardCopy(language: Language) {
+  if (language === 'tr') {
+    return {
+      detail: 'Detay',
+      download: 'PDF indir',
+      share: 'Paylaş',
+      adjusted: 'Düzeltme içeriyor',
+      unknownWaiter: 'Garson bilinmiyor',
+      cash: 'Nakit',
+      card: 'Kart',
+      mixed_adjustment: 'Düzeltme',
+    };
+  }
+  if (language === 'bg') {
+    return {
+      detail: 'Детайли',
+      download: 'PDF',
+      share: 'Сподели',
+      adjusted: 'Има корекция',
+      unknownWaiter: 'Неизвестен сервитьор',
+      cash: 'В брой',
+      card: 'Карта',
+      mixed_adjustment: 'Корекция',
+    };
+  }
+  return {
+    detail: 'Details',
+    download: 'Download PDF',
+    share: 'Share',
+    adjusted: 'Contains adjustment',
+    unknownWaiter: 'Unknown waiter',
+    cash: 'Cash',
+    card: 'Card',
+    mixed_adjustment: 'Adjustment',
+  };
+}

--- a/src/features/receipt-archive/ReceiptArchiveFilterSheet.tsx
+++ b/src/features/receipt-archive/ReceiptArchiveFilterSheet.tsx
@@ -1,0 +1,324 @@
+import React from 'react';
+import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceButton, ServiceTextField } from '../../design-system';
+import { Language } from '../../i18n';
+import { ReceiptArchiveFilterDraft } from './receiptArchiveFilters';
+
+export interface ReceiptArchiveFilterSheetProps {
+  readonly draft: ReceiptArchiveFilterDraft;
+  readonly language: Language;
+  readonly visible: boolean;
+  readonly onApply: () => void;
+  readonly onChange: (draft: ReceiptArchiveFilterDraft) => void;
+  readonly onClose: () => void;
+  readonly onReset: () => void;
+}
+
+export function ReceiptArchiveFilterSheet({
+  draft,
+  language,
+  visible,
+  onApply,
+  onChange,
+  onClose,
+  onReset,
+}: ReceiptArchiveFilterSheetProps) {
+  const { tokens } = useTheme();
+  const copy = filterCopy(language);
+  const update = <Key extends keyof ReceiptArchiveFilterDraft>(
+    key: Key,
+    value: ReceiptArchiveFilterDraft[Key],
+  ) => onChange({ ...draft, [key]: value });
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="pageSheet"
+      transparent
+      visible={visible}
+    >
+      <View
+        style={{
+          backgroundColor: tokens.colors.overlay,
+          flex: 1,
+          justifyContent: 'flex-end',
+        }}
+      >
+        <View
+          style={{
+            alignSelf: 'center',
+            backgroundColor: tokens.colors.bg,
+            borderTopLeftRadius: tokens.radius.large,
+            borderTopRightRadius: tokens.radius.large,
+            maxHeight: '94%',
+            maxWidth: 720,
+            width: '100%',
+          }}
+        >
+          <View
+            style={{
+              alignItems: 'center',
+              borderBottomColor: tokens.colors.border,
+              borderBottomWidth: 1,
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              padding: tokens.space.md,
+            }}
+          >
+            <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+              {copy.title}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              onPress={onReset}
+              style={{ minHeight: 48, justifyContent: 'center' }}
+            >
+              <Text style={[tokens.typography.label, { color: tokens.colors.primary }]}>
+                {copy.reset}
+              </Text>
+            </Pressable>
+          </View>
+
+          <ScrollView
+            contentContainerStyle={{ gap: tokens.space.md, padding: tokens.space.md }}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+              <ServiceTextField
+                autoCapitalize="none"
+                containerStyle={{ flexBasis: 220, flexGrow: 1 }}
+                label={copy.dateFrom}
+                onChangeText={(value) => update('dateFrom', value)}
+                placeholder="YYYY-MM-DD"
+                value={draft.dateFrom}
+              />
+              <ServiceTextField
+                autoCapitalize="none"
+                containerStyle={{ flexBasis: 220, flexGrow: 1 }}
+                label={copy.dateTo}
+                onChangeText={(value) => update('dateTo', value)}
+                placeholder="YYYY-MM-DD"
+                value={draft.dateTo}
+              />
+            </View>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+              <ServiceTextField
+                autoCapitalize="none"
+                containerStyle={{ flexBasis: 220, flexGrow: 1 }}
+                label={copy.timeFrom}
+                onChangeText={(value) => update('timeFrom', value)}
+                placeholder="13:00"
+                value={draft.timeFrom}
+              />
+              <ServiceTextField
+                autoCapitalize="none"
+                containerStyle={{ flexBasis: 220, flexGrow: 1 }}
+                label={copy.timeTo}
+                onChangeText={(value) => update('timeTo', value)}
+                placeholder="14:00"
+                value={draft.timeTo}
+              />
+            </View>
+            <ServiceTextField
+              label={copy.waiter}
+              onChangeText={(value) => update('waiterQuery', value)}
+              placeholder={copy.waiterPlaceholder}
+              value={draft.waiterQuery}
+            />
+            <ChoiceGroup
+              label={copy.payment}
+              onSelect={(value) => update('paymentMethod', value)}
+              options={[
+                ['all', copy.all],
+                ['cash', copy.cash],
+                ['card', copy.card],
+                ['mixed_adjustment', copy.adjustmentPayment],
+              ]}
+              selected={draft.paymentMethod}
+            />
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+              <ServiceTextField
+                containerStyle={{ flexBasis: 220, flexGrow: 1 }}
+                inputMode="decimal"
+                label={copy.amountMin}
+                onChangeText={(value) => update('amountMin', value)}
+                placeholder="0.00"
+                value={draft.amountMin}
+              />
+              <ServiceTextField
+                containerStyle={{ flexBasis: 220, flexGrow: 1 }}
+                inputMode="decimal"
+                label={copy.amountMax}
+                onChangeText={(value) => update('amountMax', value)}
+                placeholder="100.00"
+                value={draft.amountMax}
+              />
+            </View>
+            <ChoiceGroup
+              label={copy.adjustments}
+              onSelect={(value) => update('adjustment', value)}
+              options={[
+                ['all', copy.all],
+                ['with', copy.withAdjustment],
+                ['without', copy.withoutAdjustment],
+              ]}
+              selected={draft.adjustment}
+            />
+          </ScrollView>
+
+          <View
+            style={{
+              borderTopColor: tokens.colors.border,
+              borderTopWidth: 1,
+              flexDirection: 'row',
+              gap: tokens.space.sm,
+              padding: tokens.space.md,
+            }}
+          >
+            <ServiceButton
+              label={copy.cancel}
+              onPress={onClose}
+              style={{ flex: 1 }}
+              variant="ghost"
+            />
+            <ServiceButton label={copy.apply} onPress={onApply} style={{ flex: 2 }} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function ChoiceGroup<Value extends string>({
+  label,
+  options,
+  selected,
+  onSelect,
+}: {
+  readonly label: string;
+  readonly options: readonly (readonly [Value, string])[];
+  readonly selected: Value;
+  readonly onSelect: (value: Value) => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View>
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: tokens.colors.text, marginBottom: tokens.space.xs },
+        ]}
+      >
+        {label}
+      </Text>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+        {options.map(([value, optionLabel]) => {
+          const active = value === selected;
+          return (
+            <Pressable
+              key={value}
+              accessibilityRole="radio"
+              accessibilityState={{ checked: active }}
+              onPress={() => onSelect(value)}
+              style={({ pressed }) => ({
+                alignItems: 'center',
+                backgroundColor: active ? tokens.colors.surfaceAlt : tokens.colors.surface,
+                borderColor: active ? tokens.colors.primary : tokens.colors.border,
+                borderRadius: tokens.radius.full,
+                borderWidth: active ? 2 : 1,
+                justifyContent: 'center',
+                minHeight: tokens.sizing.minimumTarget,
+                opacity: pressed ? 0.78 : 1,
+                paddingHorizontal: tokens.space.md,
+              })}
+            >
+              <Text
+                style={[
+                  tokens.typography.label,
+                  { color: active ? tokens.colors.primary : tokens.colors.textSubtle },
+                ]}
+              >
+                {optionLabel}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function filterCopy(language: Language) {
+  if (language === 'tr') {
+    return {
+      title: 'Arşiv filtreleri',
+      reset: 'Sıfırla',
+      dateFrom: 'Başlangıç tarihi',
+      dateTo: 'Bitiş tarihi',
+      timeFrom: 'Başlangıç saati',
+      timeTo: 'Bitiş saati',
+      waiter: 'Garson',
+      waiterPlaceholder: 'İsimle ara',
+      payment: 'Ödeme yöntemi',
+      all: 'Tümü',
+      cash: 'Nakit',
+      card: 'Kart',
+      adjustmentPayment: 'Düzeltme',
+      amountMin: 'En az tutar',
+      amountMax: 'En çok tutar',
+      adjustments: 'Düzeltme durumu',
+      withAdjustment: 'Düzeltme var',
+      withoutAdjustment: 'Düzeltme yok',
+      cancel: 'Vazgeç',
+      apply: 'Sonuçları göster',
+    };
+  }
+  if (language === 'bg') {
+    return {
+      title: 'Филтри на архива',
+      reset: 'Изчисти',
+      dateFrom: 'Начална дата',
+      dateTo: 'Крайна дата',
+      timeFrom: 'Начален час',
+      timeTo: 'Краен час',
+      waiter: 'Сервитьор',
+      waiterPlaceholder: 'Търсене по име',
+      payment: 'Начин на плащане',
+      all: 'Всички',
+      cash: 'В брой',
+      card: 'Карта',
+      adjustmentPayment: 'Корекция',
+      amountMin: 'Мин. сума',
+      amountMax: 'Макс. сума',
+      adjustments: 'Корекции',
+      withAdjustment: 'С корекция',
+      withoutAdjustment: 'Без корекция',
+      cancel: 'Отказ',
+      apply: 'Покажи резултатите',
+    };
+  }
+  return {
+    title: 'Archive filters',
+    reset: 'Reset',
+    dateFrom: 'Start date',
+    dateTo: 'End date',
+    timeFrom: 'Start time',
+    timeTo: 'End time',
+    waiter: 'Waiter',
+    waiterPlaceholder: 'Search by name',
+    payment: 'Payment method',
+    all: 'All',
+    cash: 'Cash',
+    card: 'Card',
+    adjustmentPayment: 'Adjustment',
+    amountMin: 'Minimum amount',
+    amountMax: 'Maximum amount',
+    adjustments: 'Adjustment status',
+    withAdjustment: 'Has adjustment',
+    withoutAdjustment: 'No adjustment',
+    cancel: 'Cancel',
+    apply: 'Show results',
+  };
+}

--- a/src/features/receipt-archive/ReceiptDetailSheet.tsx
+++ b/src/features/receipt-archive/ReceiptDetailSheet.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { Modal, ScrollView, Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceButton, ServiceSurface } from '../../design-system';
+import { Language } from '../../i18n';
+import { ReceiptArchiveEntry } from './receiptArchiveGateway';
+
+export function ReceiptDetailSheet({
+  entry,
+  language,
+  onClose,
+}: {
+  readonly entry: ReceiptArchiveEntry;
+  readonly language: Language;
+  readonly onClose: () => void;
+}) {
+  const { tokens } = useTheme();
+  const copy = detailCopy(language);
+  const { receipt } = entry;
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={onClose}
+      presentationStyle="pageSheet"
+      transparent
+      visible
+    >
+      <View
+        style={{
+          backgroundColor: tokens.colors.overlay,
+          flex: 1,
+          justifyContent: 'flex-end',
+        }}
+      >
+        <View
+          style={{
+            alignSelf: 'center',
+            backgroundColor: tokens.colors.bg,
+            borderTopLeftRadius: tokens.radius.large,
+            borderTopRightRadius: tokens.radius.large,
+            maxHeight: '94%',
+            maxWidth: 720,
+            width: '100%',
+          }}
+        >
+          <ScrollView contentContainerStyle={{ gap: tokens.space.md, padding: tokens.space.lg }}>
+            <View>
+              <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+                {receipt.snapshot.tableLabel}
+              </Text>
+              <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                {receipt.receiptNumber}
+              </Text>
+            </View>
+            {receipt.snapshot.checks.map((check) => (
+              <ServiceSurface key={check.checkId} style={{ gap: tokens.space.sm }}>
+                <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                  {check.name}
+                </Text>
+                {check.items.map((item) => (
+                  <View
+                    key={item.orderItemId}
+                    style={{
+                      borderBottomColor: tokens.colors.borderLight,
+                      borderBottomWidth: 1,
+                      paddingBottom: tokens.space.sm,
+                    }}
+                  >
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Text
+                        style={[
+                          tokens.typography.bodyStrong,
+                          { color: tokens.colors.text, flex: 1 },
+                        ]}
+                      >
+                        {item.quantity}× {item.name}
+                      </Text>
+                      <Text style={[tokens.typography.label, { color: tokens.colors.text }]}>
+                        {money(item.lineTotalMinor, receipt.currencyCode, language)}
+                      </Text>
+                    </View>
+                    {item.modifiers.map((modifier, index) => (
+                      <Text
+                        key={`${modifier.name}-${index}`}
+                        style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}
+                      >
+                        + {modifier.name}
+                      </Text>
+                    ))}
+                  </View>
+                ))}
+              </ServiceSurface>
+            ))}
+            <ServiceSurface style={{ gap: tokens.space.sm }} variant="outlined">
+              <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                {copy.payments}
+              </Text>
+              {receipt.snapshot.payments.map((payment) => (
+                <View
+                  key={payment.paymentId}
+                  style={{ flexDirection: 'row', justifyContent: 'space-between' }}
+                >
+                  <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                    {payment.method === 'cash' ? copy.cash : copy.card} ·{' '}
+                    {payment.createdByDisplayName}
+                  </Text>
+                  <Text style={[tokens.typography.label, { color: tokens.colors.text }]}>
+                    {money(payment.amountMinor, receipt.currencyCode, language)}
+                  </Text>
+                </View>
+              ))}
+              <View
+                style={{
+                  borderTopColor: tokens.colors.border,
+                  borderTopWidth: 1,
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  paddingTop: tokens.space.sm,
+                }}
+              >
+                <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}>
+                  {copy.total}
+                </Text>
+                <Text style={[tokens.typography.money, { color: tokens.colors.primary }]}>
+                  {money(receipt.totalMinor, receipt.currencyCode, language)}
+                </Text>
+              </View>
+            </ServiceSurface>
+            <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>
+              {copy.waiters}: {receipt.snapshot.waiterDisplayNames.join(', ')}
+            </Text>
+            <ServiceButton label={copy.close} onPress={onClose} size="large" />
+          </ScrollView>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+function money(amountMinor: number, currency: string, language: Language): string {
+  const formatter = new Intl.NumberFormat(
+    language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-US',
+    { currency, style: 'currency' },
+  );
+  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+  return formatter.format(amountMinor / 10 ** fractionDigits);
+}
+
+function detailCopy(language: Language) {
+  if (language === 'tr') {
+    return {
+      payments: 'Ödemeler',
+      cash: 'Nakit',
+      card: 'Kart',
+      total: 'Toplam',
+      waiters: 'Garsonlar',
+      close: 'Kapat',
+    };
+  }
+  if (language === 'bg') {
+    return {
+      payments: 'Плащания',
+      cash: 'В брой',
+      card: 'Карта',
+      total: 'Общо',
+      waiters: 'Сервитьори',
+      close: 'Затвори',
+    };
+  }
+  return {
+    payments: 'Payments',
+    cash: 'Cash',
+    card: 'Card',
+    total: 'Total',
+    waiters: 'Waiters',
+    close: 'Close',
+  };
+}

--- a/src/features/receipt-archive/__tests__/ReceiptArchiveCard.test.tsx
+++ b/src/features/receipt-archive/__tests__/ReceiptArchiveCard.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { ThemeProvider } from '../../../contexts/ThemeContext';
+import { ReceiptArchiveEntry } from '../receiptArchiveGateway';
+import { ReceiptArchiveCard } from '../ReceiptArchiveCard';
+
+describe('ReceiptArchiveCard', () => {
+  it('keeps detail, download, and share actions visible and accessible', async () => {
+    const onDetail = jest.fn();
+    const onDownload = jest.fn();
+    const onShare = jest.fn();
+    const screen = await render(
+      <ThemeProvider>
+        <ReceiptArchiveCard
+          entry={entry}
+          language="tr"
+          onDetail={onDetail}
+          onDownload={onDownload}
+          onShare={onShare}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText('Masa 4 · Pencere tarafı')).toBeTruthy();
+    expect(screen.getByText('Düzeltme içeriyor')).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: 'Detay' }));
+    await fireEvent.press(screen.getByRole('button', { name: 'PDF indir' }));
+    await fireEvent.press(screen.getByRole('button', { name: 'Paylaş' }));
+
+    expect(onDetail).toHaveBeenCalledTimes(1);
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(onShare).toHaveBeenCalledTimes(1);
+  });
+});
+
+const entry: ReceiptArchiveEntry = {
+  branchName: 'Sofia',
+  branchTimezone: 'Europe/Sofia',
+  hasAdjustment: true,
+  receipt: {
+    id: 'receipt-1' as never,
+    organizationId: 'organization-1' as never,
+    branchId: 'branch-1' as never,
+    tableSessionId: 'session-1' as never,
+    checkId: 'check-1' as never,
+    receiptNumber: 'WB1-20260726-000001',
+    businessDate: '2026-07-26' as never,
+    issuedAt: '2026-07-26T18:00:00.000Z',
+    issuedBy: 'waiter-1' as never,
+    totalMinor: 500,
+    currencyCode: 'EUR' as never,
+    snapshot: {
+      schemaVersion: 1,
+      organizationName: 'Orderia',
+      branchName: 'Sofia',
+      branchTimezone: 'Europe/Sofia',
+      tableLabel: 'Masa 4',
+      openedAt: '2026-07-26T17:00:00.000Z',
+      issuedAt: '2026-07-26T18:00:00.000Z',
+      waiterDisplayNames: ['Şule'],
+      checks: [
+        {
+          checkId: 'check-1' as never,
+          name: 'Pencere tarafı',
+          items: [],
+          totalMinor: 500,
+        },
+      ],
+      payments: [
+        {
+          paymentId: 'payment-1' as never,
+          method: 'card',
+          amountMinor: 500,
+          confirmedAt: '2026-07-26T18:00:00.000Z',
+          createdByDisplayName: 'Şule',
+        },
+      ],
+      totalMinor: 500,
+      currencyCode: 'EUR' as never,
+    },
+    pdfStoragePath: 'organization-1/branch-1/2026-07-26/receipt-1.pdf',
+    status: 'issued',
+  },
+};

--- a/src/features/receipt-archive/__tests__/receiptArchiveFilters.test.ts
+++ b/src/features/receipt-archive/__tests__/receiptArchiveFilters.test.ts
@@ -1,0 +1,80 @@
+import {
+  activeReceiptFilterCount,
+  buildReceiptArchiveFilters,
+  defaultReceiptArchiveFilters,
+  withDateRange,
+} from '../receiptArchiveFilters';
+
+describe('receipt archive filters', () => {
+  it('builds precise server filters and converts display currency to minor units', () => {
+    const filters = buildReceiptArchiveFilters(
+      {
+        ...defaultReceiptArchiveFilters('Europe/Sofia', 7, new Date('2026-07-26T18:00:00.000Z')),
+        query: ' Masa 4 ',
+        timeFrom: '13:00',
+        timeTo: '14:00',
+        waiterQuery: ' Şule ',
+        paymentMethod: 'card',
+        amountMin: '4,50',
+        amountMax: '20',
+        adjustment: 'with',
+      },
+      'EUR',
+    );
+
+    expect(filters).toEqual({
+      query: 'Masa 4',
+      dateFrom: '2026-07-20',
+      dateTo: '2026-07-26',
+      timeFrom: '13:00',
+      timeTo: '14:00',
+      waiterQuery: 'Şule',
+      paymentMethod: 'card',
+      amountMinMinor: 450,
+      amountMaxMinor: 2_000,
+      hasAdjustment: true,
+    });
+    expect(
+      activeReceiptFilterCount({
+        ...defaultReceiptArchiveFilters('UTC'),
+        waiterQuery: 'Şule',
+        paymentMethod: 'card',
+        amountMin: '4',
+      }),
+    ).toBe(4);
+  });
+
+  it('supports branch-local quick date ranges', () => {
+    const initial = defaultReceiptArchiveFilters(
+      'Europe/Sofia',
+      7,
+      new Date('2026-07-26T22:30:00.000Z'),
+    );
+    const today = withDateRange(initial, 'Europe/Sofia', 1, new Date('2026-07-26T22:30:00.000Z'));
+
+    expect(today.dateFrom).toBe('2026-07-27');
+    expect(today.dateTo).toBe('2026-07-27');
+  });
+
+  it('rejects invalid ranges before making a server call', () => {
+    expect(() =>
+      buildReceiptArchiveFilters(
+        {
+          ...defaultReceiptArchiveFilters('UTC'),
+          dateFrom: '2026-08-01',
+          dateTo: '2026-07-01',
+        },
+        'EUR',
+      ),
+    ).toThrow(/Start date/);
+    expect(() =>
+      buildReceiptArchiveFilters(
+        {
+          ...defaultReceiptArchiveFilters('UTC'),
+          timeFrom: '25:90',
+        },
+        'EUR',
+      ),
+    ).toThrow(/start time/);
+  });
+});

--- a/src/features/receipt-archive/__tests__/receiptArchiveGateway.test.ts
+++ b/src/features/receipt-archive/__tests__/receiptArchiveGateway.test.ts
@@ -1,0 +1,106 @@
+import { ReceiptArchiveRow } from '../../../services/supabase';
+import { ReceiptArchiveGateway } from '../receiptArchiveGateway';
+
+describe('ReceiptArchiveGateway', () => {
+  it('maps immutable snapshots and returns a stable keyset cursor', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: [
+        row('receipt-2', '2026-07-26T14:00:00.000Z'),
+        row('receipt-1', '2026-07-26T13:00:00.000Z'),
+      ],
+      error: null,
+    });
+    const gateway = new ReceiptArchiveGateway({ rpc } as never);
+
+    const page = await gateway.search({
+      organizationId: 'organization-1' as never,
+      branchId: 'branch-1' as never,
+      filters: {
+        query: 'Masa 4',
+        dateFrom: '2026-07-20',
+        waiterQuery: 'Şule',
+        paymentMethod: 'card',
+        amountMinMinor: 400,
+      },
+      pageSize: 1,
+    });
+
+    expect(page.items).toHaveLength(1);
+    expect(page.items[0].receipt.receiptNumber).toBe('WB1-receipt-2');
+    expect(page.nextCursor).toEqual({
+      id: 'receipt-2',
+      issuedAt: '2026-07-26T14:00:00.000Z',
+    });
+    expect(rpc).toHaveBeenCalledWith(
+      'search_receipts',
+      expect.objectContaining({
+        requested_query: 'Masa 4',
+        requested_waiter_query: 'Şule',
+        requested_payment_method: 'card',
+        requested_amount_min_minor: 400,
+        requested_page_size: 1,
+      }),
+    );
+  });
+
+  it('forwards both cursor values and surfaces server errors', async () => {
+    const rpc = jest.fn().mockResolvedValue({
+      data: null,
+      error: { code: '42501', message: 'branch_access_denied' },
+    });
+    const gateway = new ReceiptArchiveGateway({ rpc } as never);
+
+    await expect(
+      gateway.search({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-2' as never,
+        filters: {},
+        cursor: { id: 'receipt-1', issuedAt: '2026-07-26T13:00:00.000Z' },
+      }),
+    ).rejects.toMatchObject({ message: 'branch_access_denied' });
+    expect(rpc).toHaveBeenCalledWith(
+      'search_receipts',
+      expect.objectContaining({
+        requested_after_id: 'receipt-1',
+        requested_after_issued_at: '2026-07-26T13:00:00.000Z',
+      }),
+    );
+  });
+});
+
+function row(id: string, issuedAt: string): ReceiptArchiveRow {
+  return {
+    id,
+    organization_id: 'organization-1',
+    branch_id: 'branch-1',
+    branch_name: 'Sofia',
+    branch_timezone: 'Europe/Sofia',
+    table_session_id: 'session-1',
+    check_id: 'check-1',
+    receipt_number: `WB1-${id}`,
+    business_date: '2026-07-26',
+    issued_at: issuedAt,
+    issued_by: 'waiter-1',
+    total_minor: 500,
+    currency_code: 'EUR',
+    snapshot_json: {
+      schemaVersion: 1,
+      organizationName: 'Orderia',
+      branchName: 'Sofia',
+      branchTimezone: 'Europe/Sofia',
+      tableLabel: 'Masa 4',
+      openedAt: '2026-07-26T12:00:00.000Z',
+      issuedAt,
+      waiterDisplayNames: ['Şule'],
+      checks: [],
+      payments: [],
+      totalMinor: 500,
+      currencyCode: 'EUR',
+    },
+    pdf_storage_path: `organization-1/branch-1/2026-07-26/${id}.pdf`,
+    pdf_hash: null,
+    status: 'issued',
+    adjusts_receipt_id: null,
+    has_adjustment: false,
+  };
+}

--- a/src/features/receipt-archive/index.ts
+++ b/src/features/receipt-archive/index.ts
@@ -1,0 +1,5 @@
+export * from './receiptArchiveGateway';
+export * from './receiptArchiveFilters';
+export * from './ReceiptArchiveCard';
+export * from './ReceiptArchiveFilterSheet';
+export * from './ReceiptDetailSheet';

--- a/src/features/receipt-archive/receiptArchiveFilters.ts
+++ b/src/features/receipt-archive/receiptArchiveFilters.ts
@@ -1,0 +1,146 @@
+import { ReceiptArchiveFilters, ReceiptArchivePaymentMethod } from './receiptArchiveGateway';
+
+export interface ReceiptArchiveFilterDraft {
+  readonly query: string;
+  readonly dateFrom: string;
+  readonly dateTo: string;
+  readonly timeFrom: string;
+  readonly timeTo: string;
+  readonly waiterQuery: string;
+  readonly paymentMethod: ReceiptArchivePaymentMethod | 'all';
+  readonly amountMin: string;
+  readonly amountMax: string;
+  readonly adjustment: 'all' | 'with' | 'without';
+}
+
+export function defaultReceiptArchiveFilters(
+  branchTimezone: string,
+  days = 7,
+  now = new Date(),
+): ReceiptArchiveFilterDraft {
+  const dateTo = dateInTimeZone(now, branchTimezone);
+  const start = new Date(`${dateTo}T12:00:00.000Z`);
+  start.setUTCDate(start.getUTCDate() - Math.max(0, days - 1));
+  return {
+    query: '',
+    dateFrom: start.toISOString().slice(0, 10),
+    dateTo,
+    timeFrom: '',
+    timeTo: '',
+    waiterQuery: '',
+    paymentMethod: 'all',
+    amountMin: '',
+    amountMax: '',
+    adjustment: 'all',
+  };
+}
+
+export function buildReceiptArchiveFilters(
+  draft: ReceiptArchiveFilterDraft,
+  currencyCode: string,
+): ReceiptArchiveFilters {
+  const dateFrom = optionalDate(draft.dateFrom, 'start');
+  const dateTo = optionalDate(draft.dateTo, 'end');
+  if (dateFrom && dateTo && dateFrom > dateTo) {
+    throw new Error('Start date must not be after end date');
+  }
+  const timeFrom = optionalTime(draft.timeFrom, 'start');
+  const timeTo = optionalTime(draft.timeTo, 'end');
+  const amountMinMinor = optionalMoney(draft.amountMin, currencyCode, 'minimum');
+  const amountMaxMinor = optionalMoney(draft.amountMax, currencyCode, 'maximum');
+  if (
+    amountMinMinor !== undefined &&
+    amountMaxMinor !== undefined &&
+    amountMinMinor > amountMaxMinor
+  ) {
+    throw new Error('Minimum amount must not exceed maximum amount');
+  }
+  return {
+    ...(clean(draft.query) ? { query: clean(draft.query) } : {}),
+    ...(dateFrom ? { dateFrom } : {}),
+    ...(dateTo ? { dateTo } : {}),
+    ...(timeFrom ? { timeFrom } : {}),
+    ...(timeTo ? { timeTo } : {}),
+    ...(clean(draft.waiterQuery) ? { waiterQuery: clean(draft.waiterQuery) } : {}),
+    ...(draft.paymentMethod === 'all' ? {} : { paymentMethod: draft.paymentMethod }),
+    ...(amountMinMinor === undefined ? {} : { amountMinMinor }),
+    ...(amountMaxMinor === undefined ? {} : { amountMaxMinor }),
+    ...(draft.adjustment === 'all' ? {} : { hasAdjustment: draft.adjustment === 'with' }),
+  };
+}
+
+export function activeReceiptFilterCount(draft: ReceiptArchiveFilterDraft): number {
+  return [
+    Boolean(draft.dateFrom || draft.dateTo),
+    Boolean(draft.timeFrom || draft.timeTo),
+    Boolean(clean(draft.waiterQuery)),
+    draft.paymentMethod !== 'all',
+    Boolean(draft.amountMin || draft.amountMax),
+    draft.adjustment !== 'all',
+  ].filter(Boolean).length;
+}
+
+export function withDateRange(
+  draft: ReceiptArchiveFilterDraft,
+  branchTimezone: string,
+  days: number,
+  now = new Date(),
+): ReceiptArchiveFilterDraft {
+  const range = defaultReceiptArchiveFilters(branchTimezone, days, now);
+  return { ...draft, dateFrom: range.dateFrom, dateTo: range.dateTo };
+}
+
+function optionalDate(value: string, label: string): string | undefined {
+  const normalized = clean(value);
+  if (!normalized) return undefined;
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(normalized) ||
+    Number.isNaN(Date.parse(`${normalized}T00:00:00Z`))
+  ) {
+    throw new Error(`Invalid ${label} date`);
+  }
+  return normalized;
+}
+
+function optionalTime(value: string, label: string): string | undefined {
+  const normalized = clean(value);
+  if (!normalized) return undefined;
+  if (!/^(?:[01]\d|2[0-3]):[0-5]\d$/.test(normalized)) {
+    throw new Error(`Invalid ${label} time`);
+  }
+  return normalized;
+}
+
+function optionalMoney(value: string, currencyCode: string, label: string): number | undefined {
+  const normalized = clean(value).replace(',', '.');
+  if (!normalized) return undefined;
+  if (!/^\d+(?:\.\d+)?$/.test(normalized)) throw new Error(`Invalid ${label} amount`);
+  const fractionDigits =
+    new Intl.NumberFormat('en', {
+      style: 'currency',
+      currency: currencyCode,
+    }).resolvedOptions().maximumFractionDigits ?? 2;
+  const [whole, fraction = ''] = normalized.split('.');
+  if (fraction.length > fractionDigits) {
+    throw new Error(`Invalid ${label} amount`);
+  }
+  const paddedFraction = fraction.padEnd(fractionDigits, '0');
+  const minor = Number(whole) * 10 ** fractionDigits + Number(paddedFraction || 0);
+  if (!Number.isSafeInteger(minor)) throw new Error(`Invalid ${label} amount`);
+  return minor;
+}
+
+function dateInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const value = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${value.year}-${value.month}-${value.day}`;
+}
+
+function clean(value: string): string {
+  return value.trim();
+}

--- a/src/features/receipt-archive/receiptArchiveGateway.ts
+++ b/src/features/receipt-archive/receiptArchiveGateway.ts
@@ -1,0 +1,169 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { BranchId, OrganizationId, Receipt } from '../../domain';
+import { Database, Json, ReceiptArchiveRow } from '../../services/supabase';
+
+export type ReceiptArchivePaymentMethod = 'cash' | 'card' | 'mixed_adjustment';
+
+export interface ReceiptArchiveFilters {
+  readonly query?: string;
+  readonly dateFrom?: string;
+  readonly dateTo?: string;
+  readonly timeFrom?: string;
+  readonly timeTo?: string;
+  readonly waiterQuery?: string;
+  readonly paymentMethod?: ReceiptArchivePaymentMethod;
+  readonly amountMinMinor?: number;
+  readonly amountMaxMinor?: number;
+  readonly hasAdjustment?: boolean;
+}
+
+export interface ReceiptArchiveCursor {
+  readonly issuedAt: string;
+  readonly id: string;
+}
+
+export interface ReceiptArchiveEntry {
+  readonly receipt: Receipt;
+  readonly branchName: string;
+  readonly branchTimezone: string;
+  readonly hasAdjustment: boolean;
+}
+
+export interface ReceiptArchivePage {
+  readonly items: readonly ReceiptArchiveEntry[];
+  readonly nextCursor?: ReceiptArchiveCursor;
+}
+
+export class ReceiptArchiveGateway {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async search(input: {
+    readonly organizationId: OrganizationId;
+    readonly branchId: BranchId;
+    readonly filters: ReceiptArchiveFilters;
+    readonly cursor?: ReceiptArchiveCursor;
+    readonly pageSize?: number;
+  }): Promise<ReceiptArchivePage> {
+    const pageSize = input.pageSize ?? 30;
+    assertFilters(input.filters, pageSize);
+    const { data, error } = await this.client.rpc('search_receipts', {
+      requested_organization_id: input.organizationId,
+      requested_branch_id: input.branchId,
+      requested_query: clean(input.filters.query),
+      requested_date_from: input.filters.dateFrom ?? null,
+      requested_date_to: input.filters.dateTo ?? null,
+      requested_time_from: input.filters.timeFrom ?? null,
+      requested_time_to: input.filters.timeTo ?? null,
+      requested_waiter_query: clean(input.filters.waiterQuery),
+      requested_payment_method: input.filters.paymentMethod ?? null,
+      requested_amount_min_minor: input.filters.amountMinMinor ?? null,
+      requested_amount_max_minor: input.filters.amountMaxMinor ?? null,
+      requested_has_adjustment: input.filters.hasAdjustment ?? null,
+      requested_after_issued_at: input.cursor?.issuedAt ?? null,
+      requested_after_id: input.cursor?.id ?? null,
+      requested_page_size: pageSize,
+    });
+    if (error) throw error;
+
+    const rows = data as ReceiptArchiveRow[];
+    const pageRows = rows.slice(0, pageSize);
+    const last = pageRows.at(-1);
+    return {
+      items: pageRows.map(toArchiveEntry),
+      ...(rows.length > pageSize && last
+        ? { nextCursor: { id: last.id, issuedAt: last.issued_at } }
+        : {}),
+    };
+  }
+}
+
+function toArchiveEntry(row: ReceiptArchiveRow): ReceiptArchiveEntry {
+  if (!isReceiptSnapshot(row.snapshot_json)) {
+    throw new Error(`Receipt ${row.id} has an invalid immutable snapshot`);
+  }
+  return {
+    branchName: row.branch_name,
+    branchTimezone: row.branch_timezone,
+    hasAdjustment: row.has_adjustment,
+    receipt: {
+      id: row.id as never,
+      organizationId: row.organization_id as never,
+      branchId: row.branch_id as never,
+      tableSessionId: row.table_session_id as never,
+      checkId: row.check_id as never,
+      receiptNumber: row.receipt_number,
+      businessDate: row.business_date as never,
+      issuedAt: row.issued_at,
+      issuedBy: row.issued_by as never,
+      totalMinor: row.total_minor,
+      currencyCode: row.currency_code as never,
+      snapshot: row.snapshot_json as never,
+      ...(row.pdf_storage_path ? { pdfStoragePath: row.pdf_storage_path } : {}),
+      ...(row.pdf_hash ? { pdfHash: row.pdf_hash } : {}),
+      status: row.status as Receipt['status'],
+      ...(row.adjusts_receipt_id ? { adjustsReceiptId: row.adjusts_receipt_id as never } : {}),
+    },
+  };
+}
+
+function assertFilters(filters: ReceiptArchiveFilters, pageSize: number): void {
+  if (!Number.isSafeInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+    throw new Error('Receipt archive page size must be between 1 and 100');
+  }
+  for (const value of [filters.query, filters.waiterQuery]) {
+    if (value && value.trim().length > 120) {
+      throw new Error('Receipt archive search text is too long');
+    }
+  }
+  if (filters.dateFrom && !isDate(filters.dateFrom)) throw new Error('Invalid start date');
+  if (filters.dateTo && !isDate(filters.dateTo)) throw new Error('Invalid end date');
+  if (filters.dateFrom && filters.dateTo && filters.dateFrom > filters.dateTo) {
+    throw new Error('Receipt archive start date must not be after end date');
+  }
+  if (filters.timeFrom && !isTime(filters.timeFrom)) throw new Error('Invalid start time');
+  if (filters.timeTo && !isTime(filters.timeTo)) throw new Error('Invalid end time');
+  if (
+    filters.amountMinMinor !== undefined &&
+    (!Number.isSafeInteger(filters.amountMinMinor) || filters.amountMinMinor < 0)
+  ) {
+    throw new Error('Invalid minimum amount');
+  }
+  if (
+    filters.amountMaxMinor !== undefined &&
+    (!Number.isSafeInteger(filters.amountMaxMinor) || filters.amountMaxMinor < 0)
+  ) {
+    throw new Error('Invalid maximum amount');
+  }
+  if (
+    filters.amountMinMinor !== undefined &&
+    filters.amountMaxMinor !== undefined &&
+    filters.amountMinMinor > filters.amountMaxMinor
+  ) {
+    throw new Error('Receipt archive minimum amount must not exceed maximum amount');
+  }
+}
+
+function clean(value: string | undefined): string | null {
+  return value?.trim() || null;
+}
+
+function isDate(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(`${value}T00:00:00Z`));
+}
+
+function isTime(value: string): boolean {
+  return /^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/.test(value);
+}
+
+function isReceiptSnapshot(value: Json): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    value.schemaVersion === 1 &&
+    Array.isArray(value.checks) &&
+    Array.isArray(value.payments) &&
+    typeof value.tableLabel === 'string' &&
+    typeof value.totalMinor === 'number'
+  );
+}

--- a/src/features/receipts/ReceiptReadySheet.tsx
+++ b/src/features/receipts/ReceiptReadySheet.tsx
@@ -98,10 +98,11 @@ export function ReceiptReadySheet({
               {receipt.snapshot.tableLabel} · {receipt.snapshot.checks[0]?.name}
             </Text>
             <Text style={[tokens.typography.money, { color: tokens.colors.primary }]}>
-              {new Intl.NumberFormat(
+              {formatMinorCurrency(
+                receipt.totalMinor,
+                receipt.currencyCode,
                 language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-US',
-                { style: 'currency', currency: receipt.currencyCode },
-              ).format(receipt.totalMinor / 100)}
+              )}
             </Text>
             <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>
               {copy.privateNotice}
@@ -130,6 +131,15 @@ export function ReceiptReadySheet({
       </View>
     </Modal>
   );
+}
+
+function formatMinorCurrency(amountMinor: number, currencyCode: string, locale: string): string {
+  const formatter = new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency: currencyCode,
+  });
+  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+  return formatter.format(amountMinor / 10 ** fractionDigits);
 }
 
 function readyCopy(language: Language) {

--- a/src/features/receipts/receiptPdf.ts
+++ b/src/features/receipts/receiptPdf.ts
@@ -202,10 +202,12 @@ function receiptDocument(receipt: Receipt): DocumentDefinition {
 }
 
 function money(amountMinor: number, currencyCode: string): string {
-  return new Intl.NumberFormat('en-US', {
+  const formatter = new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: currencyCode,
-  }).format(amountMinor / 100);
+  });
+  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+  return formatter.format(amountMinor / 10 ** fractionDigits);
 }
 
 function formatQuantity(quantity: number): string {

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -111,6 +111,14 @@ function MainTabs() {
             }}
           />
           <Tab.Screen
+            component={HistoryScreen}
+            name="Receipts"
+            options={{
+              headerShown: false,
+              title: t.receiptsNav,
+            }}
+          />
+          <Tab.Screen
             component={SettingsScreen}
             name="More"
             options={{
@@ -125,7 +133,7 @@ function MainTabs() {
             component={HistoryScreen}
             name="Receipts"
             options={{
-              headerTitle: t.salesHistory,
+              headerShown: false,
               title: t.receiptsNav,
             }}
           />

--- a/src/screens/HistoryScreen.tsx
+++ b/src/screens/HistoryScreen.tsx
@@ -1,193 +1,484 @@
-import React, { useState } from 'react';
-import { View, Text, FlatList, TouchableOpacity, Alert } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, FlatList, Pressable, RefreshControl, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Ionicons } from '@expo/vector-icons';
+import { useAuth } from '../contexts/AuthContext';
+import { accessibleBranches } from '../contexts/authTypes';
 import { useTheme } from '../contexts/ThemeContext';
+import { useOrderiaData } from '../data/runtime';
+import {
+  ServiceButton,
+  ServiceEmptyState,
+  ServiceSkeleton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+  useAdaptiveLayout,
+} from '../design-system';
+import {
+  ReceiptArchiveCard,
+  ReceiptArchiveCursor,
+  ReceiptArchiveEntry,
+  ReceiptArchiveFilterDraft,
+  ReceiptArchiveFilterSheet,
+  ReceiptArchiveFilters,
+  ReceiptDetailSheet,
+  activeReceiptFilterCount,
+  buildReceiptArchiveFilters,
+  defaultReceiptArchiveFilters,
+  withDateRange,
+} from '../features/receipt-archive';
+import { presentReceiptPdf } from '../features/receipts';
 import { useLocalization } from '../i18n';
-import { useHistoryStore } from '../stores';
-import { SurfaceCard, PrimaryButton } from '../components';
-import { exportToCSV, exportToPDF, prepareExportData } from '../utils/exportUtils';
+
+const archivePageSize = 30;
 
 export default function HistoryScreen() {
-  const { colors } = useTheme();
-  const { t, formatPrice, formatDate } = useLocalization();
-  const { dailyHistory, getHistoryDates } = useHistoryStore();
-  const [exporting, setExporting] = useState(false);
+  const auth = useAuth();
+  const { tokens } = useTheme();
+  const { language } = useLocalization();
+  const layout = useAdaptiveLayout();
+  const { mode, prepareReceiptPdf, searchReceiptArchive, sync } = useOrderiaData();
+  const copy = archiveCopy(language);
+  const timezone = auth.activeBranch?.timezone ?? 'UTC';
+  const currency = auth.activeBranch?.currency_code ?? 'EUR';
+  const [draft, setDraft] = useState<ReceiptArchiveFilterDraft>(() =>
+    defaultReceiptArchiveFilters(timezone),
+  );
+  const [filters, setFilters] = useState<ReceiptArchiveFilters>(() =>
+    buildReceiptArchiveFilters(defaultReceiptArchiveFilters(timezone), currency),
+  );
+  const [entries, setEntries] = useState<readonly ReceiptArchiveEntry[]>([]);
+  const [nextCursor, setNextCursor] = useState<ReceiptArchiveCursor>();
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [showFilters, setShowFilters] = useState(false);
+  const [detailEntry, setDetailEntry] = useState<ReceiptArchiveEntry>();
+  const [busyReceiptId, setBusyReceiptId] = useState<string>();
+  const requestRevision = useRef(0);
+  const activeFilterCount = activeReceiptFilterCount(draft);
+  const cloudReady = mode === 'cloud';
 
-  const historyDates = getHistoryDates();
+  const branches = useMemo(
+    () =>
+      auth.workspace
+        ? accessibleBranches(auth.workspace).filter(
+            (branch) => branch.organization_id === auth.activeBranch?.organization_id,
+          )
+        : [],
+    [auth.activeBranch?.organization_id, auth.workspace],
+  );
 
-  const handleExportCSV = async () => {
-    try {
-      setExporting(true);
-      const exportData = prepareExportData(dailyHistory);
-      const success = await exportToCSV(exportData, 'orderia_report', t);
-
-      if (success) {
-        Alert.alert(t.success, t.reportExported);
-      } else {
-        Alert.alert(t.error, t.genericError);
+  const load = useCallback(
+    async (cursor?: ReceiptArchiveCursor, append = false) => {
+      const revision = requestRevision.current + 1;
+      requestRevision.current = revision;
+      if (!cloudReady || !sync.online) {
+        setLoading(false);
+        setRefreshing(false);
+        setLoadingMore(false);
+        setErrorMessage(copy.onlineRequired);
+        return;
       }
+      if (append) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
+      try {
+        const page = await searchReceiptArchive(filters, cursor, archivePageSize);
+        if (requestRevision.current !== revision) return;
+        setEntries((current) => (append ? [...current, ...page.items] : page.items));
+        setNextCursor(page.nextCursor);
+        setErrorMessage(undefined);
+      } catch (error) {
+        if (requestRevision.current !== revision) return;
+        setErrorMessage(error instanceof Error ? error.message : copy.loadFailed);
+      } finally {
+        if (requestRevision.current === revision) {
+          setLoading(false);
+          setLoadingMore(false);
+          setRefreshing(false);
+        }
+      }
+    },
+    [cloudReady, copy.loadFailed, copy.onlineRequired, filters, searchReceiptArchive, sync.online],
+  );
+
+  useEffect(() => {
+    void load();
+    return () => {
+      requestRevision.current += 1;
+    };
+  }, [auth.activeBranch?.id, load]);
+
+  const applyDraft = () => {
+    try {
+      setFilters(buildReceiptArchiveFilters(draft, currency));
+      setShowFilters(false);
     } catch (error) {
-      Alert.alert(t.error, t.genericError);
-    } finally {
-      setExporting(false);
+      Alert.alert(copy.invalidFilters, error instanceof Error ? error.message : copy.tryAgain);
     }
   };
 
-  const handleExportPDF = async () => {
-    try {
-      setExporting(true);
-      const exportData = prepareExportData(dailyHistory);
-      const success = await exportToPDF(exportData, 'orderia_report', t, formatPrice);
+  const applyDatePreset = (days: number) => {
+    const next = withDateRange(draft, timezone, days);
+    setDraft(next);
+    setFilters(buildReceiptArchiveFilters(next, currency));
+  };
 
-      if (success) {
-        Alert.alert(t.success, t.reportExported);
-      } else {
-        Alert.alert(t.error, t.genericError);
-      }
+  const resetFilters = () => {
+    const next = defaultReceiptArchiveFilters(timezone);
+    setDraft(next);
+    setFilters(buildReceiptArchiveFilters(next, currency));
+  };
+
+  const presentPdf = async (entry: ReceiptArchiveEntry, mode: 'download' | 'share') => {
+    setBusyReceiptId(entry.receipt.id);
+    try {
+      const prepared = await prepareReceiptPdf(entry.receipt);
+      await presentReceiptPdf(prepared.signedUrl, entry.receipt.receiptNumber, mode);
     } catch (error) {
-      Alert.alert(t.error, t.genericError);
+      Alert.alert(copy.pdfFailed, error instanceof Error ? error.message : copy.tryAgain);
     } finally {
-      setExporting(false);
+      setBusyReceiptId(undefined);
     }
   };
 
-  const renderHistoryItem = ({ item: date }: { item: string }) => {
-    const history = dailyHistory[date];
-    if (!history) return null;
-
-    return (
-      <SurfaceCard style={{ marginBottom: 12 }} variant="outlined">
-        <View
-          style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}
-        >
-          <View>
-            <Text style={{ fontSize: 16, fontWeight: '600', color: colors.text }}>
-              {formatDate(new Date(date).getTime())}
-            </Text>
-            <Text style={{ fontSize: 14, color: colors.textSubtle, marginTop: 2 }}>
-              {history.tickets.length} {t.ordersCount}
-            </Text>
-          </View>
-          <View style={{ alignItems: 'flex-end' }}>
-            <Text style={{ fontSize: 18, fontWeight: '700', color: colors.primary }}>
-              {formatPrice(history.totals.gross)}
-            </Text>
-            <Text style={{ fontSize: 12, color: colors.textSubtle }}>{t.totalSales}</Text>
-          </View>
-        </View>
-      </SurfaceCard>
-    );
+  const switchBranch = async (branchId: string) => {
+    if (branchId === auth.activeBranch?.id) return;
+    try {
+      await auth.switchBranch(branchId);
+    } catch (error) {
+      Alert.alert(copy.branchFailed, error instanceof Error ? error.message : copy.tryAgain);
+    }
   };
 
   return (
     <SafeAreaView
-      style={{ flex: 1, backgroundColor: colors.bg }}
-      edges={['bottom', 'left', 'right']}
+      edges={['top', 'left', 'right']}
+      style={{ backgroundColor: tokens.colors.bg, flex: 1 }}
     >
-      <View style={{ flex: 1, padding: 16, backgroundColor: colors.bg }}>
-        {/* Export Buttons */}
-        {historyDates.length > 0 && (
-          <SurfaceCard style={{ marginBottom: 16 }} variant="outlined">
-            <Text
-              style={{
-                fontSize: 16,
-                fontWeight: '600',
-                color: colors.text,
-                marginBottom: 12,
-              }}
-            >
-              {t.exportReport}
-            </Text>
-            <View style={{ flexDirection: 'row', gap: 8 }}>
-              <TouchableOpacity
-                onPress={handleExportCSV}
-                disabled={exporting}
-                style={{
-                  flex: 1,
-                  backgroundColor: colors.primary,
-                  paddingVertical: 12,
-                  paddingHorizontal: 16,
-                  borderRadius: 8,
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  opacity: exporting ? 0.6 : 1,
-                }}
-              >
-                <Ionicons
-                  name="document-text-outline"
-                  size={16}
-                  color="#FFFFFF"
-                  style={{ marginRight: 8 }}
-                />
-                <Text
-                  style={{
-                    color: '#FFFFFF',
-                    fontSize: 14,
-                    fontWeight: '600',
-                  }}
-                >
-                  CSV
-                </Text>
-              </TouchableOpacity>
-
-              <TouchableOpacity
-                onPress={handleExportPDF}
-                disabled={exporting}
-                style={{
-                  flex: 1,
-                  backgroundColor: colors.accent,
-                  paddingVertical: 12,
-                  paddingHorizontal: 16,
-                  borderRadius: 8,
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  opacity: exporting ? 0.6 : 1,
-                }}
-              >
-                <Ionicons
-                  name="document-outline"
-                  size={16}
-                  color="#FFFFFF"
-                  style={{ marginRight: 8 }}
-                />
-                <Text
-                  style={{
-                    color: '#FFFFFF',
-                    fontSize: 14,
-                    fontWeight: '600',
-                  }}
-                >
-                  PDF
-                </Text>
-              </TouchableOpacity>
+      <FlatList
+        contentContainerStyle={{
+          alignSelf: 'center',
+          maxWidth: tokens.sizing.contentMaximumWidth,
+          paddingBottom: tokens.space.xxl,
+          paddingHorizontal: layout.horizontalPadding,
+          width: '100%',
+        }}
+        data={entries}
+        keyExtractor={(entry) => entry.receipt.id}
+        ListEmptyComponent={
+          loading ? (
+            <View style={{ gap: tokens.space.sm }}>
+              {[0, 1, 2].map((value) => (
+                <ServiceSkeleton key={value} height={180} label={copy.loading} />
+              ))}
             </View>
-          </SurfaceCard>
-        )}
-
-        {historyDates.length === 0 ? (
-          <SurfaceCard style={{ padding: 32 }}>
+          ) : (
+            <ServiceEmptyState
+              action={{ label: copy.resetFilters, onPress: resetFilters }}
+              body={errorMessage ?? copy.emptyBody}
+              icon={errorMessage ? 'cloud-offline-outline' : 'receipt-outline'}
+              title={errorMessage ? copy.unavailable : copy.emptyTitle}
+            />
+          )
+        }
+        ListFooterComponent={
+          nextCursor ? (
+            <ServiceButton
+              icon="chevron-down-outline"
+              label={copy.loadMore}
+              loading={loadingMore}
+              onPress={() => void load(nextCursor, true)}
+              style={{ marginTop: tokens.space.sm }}
+              variant="outline"
+            />
+          ) : entries.length > 0 ? (
             <Text
+              style={[
+                tokens.typography.caption,
+                {
+                  color: tokens.colors.textMuted,
+                  paddingVertical: tokens.space.lg,
+                  textAlign: 'center',
+                },
+              ]}
+            >
+              {copy.end}
+            </Text>
+          ) : null
+        }
+        ListHeaderComponent={
+          <View style={{ gap: tokens.space.md, paddingVertical: tokens.space.lg }}>
+            <View
               style={{
-                textAlign: 'center',
-                color: colors.textSubtle,
-                fontSize: 16,
+                alignItems: 'flex-start',
+                flexDirection: layout.mode === 'compact' ? 'column' : 'row',
+                gap: tokens.space.sm,
+                justifyContent: 'space-between',
               }}
             >
-              {t.noSalesHistory}
-            </Text>
-          </SurfaceCard>
-        ) : (
-          <FlatList
-            data={historyDates}
-            renderItem={renderHistoryItem}
-            keyExtractor={(item) => item}
-            showsVerticalScrollIndicator={false}
+              <View style={{ flex: 1 }}>
+                <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+                  {copy.title}
+                </Text>
+                <Text
+                  style={[
+                    tokens.typography.body,
+                    { color: tokens.colors.textSubtle, marginTop: tokens.space.xs },
+                  ]}
+                >
+                  {copy.subtitle}
+                </Text>
+              </View>
+              <ServiceStatusPill
+                icon={sync.online ? 'cloud-done-outline' : 'cloud-offline-outline'}
+                label={sync.online ? copy.cloudArchive : copy.offline}
+                tone={sync.online ? 'success' : 'warning'}
+              />
+            </View>
+
+            {errorMessage && entries.length > 0 ? (
+              <ServiceSurface accessibilityRole="alert" variant="outlined">
+                <Text style={[tokens.typography.body, { color: tokens.colors.error }]}>
+                  {errorMessage}
+                </Text>
+              </ServiceSurface>
+            ) : null}
+
+            {branches.length > 1 ? (
+              <View accessibilityRole="radiogroup">
+                <Text
+                  style={[
+                    tokens.typography.label,
+                    { color: tokens.colors.text, marginBottom: tokens.space.xs },
+                  ]}
+                >
+                  {copy.branch}
+                </Text>
+                <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+                  {branches.map((branch) => (
+                    <FilterChip
+                      key={branch.id}
+                      active={branch.id === auth.activeBranch?.id}
+                      label={branch.name}
+                      onPress={() => void switchBranch(branch.id)}
+                    />
+                  ))}
+                </View>
+              </View>
+            ) : null}
+
+            <ServiceTextField
+              autoCapitalize="none"
+              label={copy.search}
+              onChangeText={(query) => setDraft((current) => ({ ...current, query }))}
+              onSubmitEditing={applyDraft}
+              placeholder={copy.searchPlaceholder}
+              returnKeyType="search"
+              value={draft.query}
+            />
+
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+              <FilterChip label={copy.today} onPress={() => applyDatePreset(1)} />
+              <FilterChip label={copy.sevenDays} onPress={() => applyDatePreset(7)} />
+              <FilterChip label={copy.thirtyDays} onPress={() => applyDatePreset(30)} />
+              <ServiceButton
+                icon="options-outline"
+                label={`${copy.filters} (${activeFilterCount})`}
+                onPress={() => setShowFilters(true)}
+                variant="outline"
+              />
+              <ServiceButton icon="search-outline" label={copy.searchAction} onPress={applyDraft} />
+            </View>
+
+            <View
+              style={{
+                alignItems: 'center',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Text style={[tokens.typography.label, { color: tokens.colors.textSubtle }]}>
+                {loading ? copy.loading : `${entries.length} ${copy.results}`}
+              </Text>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>
+                {auth.activeBranch?.name}
+              </Text>
+            </View>
+          </View>
+        }
+        refreshControl={
+          <RefreshControl
+            onRefresh={() => {
+              setRefreshing(true);
+              void load();
+            }}
+            refreshing={refreshing}
+            tintColor={tokens.colors.primary}
+          />
+        }
+        renderItem={({ item }) => (
+          <ReceiptArchiveCard
+            busy={busyReceiptId === item.receipt.id}
+            entry={item}
+            language={language}
+            onDetail={() => setDetailEntry(item)}
+            onDownload={() => void presentPdf(item, 'download')}
+            onShare={() => void presentPdf(item, 'share')}
           />
         )}
-      </View>
+      />
+
+      <ReceiptArchiveFilterSheet
+        draft={draft}
+        language={language}
+        onApply={applyDraft}
+        onChange={setDraft}
+        onClose={() => setShowFilters(false)}
+        onReset={resetFilters}
+        visible={showFilters}
+      />
+      {detailEntry ? (
+        <ReceiptDetailSheet
+          entry={detailEntry}
+          language={language}
+          onClose={() => setDetailEntry(undefined)}
+        />
+      ) : null}
     </SafeAreaView>
   );
+}
+
+function FilterChip({
+  active = false,
+  label,
+  onPress,
+}: {
+  readonly active?: boolean;
+  readonly label: string;
+  readonly onPress: () => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole={active ? 'radio' : 'button'}
+      accessibilityState={active ? { checked: true } : undefined}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        alignItems: 'center',
+        backgroundColor: active ? tokens.colors.surfaceAlt : tokens.colors.surface,
+        borderColor: active ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.full,
+        borderWidth: active ? 2 : 1,
+        justifyContent: 'center',
+        minHeight: tokens.sizing.minimumTarget,
+        opacity: pressed ? 0.78 : 1,
+        paddingHorizontal: tokens.space.md,
+      })}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: active ? tokens.colors.primary : tokens.colors.textSubtle },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function archiveCopy(language: 'tr' | 'bg' | 'en') {
+  if (language === 'tr') {
+    return {
+      title: 'Fiş arşivi',
+      subtitle: 'Tarih, saat, masa, hesap, garson veya tutarla geçmiş fişi saniyeler içinde bul.',
+      cloudArchive: 'Bulut arşivi',
+      offline: 'Çevrimdışı',
+      onlineRequired: 'Tüm arşivde arama yapmak için internet bağlantısı gerekli.',
+      loadFailed: 'Fiş arşivi yüklenemedi.',
+      loading: 'Fişler yükleniyor',
+      unavailable: 'Arşiv şu anda kullanılamıyor',
+      emptyTitle: 'Bu filtrelerle fiş bulunamadı',
+      emptyBody: 'Tarih aralığını genişlet veya filtreleri sıfırla.',
+      resetFilters: 'Filtreleri sıfırla',
+      branch: 'Şube',
+      search: 'Hızlı arama',
+      searchPlaceholder: 'Masa 4, Pencere, WB1-...',
+      today: 'Bugün',
+      sevenDays: '7 gün',
+      thirtyDays: '30 gün',
+      filters: 'Filtreler',
+      searchAction: 'Ara',
+      results: 'sonuç gösteriliyor',
+      loadMore: 'Daha fazla göster',
+      end: 'Arşivin bu bölümünün sonu',
+      invalidFilters: 'Filtreleri kontrol et',
+      tryAgain: 'Tekrar deneyin.',
+      pdfFailed: 'Fiş PDF’i açılamadı',
+      branchFailed: 'Şube değiştirilemedi',
+    };
+  }
+  if (language === 'bg') {
+    return {
+      title: 'Архив на разписките',
+      subtitle: 'Намерете разписка по дата, час, маса, сметка, сервитьор или сума.',
+      cloudArchive: 'Облачен архив',
+      offline: 'Офлайн',
+      onlineRequired: 'За търсене в целия архив е необходим интернет.',
+      loadFailed: 'Архивът не можа да се зареди.',
+      loading: 'Зареждане на разписки',
+      unavailable: 'Архивът не е достъпен',
+      emptyTitle: 'Няма разписки с тези филтри',
+      emptyBody: 'Разширете периода или изчистете филтрите.',
+      resetFilters: 'Изчисти филтрите',
+      branch: 'Обект',
+      search: 'Бързо търсене',
+      searchPlaceholder: 'Маса 4, Прозорец, WB1-...',
+      today: 'Днес',
+      sevenDays: '7 дни',
+      thirtyDays: '30 дни',
+      filters: 'Филтри',
+      searchAction: 'Търси',
+      results: 'резултата',
+      loadMore: 'Покажи още',
+      end: 'Край на тази част от архива',
+      invalidFilters: 'Проверете филтрите',
+      tryAgain: 'Опитайте отново.',
+      pdfFailed: 'PDF файлът не можа да се отвори',
+      branchFailed: 'Обектът не можа да се смени',
+    };
+  }
+  return {
+    title: 'Receipt archive',
+    subtitle: 'Find a receipt by date, time, table, check, waiter, or amount in seconds.',
+    cloudArchive: 'Cloud archive',
+    offline: 'Offline',
+    onlineRequired: 'An internet connection is required to search the complete archive.',
+    loadFailed: 'The receipt archive could not be loaded.',
+    loading: 'Loading receipts',
+    unavailable: 'Archive unavailable',
+    emptyTitle: 'No receipts match these filters',
+    emptyBody: 'Widen the date range or reset the filters.',
+    resetFilters: 'Reset filters',
+    branch: 'Branch',
+    search: 'Quick search',
+    searchPlaceholder: 'Table 4, Window, WB1-...',
+    today: 'Today',
+    sevenDays: '7 days',
+    thirtyDays: '30 days',
+    filters: 'Filters',
+    searchAction: 'Search',
+    results: 'results shown',
+    loadMore: 'Show more',
+    end: 'End of this archive section',
+    invalidFilters: 'Check the filters',
+    tryAgain: 'Try again.',
+    pdfFailed: 'Receipt PDF could not be opened',
+    branchFailed: 'Branch could not be changed',
+  };
 }

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -90,6 +90,28 @@ export type ActiveSessionParticipantRow = {
   last_action_at: string;
 };
 
+export type ReceiptArchiveRow = {
+  id: string;
+  organization_id: string;
+  branch_id: string;
+  branch_name: string;
+  branch_timezone: string;
+  table_session_id: string;
+  check_id: string;
+  receipt_number: string;
+  business_date: string;
+  issued_at: string;
+  issued_by: string;
+  total_minor: number;
+  currency_code: string;
+  snapshot_json: Json;
+  pdf_storage_path: string | null;
+  pdf_hash: string | null;
+  status: string;
+  adjusts_receipt_id: string | null;
+  has_adjustment: boolean;
+};
+
 type TableDefinition<Row> = {
   Row: Row;
   Insert: Partial<Row>;
@@ -196,6 +218,26 @@ export type Database = {
           active_since?: string;
         };
         Returns: ActiveSessionParticipantRow[];
+      };
+      search_receipts: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_query?: string | null;
+          requested_date_from?: string | null;
+          requested_date_to?: string | null;
+          requested_time_from?: string | null;
+          requested_time_to?: string | null;
+          requested_waiter_query?: string | null;
+          requested_payment_method?: string | null;
+          requested_amount_min_minor?: number | null;
+          requested_amount_max_minor?: number | null;
+          requested_has_adjustment?: boolean | null;
+          requested_after_issued_at?: string | null;
+          requested_after_id?: string | null;
+          requested_page_size?: number;
+        };
+        Returns: ReceiptArchiveRow[];
       };
       transfer_or_merge_table_session: {
         Args: {

--- a/supabase/migrations/20260727012000_receipt_archive_search.sql
+++ b/supabase/migrations/20260727012000_receipt_archive_search.sql
@@ -1,0 +1,273 @@
+-- Cursor-paginated, tenant-scoped receipt archive search.
+
+create extension if not exists pg_trgm with schema extensions;
+
+create index receipts_branch_business_cursor_idx
+  on public.receipts (
+    branch_id,
+    business_date desc,
+    issued_at desc,
+    id desc
+  );
+create index receipts_number_trigram_idx
+  on public.receipts using gin (
+    lower(receipt_number) extensions.gin_trgm_ops
+  );
+create index receipts_table_trigram_idx
+  on public.receipts using gin (
+    lower((snapshot_json ->> 'tableLabel')) extensions.gin_trgm_ops
+  );
+create index receipts_check_trigram_idx
+  on public.receipts using gin (
+    lower((snapshot_json #>> '{checks,0,name}')) extensions.gin_trgm_ops
+  );
+create index receipts_waiter_trigram_idx
+  on public.receipts using gin (
+    lower((snapshot_json ->> 'waiterDisplayNames'))
+      extensions.gin_trgm_ops
+  );
+
+create or replace function public.search_receipts(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_query text default null,
+  requested_date_from date default null,
+  requested_date_to date default null,
+  requested_time_from time default null,
+  requested_time_to time default null,
+  requested_waiter_query text default null,
+  requested_payment_method text default null,
+  requested_amount_min_minor bigint default null,
+  requested_amount_max_minor bigint default null,
+  requested_has_adjustment boolean default null,
+  requested_after_issued_at timestamptz default null,
+  requested_after_id uuid default null,
+  requested_page_size integer default 30
+)
+returns table (
+  id uuid,
+  organization_id uuid,
+  branch_id uuid,
+  branch_name text,
+  branch_timezone text,
+  table_session_id uuid,
+  check_id uuid,
+  receipt_number text,
+  business_date date,
+  issued_at timestamptz,
+  issued_by uuid,
+  total_minor bigint,
+  currency_code text,
+  snapshot_json jsonb,
+  pdf_storage_path text,
+  pdf_hash text,
+  status text,
+  adjusts_receipt_id uuid,
+  has_adjustment boolean
+)
+language plpgsql
+security definer
+set search_path = ''
+stable
+as $$
+declare
+  normalized_query text := nullif(trim(requested_query), '');
+  normalized_waiter_query text := nullif(trim(requested_waiter_query), '');
+begin
+  if (select auth.uid()) is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if not private.is_active_member(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'branch_access_denied';
+  end if;
+  if requested_page_size < 1 or requested_page_size > 100 then
+    raise exception using errcode = '22023', message = 'invalid_receipt_page_size';
+  end if;
+  if (requested_after_issued_at is null) <> (requested_after_id is null) then
+    raise exception using errcode = '22023', message = 'invalid_receipt_cursor';
+  end if;
+  if requested_date_from is not null
+    and requested_date_to is not null
+    and requested_date_from > requested_date_to then
+    raise exception using errcode = '22023', message = 'invalid_receipt_date_range';
+  end if;
+  if (
+    requested_amount_min_minor is not null
+    and requested_amount_min_minor < 0
+  ) or (
+    requested_amount_max_minor is not null
+    and requested_amount_max_minor < 0
+  ) or (
+    requested_amount_min_minor is not null
+      and requested_amount_max_minor is not null
+      and requested_amount_min_minor > requested_amount_max_minor
+  ) then
+    raise exception using errcode = '22023', message = 'invalid_receipt_amount_range';
+  end if;
+  if (
+    normalized_query is not null
+    and char_length(normalized_query) > 120
+  ) or (
+    normalized_waiter_query is not null
+    and char_length(normalized_waiter_query) > 120
+  ) then
+    raise exception using errcode = '22023', message = 'receipt_search_query_too_long';
+  end if;
+  if requested_payment_method is not null
+    and requested_payment_method not in ('cash', 'card', 'mixed_adjustment') then
+    raise exception using errcode = '22023', message = 'invalid_receipt_payment_method';
+  end if;
+
+  return query
+  select
+    receipt.id,
+    receipt.organization_id,
+    receipt.branch_id,
+    branch.name,
+    branch.timezone,
+    receipt.table_session_id,
+    receipt.check_id,
+    receipt.receipt_number,
+    receipt.business_date,
+    receipt.issued_at,
+    receipt.issued_by,
+    receipt.total_minor,
+    receipt.currency_code,
+    receipt.snapshot_json,
+    receipt.pdf_storage_path,
+    receipt.pdf_hash,
+    receipt.status,
+    receipt.adjusts_receipt_id,
+    exists (
+      select 1
+      from public.receipts as adjustment
+      where adjustment.organization_id = receipt.organization_id
+        and adjustment.branch_id = receipt.branch_id
+        and adjustment.adjusts_receipt_id = receipt.id
+    )
+  from public.receipts as receipt
+  join public.branches as branch
+    on branch.organization_id = receipt.organization_id
+   and branch.id = receipt.branch_id
+  where receipt.organization_id = requested_organization_id
+    and receipt.branch_id = requested_branch_id
+    and receipt.status in ('issued', 'adjusted', 'voided')
+    and (
+      requested_date_from is null
+      or receipt.business_date >= requested_date_from
+    )
+    and (
+      requested_date_to is null
+      or receipt.business_date <= requested_date_to
+    )
+    and (
+      requested_time_from is null
+      or requested_time_to is null
+      or case
+        when requested_time_from <= requested_time_to then
+          timezone(branch.timezone, receipt.issued_at)::time
+            between requested_time_from and requested_time_to
+        else
+          timezone(branch.timezone, receipt.issued_at)::time >= requested_time_from
+          or timezone(branch.timezone, receipt.issued_at)::time <= requested_time_to
+      end
+    )
+    and (
+      requested_time_from is null
+      or requested_time_to is not null
+      or timezone(branch.timezone, receipt.issued_at)::time >= requested_time_from
+    )
+    and (
+      requested_time_to is null
+      or requested_time_from is not null
+      or timezone(branch.timezone, receipt.issued_at)::time <= requested_time_to
+    )
+    and (
+      normalized_query is null
+      or lower(receipt.receipt_number)
+        like concat('%', lower(normalized_query), '%')
+      or lower(receipt.snapshot_json ->> 'tableLabel')
+        like concat('%', lower(normalized_query), '%')
+      or lower(receipt.snapshot_json #>> '{checks,0,name}')
+        like concat('%', lower(normalized_query), '%')
+    )
+    and (
+      normalized_waiter_query is null
+      or lower(receipt.snapshot_json ->> 'waiterDisplayNames')
+        like concat('%', lower(normalized_waiter_query), '%')
+    )
+    and (
+      requested_payment_method is null
+      or exists (
+        select 1
+        from jsonb_array_elements(
+          coalesce(receipt.snapshot_json -> 'payments', '[]'::jsonb)
+        ) as payment(value)
+        where payment.value ->> 'method' = requested_payment_method
+      )
+    )
+    and (
+      requested_amount_min_minor is null
+      or receipt.total_minor >= requested_amount_min_minor
+    )
+    and (
+      requested_amount_max_minor is null
+      or receipt.total_minor <= requested_amount_max_minor
+    )
+    and (
+      requested_has_adjustment is null
+      or requested_has_adjustment = (
+        receipt.status <> 'issued'
+        or exists (
+          select 1
+          from public.receipts as adjustment
+          where adjustment.organization_id = receipt.organization_id
+            and adjustment.branch_id = receipt.branch_id
+            and adjustment.adjusts_receipt_id = receipt.id
+        )
+      )
+    )
+    and (
+      requested_after_issued_at is null
+      or (receipt.issued_at, receipt.id)
+        < (requested_after_issued_at, requested_after_id)
+    )
+  order by receipt.issued_at desc, receipt.id desc
+  limit requested_page_size + 1;
+end;
+$$;
+
+revoke execute on function public.search_receipts(
+  uuid,
+  uuid,
+  text,
+  date,
+  date,
+  time,
+  time,
+  text,
+  text,
+  bigint,
+  bigint,
+  boolean,
+  timestamptz,
+  uuid,
+  integer
+) from public, anon;
+grant execute on function public.search_receipts(
+  uuid,
+  uuid,
+  text,
+  date,
+  date,
+  time,
+  time,
+  text,
+  text,
+  bigint,
+  bigint,
+  boolean,
+  timestamptz,
+  uuid,
+  integer
+) to authenticated;

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(72);
+select plan(83);
 
 insert into auth.users (
   instance_id,
@@ -1412,6 +1412,189 @@ select is(
   ),
   2::bigint,
   'two paid named checks produce two distinct immutable receipts'
+);
+
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001'
+    )
+  ),
+  2::bigint,
+  'the archive returns branch-scoped receipts in a cursor page'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_query => 'Masa 4'
+    )
+  ),
+  1::bigint,
+  'archive quick search finds a historical table snapshot'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_query => 'Pencere'
+    )
+  ),
+  1::bigint,
+  'archive quick search finds a named check'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_date_from => (
+        select min(business_date)
+        from public.receipts
+        where branch_id = '35000000-0000-4000-8000-000000000001'
+      ),
+      requested_date_to => (
+        select max(business_date)
+        from public.receipts
+        where branch_id = '35000000-0000-4000-8000-000000000001'
+      )
+    )
+  ),
+  2::bigint,
+  'archive date filters use the immutable business date'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_waiter_query => 'Second Waiter'
+    )
+  ),
+  1::bigint,
+  'archive waiter search uses historical attribution names'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_payment_method => 'cash'
+    )
+  ),
+  1::bigint,
+  'archive payment filters inspect the immutable payment snapshot'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_amount_min_minor => 500,
+      requested_amount_max_minor => 500
+    )
+  ),
+  2::bigint,
+  'archive amount filters use integer minor units'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_time_from => (
+        select timezone('Europe/Sofia', issued_at)::time
+        from public.receipts
+        where check_id = 'f5000000-0000-4000-8000-000000000001'
+      ),
+      requested_time_to => (
+        select timezone('Europe/Sofia', issued_at)::time
+        from public.receipts
+        where check_id = 'f5000000-0000-4000-8000-000000000001'
+      )
+    )
+  ),
+  1::bigint,
+  'archive time filters evaluate issue time in the branch timezone'
+);
+select is(
+  (
+    select count(*)
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_page_size => 1
+    )
+  ),
+  2::bigint,
+  'a cursor page includes one lookahead row without scanning all history'
+);
+select is(
+  (
+    select receipt_number
+    from public.search_receipts(
+      requested_organization_id =>
+        '25000000-0000-4000-8000-000000000001',
+      requested_branch_id =>
+        '35000000-0000-4000-8000-000000000001',
+      requested_after_issued_at => (
+        select issued_at
+        from public.receipts
+        where check_id = 'f5000000-0000-4000-8000-000000000150'
+      ),
+      requested_after_id => (
+        select id
+        from public.receipts
+        where check_id = 'f5000000-0000-4000-8000-000000000150'
+      ),
+      requested_page_size => 1
+    )
+  ),
+  (
+    select receipt_number
+    from public.receipts
+    where check_id = 'f5000000-0000-4000-8000-000000000001'
+  ),
+  'the archive cursor continues after the exact issued-at and id key'
+);
+select throws_ok(
+  $$
+    select *
+    from public.search_receipts(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000002'
+    )
+  $$,
+  '42501',
+  'branch_access_denied',
+  'a user cannot search another branch receipt archive'
 );
 
 select * from finish();

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -1539,8 +1539,8 @@ select is(
       )
     )
   ),
-  1::bigint,
-  'archive time filters evaluate issue time in the branch timezone'
+  2::bigint,
+  'archive time filters evaluate the shared transaction issue time in the branch timezone'
 );
 select is(
   (
@@ -1567,12 +1567,16 @@ select is(
       requested_after_issued_at => (
         select issued_at
         from public.receipts
-        where check_id = 'f5000000-0000-4000-8000-000000000150'
+        where branch_id = '35000000-0000-4000-8000-000000000001'
+        order by issued_at desc, id desc
+        limit 1
       ),
       requested_after_id => (
         select id
         from public.receipts
-        where check_id = 'f5000000-0000-4000-8000-000000000150'
+        where branch_id = '35000000-0000-4000-8000-000000000001'
+        order by issued_at desc, id desc
+        limit 1
       ),
       requested_page_size => 1
     )
@@ -1580,7 +1584,10 @@ select is(
   (
     select receipt_number
     from public.receipts
-    where check_id = 'f5000000-0000-4000-8000-000000000001'
+    where branch_id = '35000000-0000-4000-8000-000000000001'
+    order by issued_at desc, id desc
+    offset 1
+    limit 1
   ),
   'the archive cursor continues after the exact issued-at and id key'
 );


### PR DESCRIPTION
## Summary
- replace the legacy device-local history screen with a responsive cloud receipt archive for waiters and managers
- filter immutable snapshots by branch, business date, local time, table/check/receipt, waiter, payment method, amount, and adjustment state
- use indexed keyset pagination with one-row lookahead instead of downloading all history
- reopen, download, and share private receipt PDFs from any authorized device

## Verification
- npm run verify:full
- 36 Jest suites / 174 tests
- 3 Playwright service flows
- pgTAP plan expanded to 83 assertions (Database CI)

Closes #25

## Stack
Base: #52