### PR TITLE
feat(reports): add auditable manager performance reporting

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -84,3 +84,23 @@ test('opens the searchable receipt archive with explicit offline recovery', asyn
     page.getByText(/Arşiv şu anda kullanılamıyor|Архивът не е достъпен|Archive unavailable/i),
   ).toBeVisible();
 });
+
+test('opens the manager report with auditable filters and offline recovery', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  await page
+    .getByText(/Raporlar|Отчети|Reports/i)
+    .last()
+    .click();
+  await expect(
+    page.getByText(/Yönetici raporu|Управленски отчет|Manager report/i).first(),
+  ).toBeVisible();
+  await expect(page.getByLabel(/Başlangıç|Начало|From/i)).toBeVisible();
+  await expect(page.getByLabel(/Bitiş|Край|To/i)).toBeVisible();
+  await expect(
+    page.getByText(
+      /Yönetici raporu için internet bağlantısı gerekli|За управленския отчет е необходим интернет|An internet connection is required for manager reporting/i,
+    ),
+  ).toBeVisible();
+});

--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -10,12 +10,21 @@ import React, {
 } from 'react';
 import { AppState, Platform } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
-import { BranchId, DeviceId, MutationId, OrganizationId, Receipt, toDomainId } from '../../domain';
+import {
+  BranchId,
+  DeviceId,
+  MutationId,
+  OrganizationId,
+  Receipt,
+  UserId,
+  toDomainId,
+} from '../../domain';
 import {
   ConfirmCheckPaymentsCommand,
   ConfirmCheckPaymentsResult,
   SupabasePaymentGateway,
 } from '../../features/payments';
+import { ManagerReport, ManagerReportGateway } from '../../features/manager-reports';
 import {
   ReceiptArchiveCursor,
   ReceiptArchiveFilters,
@@ -75,6 +84,7 @@ export interface OrderiaDataContextValue {
     cursor?: ReceiptArchiveCursor,
     pageSize?: number,
   ): Promise<ReceiptArchivePage>;
+  loadManagerReport(dateFrom: string, dateTo: string, waiterId?: UserId): Promise<ManagerReport>;
 }
 
 interface OrderiaDataProviderProps {
@@ -324,6 +334,19 @@ export function OrderiaDataProvider({
     [client, scope],
   );
 
+  const loadManagerReport = useCallback(
+    async (dateFrom: string, dateTo: string, waiterId?: UserId): Promise<ManagerReport> => {
+      if (!client || !scope) throw new Error('Cloud manager reporting is unavailable');
+      return new ManagerReportGateway(client).load({
+        ...scope,
+        dateFrom,
+        dateTo,
+        ...(waiterId ? { waiterId } : {}),
+      });
+    },
+    [client, scope],
+  );
+
   useEffect(() => {
     if (!database || !scope || !client) return;
 
@@ -418,6 +441,7 @@ export function OrderiaDataProvider({
       transferOrMergeTableSession,
       prepareReceiptPdf,
       searchReceiptArchive,
+      loadManagerReport,
     }),
     [
       client,
@@ -425,6 +449,7 @@ export function OrderiaDataProvider({
       database,
       errorMessage,
       lastSuccessfulSyncAt,
+      loadManagerReport,
       prepareReceiptPdf,
       readiness,
       refresh,

--- a/src/features/manager-reports/DailyRevenueBars.tsx
+++ b/src/features/manager-reports/DailyRevenueBars.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { Language } from '../../i18n';
+import { ManagerReportDay } from './managerReportGateway';
+
+export function DailyRevenueBars({
+  currencyCode,
+  days,
+  language,
+  selectedWaiter,
+}: {
+  readonly currencyCode: string;
+  readonly days: readonly ManagerReportDay[];
+  readonly language: Language;
+  readonly selectedWaiter: boolean;
+}) {
+  const { tokens } = useTheme();
+  const amounts = days.map((day) =>
+    selectedWaiter ? (day.selectedWaiterContributionMinor ?? 0) : day.confirmedRevenueMinor,
+  );
+  const maximum = Math.max(1, ...amounts);
+  return (
+    <View style={{ gap: tokens.space.sm }}>
+      {days.map((day, index) => {
+        const amount = amounts[index];
+        return (
+          <View key={day.businessDate} style={{ gap: tokens.space.xxs }}>
+            <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {formatDate(day.businessDate, language)}
+              </Text>
+              <Text style={[tokens.typography.label, { color: tokens.colors.text }]}>
+                {formatMinor(amount, currencyCode, language)}
+              </Text>
+            </View>
+            <View
+              style={{
+                backgroundColor: tokens.colors.surfaceAlt,
+                borderRadius: tokens.radius.full,
+                height: 10,
+                overflow: 'hidden',
+              }}
+            >
+              <View
+                style={{
+                  backgroundColor: tokens.colors.primary,
+                  borderRadius: tokens.radius.full,
+                  height: 10,
+                  width: `${Math.max(amount > 0 ? 4 : 0, (amount / maximum) * 100)}%`,
+                }}
+              />
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+function formatDate(value: string, language: Language): string {
+  return new Intl.DateTimeFormat(locale(language), {
+    day: '2-digit',
+    month: 'short',
+  }).format(new Date(`${value}T12:00:00Z`));
+}
+
+export function formatMinor(amountMinor: number, currencyCode: string, language: Language): string {
+  const formatter = new Intl.NumberFormat(locale(language), {
+    currency: currencyCode,
+    style: 'currency',
+  });
+  const fractionDigits = formatter.resolvedOptions().maximumFractionDigits ?? 2;
+  return formatter.format(amountMinor / 10 ** fractionDigits);
+}
+
+function locale(language: Language): string {
+  return language === 'tr' ? 'tr-TR' : language === 'bg' ? 'bg-BG' : 'en-US';
+}

--- a/src/features/manager-reports/ManagerKpiGrid.tsx
+++ b/src/features/manager-reports/ManagerKpiGrid.tsx
@@ -1,0 +1,56 @@
+import { Ionicons } from '@expo/vector-icons';
+import React from 'react';
+import { Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceSurface, useAdaptiveLayout } from '../../design-system';
+
+export interface ManagerKpi {
+  readonly label: string;
+  readonly value: string;
+  readonly helper?: string;
+  readonly icon: keyof typeof Ionicons.glyphMap;
+  readonly tone?: 'primary' | 'warning' | 'neutral';
+}
+
+export function ManagerKpiGrid({ items }: { readonly items: readonly ManagerKpi[] }) {
+  const { tokens } = useTheme();
+  const layout = useAdaptiveLayout();
+  const basis = layout.mode === 'compact' ? '47%' : layout.mode === 'medium' ? '30%' : '22%';
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+      {items.map((item) => (
+        <ServiceSurface
+          key={item.label}
+          style={{
+            flexBasis: basis,
+            flexGrow: 1,
+            gap: tokens.space.xs,
+            minHeight: 128,
+          }}
+          variant="outlined"
+        >
+          <Ionicons
+            color={
+              item.tone === 'warning'
+                ? tokens.colors.warning
+                : item.tone === 'primary'
+                  ? tokens.colors.primary
+                  : tokens.colors.textSubtle
+            }
+            name={item.icon}
+            size={22}
+          />
+          <Text style={[tokens.typography.money, { color: tokens.colors.text }]}>{item.value}</Text>
+          <Text style={[tokens.typography.label, { color: tokens.colors.textSubtle }]}>
+            {item.label}
+          </Text>
+          {item.helper ? (
+            <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>
+              {item.helper}
+            </Text>
+          ) : null}
+        </ServiceSurface>
+      ))}
+    </View>
+  );
+}

--- a/src/features/manager-reports/WaiterPerformanceCard.tsx
+++ b/src/features/manager-reports/WaiterPerformanceCard.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { useTheme } from '../../contexts/ThemeContext';
+import { ServiceStatusPill, ServiceSurface } from '../../design-system';
+import { Language } from '../../i18n';
+import { formatMinor } from './DailyRevenueBars';
+import { WaiterPerformanceRow } from './managerReportGateway';
+
+export function WaiterPerformanceCard({
+  currencyCode,
+  language,
+  waiter,
+}: {
+  readonly currencyCode: string;
+  readonly language: Language;
+  readonly waiter: WaiterPerformanceRow;
+}) {
+  const { tokens } = useTheme();
+  const copy = waiterCopy(language);
+  return (
+    <ServiceSurface style={{ gap: tokens.space.md }} variant="outlined">
+      <View
+        style={{
+          alignItems: 'center',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+        }}
+      >
+        <View style={{ flex: 1 }}>
+          <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+            {waiter.displayName}
+          </Text>
+          <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+            {copy.contribution}
+          </Text>
+        </View>
+        <Text style={[tokens.typography.money, { color: tokens.colors.primary }]}>
+          {formatMinor(waiter.contributedRevenueMinor, currencyCode, language)}
+        </Text>
+      </View>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+        <Metric label={copy.items} value={`${waiter.itemRows}`} />
+        <Metric label={copy.tables} value={`${waiter.tablesServed}`} />
+        <Metric
+          label={copy.payments}
+          value={formatMinor(waiter.paymentHandledMinor, currencyCode, language)}
+        />
+        <Metric label={copy.helped} value={`${waiter.helpedTableCount}`} />
+        <Metric label={copy.observed} value={`~${waiter.observedActiveMinutes} ${copy.minute}`} />
+      </View>
+      {waiter.cancellationCount > 0 ? (
+        <ServiceStatusPill
+          icon="close-circle-outline"
+          label={`${waiter.cancellationCount} ${copy.cancellations} · ${formatMinor(
+            waiter.cancellationValueMinor,
+            currencyCode,
+            language,
+          )}`}
+          tone="warning"
+        />
+      ) : null}
+    </ServiceSurface>
+  );
+}
+
+function Metric({ label, value }: { readonly label: string; readonly value: string }) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ flexBasis: 110, flexGrow: 1 }}>
+      <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}>{value}</Text>
+      <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>{label}</Text>
+    </View>
+  );
+}
+
+function waiterCopy(language: Language) {
+  if (language === 'tr') {
+    return {
+      contribution: 'Satır bazlı ciro katkısı',
+      items: 'Ürün satırı',
+      tables: 'Servis verilen masa',
+      payments: 'Alınan ödeme',
+      helped: 'Yardım edilen masa',
+      observed: 'Gözlenen süre',
+      minute: 'dk',
+      cancellations: 'iptal',
+    };
+  }
+  if (language === 'bg') {
+    return {
+      contribution: 'Принос към оборота по артикули',
+      items: 'Редове',
+      tables: 'Обслужени маси',
+      payments: 'Обработени плащания',
+      helped: 'Помогнати маси',
+      observed: 'Наблюдавано време',
+      minute: 'мин',
+      cancellations: 'анулирания',
+    };
+  }
+  return {
+    contribution: 'Item-attributed revenue',
+    items: 'Item rows',
+    tables: 'Tables served',
+    payments: 'Payments handled',
+    helped: 'Tables helped',
+    observed: 'Observed time',
+    minute: 'min',
+    cancellations: 'cancellations',
+  };
+}

--- a/src/features/manager-reports/__tests__/managerReportExport.test.ts
+++ b/src/features/manager-reports/__tests__/managerReportExport.test.ts
@@ -1,0 +1,36 @@
+import { ManagerReport } from '../managerReportGateway';
+import { createManagerReportCsv } from '../managerReportExport';
+
+describe('manager report CSV', () => {
+  it('exports transparent item, payment, cancellation, help, and activity attribution', () => {
+    const csv = createManagerReportCsv(report);
+
+    expect(csv).toMatch(/contributed_revenue_minor,payments_handled_minor/);
+    expect(csv).toMatch(/cancellation_count,cancellation_value_minor,helped_tables/);
+    expect(csv).toContain('"Şule, Akın"');
+    expect(csv).toContain(',1000,1500,2,2,1,500,1,42');
+    expect(csv.startsWith('\uFEFF')).toBe(true);
+    expect(csv.endsWith('\n')).toBe(true);
+  });
+});
+
+const report = {
+  branchId: 'branch-1',
+  dateFrom: '2026-07-20',
+  dateTo: '2026-07-26',
+  waiters: [
+    {
+      displayName: 'Şule, Akın',
+      itemRows: 2,
+      itemQuantity: 3,
+      contributedRevenueMinor: 1_000,
+      paymentHandledMinor: 1_500,
+      paymentCount: 2,
+      tablesServed: 2,
+      cancellationCount: 1,
+      cancellationValueMinor: 500,
+      helpedTableCount: 1,
+      observedActiveMinutes: 42,
+    },
+  ],
+} as unknown as ManagerReport;

--- a/src/features/manager-reports/__tests__/managerReportGateway.test.ts
+++ b/src/features/manager-reports/__tests__/managerReportGateway.test.ts
@@ -1,0 +1,107 @@
+import { ManagerReport, ManagerReportGateway } from '../managerReportGateway';
+
+describe('ManagerReportGateway', () => {
+  it('requests the branch ledger with an optional waiter attribution filter', async () => {
+    const rpc = jest.fn().mockResolvedValue({ data: report, error: null });
+    const gateway = new ManagerReportGateway({ rpc } as never);
+
+    await expect(
+      gateway.load({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        dateFrom: '2026-07-20',
+        dateTo: '2026-07-26',
+        waiterId: 'waiter-1' as never,
+      }),
+    ).resolves.toEqual(report);
+    expect(rpc).toHaveBeenCalledWith('get_manager_report', {
+      requested_organization_id: 'organization-1',
+      requested_branch_id: 'branch-1',
+      requested_date_from: '2026-07-20',
+      requested_date_to: '2026-07-26',
+      requested_waiter_id: 'waiter-1',
+    });
+  });
+
+  it('surfaces manager authorization errors and rejects malformed responses', async () => {
+    const denied = new ManagerReportGateway({
+      rpc: jest.fn().mockResolvedValue({
+        data: null,
+        error: { code: '42501', message: 'manager_role_required' },
+      }),
+    } as never);
+    await expect(
+      denied.load({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        dateFrom: '2026-07-20',
+        dateTo: '2026-07-26',
+      }),
+    ).rejects.toMatchObject({ message: 'manager_role_required' });
+
+    const malformed = new ManagerReportGateway({
+      rpc: jest.fn().mockResolvedValue({ data: { summary: {} }, error: null }),
+    } as never);
+    await expect(
+      malformed.load({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        dateFrom: '2026-07-20',
+        dateTo: '2026-07-26',
+      }),
+    ).rejects.toThrow('response is invalid');
+  });
+});
+
+const report: ManagerReport = {
+  generatedAt: '2026-07-26T18:00:00.000Z',
+  organizationId: 'organization-1' as never,
+  branchId: 'branch-1' as never,
+  branchName: 'Sofia',
+  currencyCode: 'EUR',
+  dateFrom: '2026-07-20',
+  dateTo: '2026-07-26',
+  selectedWaiterId: 'waiter-1' as never,
+  summary: {
+    confirmedRevenueMinor: 1_500,
+    receiptCount: 2,
+    confirmedPaymentCount: 2,
+    servedTableCount: 2,
+    averageReceiptMinor: 750,
+    cancelledItemCount: 1,
+    cancelledValueMinor: 500,
+    selectedWaiterContributionMinor: 1_000,
+    selectedWaiterPaymentHandledMinor: 1_500,
+    currentOpenTableCount: 1,
+    currentPaymentPendingCount: 0,
+    currentOpenBalanceMinor: 400,
+    activeWaiterCount: 1,
+  },
+  waiters: [
+    {
+      userId: 'waiter-1' as never,
+      displayName: 'Şule',
+      itemRows: 2,
+      itemQuantity: 3,
+      contributedRevenueMinor: 1_000,
+      paymentHandledMinor: 1_500,
+      paymentCount: 2,
+      tablesServed: 2,
+      cancellationCount: 1,
+      cancellationValueMinor: 500,
+      helpedTableCount: 1,
+      observedActiveMinutes: 42,
+    },
+  ],
+  daily: [
+    {
+      businessDate: '2026-07-26',
+      confirmedRevenueMinor: 1_500,
+      receiptCount: 2,
+      cancellationCount: 1,
+      selectedWaiterContributionMinor: 1_000,
+    },
+  ],
+  cancellations: [],
+  definitions: { confirmedRevenue: 'confirmed allocations' },
+};

--- a/src/features/manager-reports/__tests__/managerReportRange.test.ts
+++ b/src/features/manager-reports/__tests__/managerReportRange.test.ts
@@ -1,0 +1,22 @@
+import { assertManagerReportRange, managerReportRange } from '../managerReportRange';
+
+describe('manager report range', () => {
+  it('uses the branch-local business date across a UTC day boundary', () => {
+    expect(managerReportRange('Europe/Sofia', 7, new Date('2026-07-26T21:30:00.000Z'))).toEqual({
+      dateFrom: '2026-07-21',
+      dateTo: '2026-07-27',
+    });
+  });
+
+  it('rejects impossible, reversed, and overlong ranges', () => {
+    expect(() =>
+      assertManagerReportRange({ dateFrom: '2026-02-31', dateTo: '2026-03-01' }),
+    ).toThrow('YYYY-MM-DD');
+    expect(() =>
+      assertManagerReportRange({ dateFrom: '2026-07-27', dateTo: '2026-07-26' }),
+    ).toThrow('after end date');
+    expect(() =>
+      assertManagerReportRange({ dateFrom: '2025-01-01', dateTo: '2026-07-26' }),
+    ).toThrow('366 days');
+  });
+});

--- a/src/features/manager-reports/index.ts
+++ b/src/features/manager-reports/index.ts
@@ -1,0 +1,6 @@
+export * from './DailyRevenueBars';
+export * from './ManagerKpiGrid';
+export * from './managerReportExport';
+export * from './managerReportGateway';
+export * from './managerReportRange';
+export * from './WaiterPerformanceCard';

--- a/src/features/manager-reports/managerReportExport.ts
+++ b/src/features/manager-reports/managerReportExport.ts
@@ -1,0 +1,72 @@
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { Platform } from 'react-native';
+import { ManagerReport } from './managerReportGateway';
+
+export function createManagerReportCsv(report: ManagerReport): string {
+  const rows: readonly (readonly (number | string)[])[] = [
+    [
+      'waiter',
+      'item_rows',
+      'item_quantity',
+      'contributed_revenue_minor',
+      'payments_handled_minor',
+      'payment_count',
+      'tables_served',
+      'cancellation_count',
+      'cancellation_value_minor',
+      'helped_tables',
+      'observed_active_minutes',
+    ],
+    ...report.waiters.map((waiter) => [
+      waiter.displayName,
+      waiter.itemRows,
+      waiter.itemQuantity,
+      waiter.contributedRevenueMinor,
+      waiter.paymentHandledMinor,
+      waiter.paymentCount,
+      waiter.tablesServed,
+      waiter.cancellationCount,
+      waiter.cancellationValueMinor,
+      waiter.helpedTableCount,
+      waiter.observedActiveMinutes,
+    ]),
+  ];
+  return `\uFEFF${rows.map((row) => row.map(csvCell).join(',')).join('\n')}\n`;
+}
+
+export async function presentManagerReportCsv(report: ManagerReport): Promise<string | undefined> {
+  const contents = createManagerReportCsv(report);
+  const fileName = `orderia-${report.branchId}-${report.dateFrom}-${report.dateTo}.csv`;
+  if (Platform.OS === 'web') {
+    if (typeof document === 'undefined' || typeof URL === 'undefined') {
+      throw new Error('Browser export is unavailable');
+    }
+    const url = URL.createObjectURL(new Blob([contents], { type: 'text/csv;charset=utf-8' }));
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = fileName;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    return;
+  }
+
+  const directory = FileSystem.cacheDirectory ?? FileSystem.documentDirectory;
+  if (!directory) throw new Error('Device export storage is unavailable');
+  const uri = `${directory}${fileName}`;
+  await FileSystem.writeAsStringAsync(uri, contents, {
+    encoding: FileSystem.EncodingType.UTF8,
+  });
+  if (!(await Sharing.isAvailableAsync())) throw new Error('Sharing is unavailable');
+  await Sharing.shareAsync(uri, {
+    dialogTitle: 'Orderia manager report',
+    mimeType: 'text/csv',
+    UTI: 'public.comma-separated-values-text',
+  });
+  return uri;
+}
+
+function csvCell(value: number | string): string {
+  const text = String(value);
+  return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}

--- a/src/features/manager-reports/managerReportGateway.ts
+++ b/src/features/manager-reports/managerReportGateway.ts
@@ -1,0 +1,137 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { BranchId, OrganizationId, UserId } from '../../domain';
+import { Database, Json } from '../../services/supabase';
+
+export interface ManagerReportSummary {
+  readonly confirmedRevenueMinor: number;
+  readonly receiptCount: number;
+  readonly confirmedPaymentCount: number;
+  readonly servedTableCount: number;
+  readonly averageReceiptMinor: number;
+  readonly cancelledItemCount: number;
+  readonly cancelledValueMinor: number;
+  readonly selectedWaiterContributionMinor?: number;
+  readonly selectedWaiterPaymentHandledMinor?: number;
+  readonly currentOpenTableCount: number;
+  readonly currentPaymentPendingCount: number;
+  readonly currentOpenBalanceMinor: number;
+  readonly activeWaiterCount: number;
+}
+
+export interface WaiterPerformanceRow {
+  readonly userId: UserId;
+  readonly displayName: string;
+  readonly itemRows: number;
+  readonly itemQuantity: number;
+  readonly contributedRevenueMinor: number;
+  readonly paymentHandledMinor: number;
+  readonly paymentCount: number;
+  readonly tablesServed: number;
+  readonly cancellationCount: number;
+  readonly cancellationValueMinor: number;
+  readonly helpedTableCount: number;
+  readonly firstActionAt?: string;
+  readonly lastActionAt?: string;
+  readonly observedActiveMinutes: number;
+}
+
+export interface ManagerReportDay {
+  readonly businessDate: string;
+  readonly confirmedRevenueMinor: number;
+  readonly receiptCount: number;
+  readonly cancellationCount: number;
+  readonly selectedWaiterContributionMinor?: number;
+}
+
+export interface ManagerCancellationContext {
+  readonly orderItemId: string;
+  readonly tableLabel: string;
+  readonly itemName: string;
+  readonly reasonName: string;
+  readonly createdBy: UserId;
+  readonly createdByDisplayName: string;
+  readonly cancelledBy: UserId;
+  readonly cancelledByDisplayName: string;
+  readonly cancelledAt: string;
+  readonly excludedAmountMinor: number;
+}
+
+export interface ManagerReport {
+  readonly generatedAt: string;
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly branchName: string;
+  readonly currencyCode: string;
+  readonly dateFrom: string;
+  readonly dateTo: string;
+  readonly selectedWaiterId?: UserId;
+  readonly summary: ManagerReportSummary;
+  readonly waiters: readonly WaiterPerformanceRow[];
+  readonly daily: readonly ManagerReportDay[];
+  readonly cancellations: readonly ManagerCancellationContext[];
+  readonly definitions: Readonly<Record<string, string>>;
+}
+
+export class ManagerReportGateway {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async load(input: {
+    readonly organizationId: OrganizationId;
+    readonly branchId: BranchId;
+    readonly dateFrom: string;
+    readonly dateTo: string;
+    readonly waiterId?: UserId;
+  }): Promise<ManagerReport> {
+    assertDateRange(input.dateFrom, input.dateTo);
+    const { data, error } = await this.client.rpc('get_manager_report', {
+      requested_organization_id: input.organizationId,
+      requested_branch_id: input.branchId,
+      requested_date_from: input.dateFrom,
+      requested_date_to: input.dateTo,
+      requested_waiter_id: input.waiterId ?? null,
+    });
+    if (error) throw error;
+    if (!isManagerReport(data)) throw new Error('Manager report response is invalid');
+    return data as unknown as ManagerReport;
+  }
+}
+
+function assertDateRange(dateFrom: string, dateTo: string): void {
+  if (!isDate(dateFrom) || !isDate(dateTo)) throw new Error('Manager report dates are invalid');
+  if (dateFrom > dateTo) throw new Error('Manager report start date must not be after end date');
+  const rangeDays =
+    (Date.parse(`${dateTo}T00:00:00Z`) - Date.parse(`${dateFrom}T00:00:00Z`)) / 86_400_000;
+  if (rangeDays > 366) throw new Error('Manager report range cannot exceed 366 days');
+}
+
+function isDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function isManagerReport(value: Json): boolean {
+  if (!isRecord(value) || !isRecord(value.summary)) return false;
+  return (
+    typeof value.generatedAt === 'string' &&
+    typeof value.branchName === 'string' &&
+    typeof value.currencyCode === 'string' &&
+    typeof value.summary.confirmedRevenueMinor === 'number' &&
+    typeof value.summary.receiptCount === 'number' &&
+    Array.isArray(value.waiters) &&
+    value.waiters.every(
+      (waiter) =>
+        isRecord(waiter) &&
+        typeof waiter.userId === 'string' &&
+        typeof waiter.displayName === 'string' &&
+        typeof waiter.contributedRevenueMinor === 'number',
+    ) &&
+    Array.isArray(value.daily) &&
+    Array.isArray(value.cancellations) &&
+    isRecord(value.definitions)
+  );
+}
+
+function isRecord(value: Json | undefined): value is { [key: string]: Json | undefined } {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/features/manager-reports/managerReportRange.ts
+++ b/src/features/manager-reports/managerReportRange.ts
@@ -1,0 +1,46 @@
+export interface ManagerReportRange {
+  readonly dateFrom: string;
+  readonly dateTo: string;
+}
+
+export function managerReportRange(
+  branchTimezone: string,
+  days: number,
+  now = new Date(),
+): ManagerReportRange {
+  const dateTo = dateInTimeZone(now, branchTimezone);
+  const start = new Date(`${dateTo}T12:00:00.000Z`);
+  start.setUTCDate(start.getUTCDate() - Math.max(0, days - 1));
+  return {
+    dateFrom: start.toISOString().slice(0, 10),
+    dateTo,
+  };
+}
+
+export function assertManagerReportRange(range: ManagerReportRange): void {
+  if (!isDate(range.dateFrom) || !isDate(range.dateTo)) {
+    throw new Error('Report dates must use YYYY-MM-DD');
+  }
+  if (range.dateFrom > range.dateTo) throw new Error('Start date must not be after end date');
+  const days =
+    (Date.parse(`${range.dateTo}T00:00:00Z`) - Date.parse(`${range.dateFrom}T00:00:00Z`)) /
+    86_400_000;
+  if (days > 366) throw new Error('Report range cannot exceed 366 days');
+}
+
+function dateInTimeZone(date: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const value = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${value.year}-${value.month}-${value.day}`;
+}
+
+function isDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -106,7 +106,7 @@ function MainTabs() {
             component={AnalyticsScreen}
             name="Reports"
             options={{
-              headerTitle: t.salesAnalytics,
+              headerShown: false,
               title: t.reportsNav,
             }}
           />

--- a/src/screens/AnalyticsScreen.tsx
+++ b/src/screens/AnalyticsScreen.tsx
@@ -1,795 +1,699 @@
-import React, { useState, useMemo } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Dimensions, Alert } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Ionicons } from '@expo/vector-icons';
-import { LineChart, BarChart, PieChart } from 'react-native-chart-kit';
-import * as Print from 'expo-print';
-import * as Sharing from 'expo-sharing';
+import { useAuth } from '../contexts/AuthContext';
+import { accessibleBranches } from '../contexts/authTypes';
 import { useTheme } from '../contexts/ThemeContext';
+import { useOrderiaData } from '../data/runtime';
+import { UserId } from '../domain';
+import {
+  ServiceButton,
+  ServiceEmptyState,
+  ServiceSkeleton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+  useAdaptiveLayout,
+} from '../design-system';
+import {
+  DailyRevenueBars,
+  ManagerKpi,
+  ManagerKpiGrid,
+  ManagerReport,
+  ManagerReportRange,
+  WaiterPerformanceCard,
+  WaiterPerformanceRow,
+  assertManagerReportRange,
+  formatMinor,
+  managerReportRange,
+  presentManagerReportCsv,
+} from '../features/manager-reports';
 import { useLocalization } from '../i18n';
-import { useAnalytics, DateRange } from '../contexts/AnalyticsContext';
-import { useOrderStore, useMenuStore, useHistoryStore } from '../stores';
-import { SurfaceCard, PrimaryButton } from '../components';
-import { brand, radius, spacing } from '../constants/branding';
-
-type TimePeriod = 'today' | 'week' | 'month' | 'year' | 'custom';
-type ChartType = 'revenue' | 'orders' | 'items' | 'tables';
 
 export default function AnalyticsScreen() {
-  const { colors } = useTheme();
-  const { t, formatPrice } = useLocalization();
-  const { getAllOpenTickets, getTicketTotal } = useOrderStore();
-  const { menuItems } = useMenuStore();
-  const { dailyHistory, getHistoryDates } = useHistoryStore();
-  const {
-    getSalesAnalytics,
-    getTopSellingItems,
-    getPeakHours,
-    getTableTurnoverAnalysis,
-    getCategoryPerformance,
-    getDailySalesChart,
-    getRevenueGrowth,
-  } = useAnalytics();
+  const auth = useAuth();
+  const { tokens } = useTheme();
+  const { language } = useLocalization();
+  const layout = useAdaptiveLayout();
+  const { loadManagerReport, mode, sync } = useOrderiaData();
+  const copy = reportCopy(language);
+  const timezone = auth.activeBranch?.timezone ?? 'UTC';
+  const initialRange = useMemo(() => managerReportRange(timezone, 7), [timezone]);
+  const [range, setRange] = useState<ManagerReportRange>(initialRange);
+  const [rangeDraft, setRangeDraft] = useState<ManagerReportRange>(initialRange);
+  const [report, setReport] = useState<ManagerReport>();
+  const [waiterOptions, setWaiterOptions] = useState<readonly WaiterPerformanceRow[]>([]);
+  const [selectedWaiterId, setSelectedWaiterId] = useState<UserId>();
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const branchSwitchInFlight = useRef(false);
+  const isManager = auth.activeMembership?.role === 'manager' || auth.status === 'unconfigured';
+  const cloudReady = mode === 'cloud' && sync.online && isManager;
 
-  const [selectedPeriod, setSelectedPeriod] = useState<TimePeriod>('month');
-  const [selectedChart, setSelectedChart] = useState<ChartType>('revenue');
-  const [customDateRange, setCustomDateRange] = useState<DateRange | null>(null);
+  const branches = useMemo(
+    () =>
+      auth.workspace
+        ? accessibleBranches(auth.workspace).filter(
+            (branch) => branch.organization_id === auth.activeBranch?.organization_id,
+          )
+        : [],
+    [auth.activeBranch?.organization_id, auth.workspace],
+  );
 
-  const screenWidth = Dimensions.get('window').width;
-
-  // Get date range based on selected period
-  const getDateRange = (): DateRange | undefined => {
-    if (selectedPeriod === 'custom' && customDateRange) {
-      return customDateRange;
+  const load = useCallback(async () => {
+    if (branchSwitchInFlight.current) return;
+    if (!cloudReady) {
+      setLoading(false);
+      setRefreshing(false);
+      setErrorMessage(isManager ? copy.onlineRequired : copy.managerRequired);
+      return;
     }
-
-    const endDate = new Date();
-    const startDate = new Date();
-
-    switch (selectedPeriod) {
-      case 'today':
-        startDate.setHours(0, 0, 0, 0);
-        endDate.setHours(23, 59, 59, 999);
-        break;
-      case 'week':
-        startDate.setDate(endDate.getDate() - 7);
-        break;
-      case 'month':
-        startDate.setMonth(endDate.getMonth() - 1);
-        break;
-      case 'year':
-        startDate.setFullYear(endDate.getFullYear() - 1);
-        break;
-      default:
-        return undefined;
-    }
-
-    return { startDate, endDate };
-  };
-
-  const dateRange = getDateRange();
-  const analytics = useMemo(() => getSalesAnalytics(dateRange), [dateRange]);
-  const revenueGrowth = useMemo(() => getRevenueGrowth(dateRange), [dateRange]);
-  const topItems = useMemo(() => getTopSellingItems(5, dateRange), [dateRange]);
-  const peakHours = useMemo(() => getPeakHours(dateRange), [dateRange]);
-  const categoryPerformance = useMemo(() => getCategoryPerformance(dateRange), [dateRange]);
-
-  // Export analytics report to PDF
-  const handleExportReport = async () => {
+    setLoading(true);
     try {
-      // Get all tickets for the selected period
-      const allTickets = [];
-
-      // Add history tickets
-      const historyDates = getHistoryDates();
-      for (const dateKey of historyDates) {
-        const dayHistory = dailyHistory[dateKey];
-        if (dayHistory) {
-          allTickets.push(...dayHistory.tickets);
-        }
-      }
-
-      // Add open tickets
-      const openTickets = getAllOpenTickets();
-      allTickets.push(...openTickets);
-
-      // Filter by date range
-      const filteredTickets = dateRange
-        ? allTickets.filter((ticket) => {
-            const ticketDate = ticket.closedAt || ticket.createdAt;
-            return (
-              ticketDate >= dateRange.startDate.getTime() &&
-              ticketDate <= dateRange.endDate.getTime()
-            );
-          })
-        : allTickets;
-
-      // Calculate totals
-      let grandTotal = 0;
-      const orderDetails = filteredTickets.map((ticket) => {
-        const orderTotal = ticket.lines.reduce((sum, line) => {
-          return sum + line.priceSnapshot * line.quantity;
-        }, 0);
-        grandTotal += orderTotal;
-
-        return {
-          ticket,
-          orderTotal,
-          items: ticket.lines.map((line) => {
-            const menuItem = menuItems.find((item) => item.id === line.menuItemId);
-            return {
-              ...line,
-              menuItemName: menuItem?.name || line.nameSnapshot || 'Unknown Item',
-              itemTotal: line.priceSnapshot * line.quantity,
-            };
-          }),
-        };
-      });
-
-      const reportHtml = `
-        <!DOCTYPE html>
-        <html>
-        <head>
-          <meta charset="utf-8">
-          <title>Detailed Analytics Report</title>
-          <style>
-            body { 
-              font-family: Arial, sans-serif; 
-              padding: 20px; 
-              line-height: 1.4;
-              color: #333;
-            }
-            .header { 
-              text-align: center; 
-              margin-bottom: 30px; 
-              border-bottom: 3px solid #FF6B35;
-              padding-bottom: 20px;
-            }
-            .header h1 {
-              color: #FF6B35;
-              margin: 0 0 10px 0;
-              font-size: 28px;
-            }
-            .header p {
-              margin: 5px 0;
-              color: #FF6B35;
-            }
-            
-            .summary {
-              background: #f8f9fa;
-              padding: 20px;
-              border-radius: 8px;
-              margin-bottom: 30px;
-              border: 1px solid #e9ecef;
-            }
-            .summary h2 {
-              color: #FF6B35;
-              margin-top: 0;
-              border-bottom: 2px solid #FF6B35;
-              padding-bottom: 10px;
-            }
-            .summary-grid {
-              display: grid;
-              grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-              gap: 15px;
-              margin-top: 15px;
-            }
-            .summary-item {
-              text-align: center;
-              padding: 10px;
-              background: white;
-              border-radius: 6px;
-              border: 1px solid #ddd;
-            }
-            .summary-value {
-              font-size: 24px;
-              font-weight: bold;
-              color: #FF6B35;
-            }
-            .summary-label {
-              font-size: 12px;
-              color: #666;
-              text-transform: uppercase;
-              margin-top: 5px;
-            }
-            
-            .orders-section {
-              margin-top: 30px;
-            }
-            .orders-section h2 {
-              color: #333;
-              border-bottom: 2px solid #FF6B35;
-              padding-bottom: 10px;
-            }
-            
-            .order {
-              margin-bottom: 25px;
-              border: 1px solid #ddd;
-              border-radius: 8px;
-              overflow: hidden;
-            }
-            .order-header {
-              background: #f8f9fa;
-              padding: 15px;
-              border-bottom: 1px solid #ddd;
-              display: flex;
-              justify-content: space-between;
-              align-items: center;
-            }
-            .order-id {
-              font-weight: bold;
-              color: #333;
-            }
-            .order-date {
-              color: #666;
-              font-size: 14px;
-            }
-            .order-total {
-              font-weight: bold;
-              color: #FF6B35;
-              font-size: 18px;
-            }
-            
-            .items-table {
-              width: 100%;
-              border-collapse: collapse;
-            }
-            .items-table th {
-              background: #f8f9fa;
-              padding: 12px;
-              text-align: left;
-              border-bottom: 2px solid #ddd;
-              font-weight: bold;
-              color: #333;
-            }
-            .items-table td {
-              padding: 10px 12px;
-              border-bottom: 1px solid #eee;
-            }
-            .items-table tr:nth-child(even) {
-              background: #f9f9f9;
-            }
-            .items-table .qty {
-              text-align: center;
-              font-weight: bold;
-            }
-            .items-table .price {
-              text-align: right;
-              font-family: monospace;
-            }
-            .items-table .total {
-              text-align: right;
-              font-weight: bold;
-              color: #FF6B35;
-              font-family: monospace;
-            }
-            
-            .grand-total {
-              margin-top: 30px;
-              text-align: center;
-              font-size: 24px;
-              font-weight: bold;
-              color: #FF6B35;
-              background: #f8f9fa;
-              padding: 20px;
-              border: 2px solid #FF6B35;
-              border-radius: 8px;
-            }
-            
-            .footer {
-              margin-top: 40px;
-              text-align: center;
-              color: #666;
-              font-size: 12px;
-              border-top: 1px solid #ddd;
-              padding-top: 20px;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="header">
-            <h1>Detailed Analytics Report</h1>
-            <p><strong>Period:</strong> ${selectedPeriod.toUpperCase()}</p>
-            <p><strong>Generated:</strong> ${new Date().toLocaleDateString()} ${new Date().toLocaleTimeString()}</p>
-            ${dateRange ? `<p><strong>Date Range:</strong> ${dateRange.startDate.toLocaleDateString()} - ${dateRange.endDate.toLocaleDateString()}</p>` : ''}
-          </div>
-
-          <div class="summary">
-            <h2>Summary</h2>
-            <div class="summary-grid">
-              <div class="summary-item">
-                <div class="summary-value">${filteredTickets.length}</div>
-                <div class="summary-label">Total Orders</div>
-              </div>
-              <div class="summary-item">
-                <div class="summary-value">${formatPrice(grandTotal)}</div>
-                <div class="summary-label">Total Revenue</div>
-              </div>
-              <div class="summary-item">
-                <div class="summary-value">${filteredTickets.length > 0 ? formatPrice(Math.round(grandTotal / filteredTickets.length)) : '0'}</div>
-                <div class="summary-label">Average Order</div>
-              </div>
-              <div class="summary-item">
-                <div class="summary-value">${orderDetails.reduce((sum, order) => sum + order.items.length, 0)}</div>
-                <div class="summary-label">Total Items</div>
-              </div>
-            </div>
-          </div>
-
-          <div class="orders-section">
-            <h2>Order Details</h2>
-            ${orderDetails
-              .map(
-                (order, index) => `
-              <div class="order">
-                <div class="order-header">
-                  <div>
-                    <div class="order-id">Order #${index + 1} - ${order.ticket.id}</div>
-                    <div class="order-date">${new Date(order.ticket.createdAt).toLocaleDateString()} ${new Date(order.ticket.createdAt).toLocaleTimeString()}</div>
-                    ${order.ticket.name ? `<div style="color: #666; font-size: 14px;">Name: ${order.ticket.name}</div>` : ''}
-                  </div>
-                  <div class="order-total">${formatPrice(order.orderTotal)}</div>
-                </div>
-                
-                <table class="items-table">
-                  <thead>
-                    <tr>
-                      <th>Item</th>
-                      <th style="width: 80px;">Qty</th>
-                      <th style="width: 100px;">Unit Price</th>
-                      <th style="width: 100px;">Total</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${order.items
-                      .map(
-                        (item) => `
-                      <tr>
-                        <td>
-                          ${item.menuItemName}
-                          ${item.note ? `<div style="font-size: 12px; color: #666; font-style: italic;">Note: ${item.note}</div>` : ''}
-                        </td>
-                        <td class="qty">${item.quantity}</td>
-                        <td class="price">${formatPrice(item.priceSnapshot)}</td>
-                        <td class="total">${formatPrice(item.itemTotal)}</td>
-                      </tr>
-                    `,
-                      )
-                      .join('')}
-                  </tbody>
-                </table>
-              </div>
-            `,
-              )
-              .join('')}
-          </div>
-
-          <div class="grand-total">
-            GRAND TOTAL: ${formatPrice(grandTotal)}
-          </div>
-
-          <div class="footer">
-            <p>Generated by Orderia Analytics System</p>
-            <p>Report includes ${filteredTickets.length} orders with ${orderDetails.reduce((sum, order) => sum + order.items.length, 0)} total items</p>
-          </div>
-        </body>
-        </html>
-      `;
-
-      const { uri } = await Print.printToFileAsync({
-        html: reportHtml,
-        base64: false,
-        width: 612, // A4 width
-        height: 792, // A4 height
-        margins: {
-          left: 20,
-          top: 20,
-          right: 20,
-          bottom: 20,
-        },
-      });
-
-      if (await Sharing.isAvailableAsync()) {
-        const filename = `analytics-detailed-${selectedPeriod}-${new Date().toISOString().split('T')[0]}.pdf`;
-        await Sharing.shareAsync(uri, {
-          mimeType: 'application/pdf',
-          dialogTitle: 'Detailed Analytics Report',
-        });
-      }
-
-      Alert.alert(
-        t.success || 'Success',
-        `Detailed report exported successfully!\n\n${filteredTickets.length} orders\n${formatPrice(grandTotal)} total revenue`,
-        [{ text: t.ok || 'OK' }],
-      );
+      assertManagerReportRange(range);
+      const next = await loadManagerReport(range.dateFrom, range.dateTo, selectedWaiterId);
+      setReport(next);
+      if (!selectedWaiterId) setWaiterOptions(next.waiters);
+      setErrorMessage(undefined);
     } catch (error) {
-      console.error('Analytics export error:', error);
-      Alert.alert(
-        t.error || 'Error',
-        t.exportFailed || 'Failed to export analytics report. Please try again.',
-        [{ text: t.ok || 'OK' }],
-      );
+      setErrorMessage(error instanceof Error ? error.message : copy.loadFailed);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [
+    cloudReady,
+    copy.loadFailed,
+    copy.managerRequired,
+    copy.onlineRequired,
+    isManager,
+    loadManagerReport,
+    range,
+    selectedWaiterId,
+  ]);
+
+  useEffect(() => {
+    void load();
+  }, [auth.activeBranch?.id, load]);
+
+  const applyPreset = (days: number) => {
+    const next = managerReportRange(timezone, days);
+    setRangeDraft(next);
+    setRange(next);
+  };
+
+  const applyRange = () => {
+    try {
+      assertManagerReportRange(rangeDraft);
+      if (rangeDraft.dateFrom === range.dateFrom && rangeDraft.dateTo === range.dateTo) {
+        void load();
+      } else {
+        setRange(rangeDraft);
+      }
+    } catch (error) {
+      Alert.alert(copy.invalidRange, error instanceof Error ? error.message : copy.tryAgain);
     }
   };
 
-  const chartConfig = {
-    backgroundColor: colors.surface,
-    backgroundGradientFrom: colors.surface,
-    backgroundGradientTo: colors.surface,
-    decimalPlaces: 0,
-    color: (opacity = 1) => `rgba(255, 107, 53, ${opacity})`,
-    labelColor: (opacity = 1) => colors.text + Math.floor(opacity * 255).toString(16),
-    style: {
-      borderRadius: radius.md,
-    },
-    propsForDots: {
-      r: '4',
-      strokeWidth: '2',
-      stroke: colors.primary,
-    },
-  };
-
-  const renderPeriodSelector = () => (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      style={{ marginBottom: spacing.md }}
-    >
-      <View style={{ flexDirection: 'row', paddingHorizontal: spacing.md }}>
-        {[
-          { key: 'today', label: t.today || 'Today' },
-          { key: 'week', label: t.thisWeek || 'This Week' },
-          { key: 'month', label: t.thisMonth || 'This Month' },
-          { key: 'year', label: t.thisYear || 'This Year' },
-          { key: 'custom', label: t.custom || 'Custom' },
-        ].map((period) => (
-          <TouchableOpacity
-            key={period.key}
-            onPress={() => setSelectedPeriod(period.key as TimePeriod)}
-            style={{
-              paddingHorizontal: spacing.md,
-              paddingVertical: spacing.sm,
-              marginRight: spacing.sm,
-              borderRadius: radius.full,
-              backgroundColor: selectedPeriod === period.key ? colors.primary : colors.surfaceAlt,
-            }}
-          >
-            <Text
-              style={{
-                color: selectedPeriod === period.key ? colors.primaryContrast : colors.text,
-                fontWeight: selectedPeriod === period.key ? '600' : '400',
-                fontSize: 14,
-              }}
-            >
-              {period.label}
-            </Text>
-          </TouchableOpacity>
-        ))}
-      </View>
-    </ScrollView>
-  );
-
-  const renderKPICards = () => (
-    <View style={{ paddingHorizontal: spacing.md, marginBottom: spacing.md }}>
-      <View style={{ flexDirection: 'row', gap: spacing.sm }}>
-        <SurfaceCard variant="elevated" padding="medium" style={{ flex: 1 }}>
-          <View style={{ alignItems: 'center' }}>
-            <Ionicons name="cash-outline" size={24} color={colors.success} />
-            <Text
-              style={{ fontSize: 24, fontWeight: '700', color: colors.text, marginTop: spacing.xs }}
-            >
-              {formatPrice(analytics.totalRevenue)}
-            </Text>
-            <Text style={{ fontSize: 12, color: colors.textSubtle }}>
-              {t.totalRevenue || 'Total Revenue'}
-            </Text>
-            {revenueGrowth.growthPercentage !== 0 && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: spacing.xs }}>
-                <Ionicons
-                  name={revenueGrowth.growthPercentage > 0 ? 'trending-up' : 'trending-down'}
-                  size={14}
-                  color={revenueGrowth.growthPercentage > 0 ? colors.success : colors.error}
-                />
-                <Text
-                  style={{
-                    fontSize: 12,
-                    color: revenueGrowth.growthPercentage > 0 ? colors.success : colors.error,
-                    marginLeft: 2,
-                  }}
-                >
-                  {Math.abs(revenueGrowth.growthPercentage).toFixed(1)}%
-                </Text>
-              </View>
-            )}
-          </View>
-        </SurfaceCard>
-
-        <SurfaceCard variant="elevated" padding="medium" style={{ flex: 1 }}>
-          <View style={{ alignItems: 'center' }}>
-            <Ionicons name="receipt-outline" size={24} color={colors.info} />
-            <Text
-              style={{ fontSize: 24, fontWeight: '700', color: colors.text, marginTop: spacing.xs }}
-            >
-              {analytics.totalOrders}
-            </Text>
-            <Text style={{ fontSize: 12, color: colors.textSubtle }}>
-              {t.totalOrders || 'Total Orders'}
-            </Text>
-          </View>
-        </SurfaceCard>
-
-        <SurfaceCard variant="elevated" padding="medium" style={{ flex: 1 }}>
-          <View style={{ alignItems: 'center' }}>
-            <Ionicons name="calculator-outline" size={24} color={colors.warning} />
-            <Text
-              style={{ fontSize: 20, fontWeight: '700', color: colors.text, marginTop: spacing.xs }}
-            >
-              {formatPrice(analytics.averageOrderValue)}
-            </Text>
-            <Text style={{ fontSize: 12, color: colors.textSubtle, textAlign: 'center' }}>
-              {t.averageOrder || 'Avg Order'}
-            </Text>
-          </View>
-        </SurfaceCard>
-      </View>
-    </View>
-  );
-
-  const renderRevenueChart = () => {
-    const dailySales = getDailySalesChart(30);
-
-    if (dailySales.length === 0) {
-      return (
-        <View style={{ alignItems: 'center', padding: spacing.xl }}>
-          <Text style={{ color: colors.textSubtle }}>
-            {t.noDataAvailable || 'No data available'}
-          </Text>
-        </View>
-      );
+  const switchBranch = async (branchId: string) => {
+    if (branchId === auth.activeBranch?.id) return;
+    branchSwitchInFlight.current = true;
+    try {
+      setSelectedWaiterId(undefined);
+      setWaiterOptions([]);
+      await auth.switchBranch(branchId);
+      const nextBranch = branches.find((branch) => branch.id === branchId);
+      const nextRange = managerReportRange(nextBranch?.timezone ?? 'UTC', 7);
+      setRangeDraft(nextRange);
+      setRange(nextRange);
+    } catch (error) {
+      Alert.alert(copy.branchFailed, error instanceof Error ? error.message : copy.tryAgain);
+    } finally {
+      branchSwitchInFlight.current = false;
     }
-
-    const chartData = {
-      labels: dailySales.slice(-7).map((item) => {
-        const date = new Date(item.date);
-        return date.toLocaleDateString('en', { weekday: 'short' });
-      }),
-      datasets: [
-        {
-          data: dailySales.slice(-7).map((item) => item.revenue / 100),
-          color: (opacity = 1) => `rgba(255, 107, 53, ${opacity})`,
-          strokeWidth: 3,
-        },
-      ],
-    };
-
-    return (
-      <LineChart
-        data={chartData}
-        width={screenWidth - 32}
-        height={220}
-        chartConfig={chartConfig}
-        bezier
-        style={{
-          marginVertical: 8,
-          borderRadius: radius.md,
-        }}
-      />
-    );
   };
 
-  const renderTopItems = () => (
-    <SurfaceCard
-      variant="elevated"
-      padding="medium"
-      style={{ marginHorizontal: spacing.md, marginBottom: spacing.md }}
-    >
-      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: spacing.md }}>
-        <Ionicons name="trophy-outline" size={20} color={colors.warning} />
-        <Text
-          style={{ fontSize: 18, fontWeight: '600', color: colors.text, marginLeft: spacing.sm }}
-        >
-          {t.topSellingItems || 'Top Selling Items'}
-        </Text>
-      </View>
-
-      {topItems.length === 0 ? (
-        <Text style={{ color: colors.textSubtle, textAlign: 'center', padding: spacing.md }}>
-          {t.noItemsSold || 'No items sold in this period'}
-        </Text>
-      ) : (
-        topItems.map((item, index) => (
-          <View
-            key={item.item.id}
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              paddingVertical: spacing.sm,
-              borderBottomWidth: index < topItems.length - 1 ? 1 : 0,
-              borderBottomColor: colors.borderLight,
-            }}
-          >
-            <View style={{ flex: 1 }}>
-              <Text style={{ fontSize: 16, fontWeight: '500', color: colors.text }}>
-                {item.item.name}
-              </Text>
-              <Text style={{ fontSize: 14, color: colors.textSubtle }}>
-                {item.quantity} {t.sold || 'sold'}
-              </Text>
-            </View>
-            <Text style={{ fontSize: 16, fontWeight: '600', color: colors.primary }}>
-              {formatPrice(item.revenue)}
-            </Text>
-          </View>
-        ))
-      )}
-    </SurfaceCard>
-  );
-
-  const renderCategoryChart = () => {
-    if (categoryPerformance.length === 0) {
-      return (
-        <View style={{ alignItems: 'center', padding: spacing.xl }}>
-          <Text style={{ color: colors.textSubtle }}>
-            {t.noCategoryData || 'No category data available'}
-          </Text>
-        </View>
-      );
+  const exportReport = async () => {
+    if (!report) return;
+    setExporting(true);
+    try {
+      await presentManagerReportCsv(report);
+    } catch (error) {
+      Alert.alert(copy.exportFailed, error instanceof Error ? error.message : copy.tryAgain);
+    } finally {
+      setExporting(false);
     }
-
-    const pieData = categoryPerformance.slice(0, 5).map((category, index) => ({
-      name: category.categoryName,
-      population: category.revenue / 100,
-      color: [colors.primary, colors.secondary, colors.accent, colors.info, colors.success][
-        index % 5
-      ],
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    }));
-
-    return (
-      <PieChart
-        data={pieData}
-        width={screenWidth - 32}
-        height={220}
-        chartConfig={chartConfig}
-        accessor="population"
-        backgroundColor="transparent"
-        paddingLeft="15"
-        center={[10, 0]}
-      />
-    );
   };
 
-  const renderPeakHoursChart = () => {
-    const hourlyData = Array.from({ length: 24 }, (_, hour) => {
-      const hourData = peakHours.find((p) => p.hour === hour);
-      return hourData ? hourData.orders : 0;
-    });
-
-    const chartData = {
-      labels: ['6', '9', '12', '15', '18', '21', '24'],
-      datasets: [
-        {
-          data: [6, 9, 12, 15, 18, 21, 24].map((hour) => hourlyData[hour] || 0),
-        },
-      ],
-    };
-
-    return (
-      <BarChart
-        data={chartData}
-        width={screenWidth - 32}
-        height={220}
-        chartConfig={chartConfig}
-        yAxisLabel=""
-        yAxisSuffix=""
-        style={{
-          marginVertical: 8,
-          borderRadius: radius.md,
-        }}
-      />
-    );
-  };
+  const kpis = report ? managerKpis(report, language, copy) : [];
+  const selectedWaiterName = waiterOptions.find(
+    (waiter) => waiter.userId === selectedWaiterId,
+  )?.displayName;
 
   return (
     <SafeAreaView
-      style={{ flex: 1, backgroundColor: colors.bg }}
-      edges={['bottom', 'left', 'right']}
+      edges={['top', 'left', 'right']}
+      style={{ backgroundColor: tokens.colors.bg, flex: 1 }}
     >
-      <ScrollView style={{ flex: 1 }} showsVerticalScrollIndicator={false}>
-        {/* Period Selector */}
-        {renderPeriodSelector()}
-
-        {/* KPI Cards */}
-        {renderKPICards()}
-
-        {/* Chart Section */}
-        <SurfaceCard
-          variant="elevated"
-          padding="medium"
-          style={{ marginHorizontal: spacing.md, marginBottom: spacing.md }}
+      <ScrollView
+        contentContainerStyle={{
+          alignSelf: 'center',
+          gap: tokens.space.lg,
+          maxWidth: tokens.sizing.contentMaximumWidth,
+          paddingBottom: tokens.space.xxl,
+          paddingHorizontal: layout.horizontalPadding,
+          paddingTop: tokens.space.lg,
+          width: '100%',
+        }}
+        refreshControl={
+          <RefreshControl
+            onRefresh={() => {
+              setRefreshing(true);
+              void load();
+            }}
+            refreshing={refreshing}
+            tintColor={tokens.colors.primary}
+          />
+        }
+      >
+        <View
+          style={{
+            alignItems: 'flex-start',
+            flexDirection: layout.mode === 'compact' ? 'column' : 'row',
+            gap: tokens.space.sm,
+            justifyContent: 'space-between',
+          }}
         >
-          <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: spacing.md }}>
-            <Ionicons name="analytics-outline" size={20} color={colors.primary} />
+          <View style={{ flex: 1 }}>
+            <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+              {copy.title}
+            </Text>
             <Text
-              style={{
-                fontSize: 18,
-                fontWeight: '600',
-                color: colors.text,
-                marginLeft: spacing.sm,
-              }}
+              style={[
+                tokens.typography.body,
+                { color: tokens.colors.textSubtle, marginTop: tokens.space.xs },
+              ]}
             >
-              {t.salesChart || 'Sales Chart'}
+              {copy.subtitle}
             </Text>
           </View>
-
-          {/* Chart Type Selector */}
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            style={{ marginBottom: spacing.md }}
-          >
-            <View style={{ flexDirection: 'row' }}>
-              {[
-                { key: 'revenue', label: t.revenue || 'Revenue', icon: 'cash-outline' },
-                { key: 'orders', label: t.orders || 'Orders', icon: 'receipt-outline' },
-                { key: 'items', label: t.categories || 'Categories', icon: 'pie-chart-outline' },
-                { key: 'tables', label: t.peakHours || 'Peak Hours', icon: 'bar-chart-outline' },
-              ].map((chart) => (
-                <TouchableOpacity
-                  key={chart.key}
-                  onPress={() => setSelectedChart(chart.key as ChartType)}
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    paddingHorizontal: spacing.md,
-                    paddingVertical: spacing.sm,
-                    marginRight: spacing.sm,
-                    borderRadius: radius.md,
-                    backgroundColor:
-                      selectedChart === chart.key ? colors.primary : colors.surfaceAlt,
-                  }}
-                >
-                  <Ionicons
-                    name={chart.icon as any}
-                    size={16}
-                    color={selectedChart === chart.key ? colors.primaryContrast : colors.text}
-                  />
-                  <Text
-                    style={{
-                      color: selectedChart === chart.key ? colors.primaryContrast : colors.text,
-                      fontWeight: selectedChart === chart.key ? '600' : '400',
-                      fontSize: 14,
-                      marginLeft: spacing.xs,
-                    }}
-                  >
-                    {chart.label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-          </ScrollView>
-
-          {/* Chart Display */}
-          {selectedChart === 'revenue' && renderRevenueChart()}
-          {selectedChart === 'items' && renderCategoryChart()}
-          {selectedChart === 'tables' && renderPeakHoursChart()}
-        </SurfaceCard>
-
-        {/* Top Selling Items */}
-        {renderTopItems()}
-
-        {/* Export Button */}
-        <View style={{ paddingHorizontal: spacing.md, paddingBottom: spacing.lg }}>
-          <PrimaryButton
-            title={t.exportReport || 'Export Report'}
-            icon="download-outline"
-            onPress={handleExportReport}
-            fullWidth
+          <ServiceStatusPill
+            icon={cloudReady ? 'shield-checkmark-outline' : 'cloud-offline-outline'}
+            label={cloudReady ? copy.serverConfirmed : copy.unavailable}
+            tone={cloudReady ? 'success' : 'warning'}
           />
         </View>
+
+        {branches.length > 1 ? (
+          <View>
+            <Text
+              style={[
+                tokens.typography.label,
+                { color: tokens.colors.text, marginBottom: tokens.space.xs },
+              ]}
+            >
+              {copy.branch}
+            </Text>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+              {branches.map((branch) => (
+                <ReportChip
+                  key={branch.id}
+                  active={branch.id === auth.activeBranch?.id}
+                  label={branch.name}
+                  onPress={() => void switchBranch(branch.id)}
+                />
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        <ServiceSurface style={{ gap: tokens.space.md }} variant="outlined">
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+            <ReportChip label={copy.today} onPress={() => applyPreset(1)} />
+            <ReportChip label={copy.sevenDays} onPress={() => applyPreset(7)} />
+            <ReportChip label={copy.thirtyDays} onPress={() => applyPreset(30)} />
+          </View>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+            <ServiceTextField
+              autoCapitalize="none"
+              containerStyle={{ flexBasis: 190, flexGrow: 1 }}
+              label={copy.dateFrom}
+              onChangeText={(dateFrom) => setRangeDraft((current) => ({ ...current, dateFrom }))}
+              placeholder="YYYY-MM-DD"
+              value={rangeDraft.dateFrom}
+            />
+            <ServiceTextField
+              autoCapitalize="none"
+              containerStyle={{ flexBasis: 190, flexGrow: 1 }}
+              label={copy.dateTo}
+              onChangeText={(dateTo) => setRangeDraft((current) => ({ ...current, dateTo }))}
+              placeholder="YYYY-MM-DD"
+              value={rangeDraft.dateTo}
+            />
+            <ServiceButton
+              icon="refresh-outline"
+              label={copy.apply}
+              onPress={applyRange}
+              style={{ alignSelf: 'flex-end' }}
+            />
+          </View>
+        </ServiceSurface>
+
+        {waiterOptions.length > 0 ? (
+          <View>
+            <Text
+              style={[
+                tokens.typography.label,
+                { color: tokens.colors.text, marginBottom: tokens.space.xs },
+              ]}
+            >
+              {copy.waiterFilter}
+            </Text>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+              <ReportChip
+                active={!selectedWaiterId}
+                label={copy.allWaiters}
+                onPress={() => setSelectedWaiterId(undefined)}
+              />
+              {waiterOptions.map((waiter) => (
+                <ReportChip
+                  key={waiter.userId}
+                  active={waiter.userId === selectedWaiterId}
+                  label={waiter.displayName}
+                  onPress={() => setSelectedWaiterId(waiter.userId)}
+                />
+              ))}
+            </View>
+          </View>
+        ) : null}
+
+        {errorMessage ? (
+          <ServiceEmptyState
+            action={{ label: copy.retry, onPress: () => void load() }}
+            body={errorMessage}
+            icon="analytics-outline"
+            title={copy.unavailable}
+          />
+        ) : loading && !report ? (
+          <View style={{ gap: tokens.space.sm }}>
+            <ServiceSkeleton height={128} label={copy.loading} />
+            <ServiceSkeleton height={220} label={copy.loading} />
+            <ServiceSkeleton height={220} label={copy.loading} />
+          </View>
+        ) : report ? (
+          <>
+            <View
+              style={{
+                alignItems: 'center',
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                gap: tokens.space.sm,
+                justifyContent: 'space-between',
+              }}
+            >
+              <View>
+                <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                  {selectedWaiterName
+                    ? `${selectedWaiterName} · ${copy.contributionView}`
+                    : copy.branchOverview}
+                </Text>
+                <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>
+                  {report.dateFrom} → {report.dateTo} · {report.branchName}
+                </Text>
+              </View>
+              <ServiceButton
+                icon="download-outline"
+                label={copy.exportCsv}
+                loading={exporting}
+                onPress={() => void exportReport()}
+                variant="outline"
+              />
+            </View>
+
+            <ManagerKpiGrid items={kpis} />
+
+            <ServiceSurface style={{ gap: tokens.space.md }} variant="outlined">
+              <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                {selectedWaiterName ? copy.dailyContribution : copy.dailyRevenue}
+              </Text>
+              <DailyRevenueBars
+                currencyCode={report.currencyCode}
+                days={report.daily}
+                language={language}
+                selectedWaiter={Boolean(selectedWaiterId)}
+              />
+            </ServiceSurface>
+
+            <View style={{ gap: tokens.space.sm }}>
+              <View>
+                <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                  {copy.waiterContributions}
+                </Text>
+                <Text style={[tokens.typography.caption, { color: tokens.colors.textMuted }]}>
+                  {copy.notLeaderboard}
+                </Text>
+              </View>
+              {report.waiters.map((waiter) => (
+                <WaiterPerformanceCard
+                  key={waiter.userId}
+                  currencyCode={report.currencyCode}
+                  language={language}
+                  waiter={waiter}
+                />
+              ))}
+            </View>
+
+            <ServiceSurface style={{ gap: tokens.space.md }} variant="outlined">
+              <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                {copy.cancellationContext}
+              </Text>
+              {report.cancellations.length === 0 ? (
+                <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                  {copy.noCancellations}
+                </Text>
+              ) : (
+                report.cancellations.map((cancellation) => (
+                  <View
+                    key={cancellation.orderItemId}
+                    style={{
+                      borderBottomColor: tokens.colors.borderLight,
+                      borderBottomWidth: 1,
+                      gap: tokens.space.xxs,
+                      paddingBottom: tokens.space.sm,
+                    }}
+                  >
+                    <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+                      <Text
+                        style={[
+                          tokens.typography.bodyStrong,
+                          { color: tokens.colors.text, flex: 1 },
+                        ]}
+                      >
+                        {cancellation.tableLabel} · {cancellation.itemName}
+                      </Text>
+                      <Text style={[tokens.typography.label, { color: tokens.colors.warning }]}>
+                        {formatMinor(
+                          cancellation.excludedAmountMinor,
+                          report.currencyCode,
+                          language,
+                        )}
+                      </Text>
+                    </View>
+                    <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                      {cancellation.reasonName} · {cancellation.cancelledByDisplayName}
+                    </Text>
+                  </View>
+                ))
+              )}
+            </ServiceSurface>
+
+            <ServiceSurface style={{ gap: tokens.space.xs }} variant="outlined">
+              <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                {copy.definitions}
+              </Text>
+              <Definition label={copy.revenueDefinition} />
+              <Definition label={copy.contributionDefinition} />
+              <Definition label={copy.paymentDefinition} />
+              <Definition label={copy.activeTimeDefinition} />
+            </ServiceSurface>
+          </>
+        ) : null}
       </ScrollView>
     </SafeAreaView>
   );
+}
+
+function ReportChip({
+  active = false,
+  label,
+  onPress,
+}: {
+  readonly active?: boolean;
+  readonly label: string;
+  readonly onPress: () => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole={active ? 'radio' : 'button'}
+      accessibilityState={active ? { checked: true } : undefined}
+      onPress={onPress}
+      style={({ pressed }) => ({
+        alignItems: 'center',
+        backgroundColor: active ? tokens.colors.surfaceAlt : tokens.colors.surface,
+        borderColor: active ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.full,
+        borderWidth: active ? 2 : 1,
+        justifyContent: 'center',
+        minHeight: tokens.sizing.minimumTarget,
+        opacity: pressed ? 0.78 : 1,
+        paddingHorizontal: tokens.space.md,
+      })}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: active ? tokens.colors.primary : tokens.colors.textSubtle },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function Definition({ label }: { readonly label: string }) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ flexDirection: 'row' }}>
+      <Text style={[tokens.typography.body, { color: tokens.colors.primary }]}>• </Text>
+      <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle, flex: 1 }]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function managerKpis(
+  report: ManagerReport,
+  language: 'tr' | 'bg' | 'en',
+  copy: ReturnType<typeof reportCopy>,
+): readonly ManagerKpi[] {
+  const summary = report.summary;
+  const selected = report.selectedWaiterId !== undefined;
+  return [
+    {
+      label: selected ? copy.waiterContribution : copy.confirmedRevenue,
+      value: formatMinor(
+        selected ? (summary.selectedWaiterContributionMinor ?? 0) : summary.confirmedRevenueMinor,
+        report.currencyCode,
+        language,
+      ),
+      helper: selected ? copy.itemAttribution : copy.confirmedOnly,
+      icon: 'cash-outline',
+      tone: 'primary',
+    },
+    {
+      label: copy.receipts,
+      value: `${summary.receiptCount}`,
+      helper: `${summary.confirmedPaymentCount} ${copy.paymentsShort}`,
+      icon: 'receipt-outline',
+    },
+    {
+      label: copy.openTables,
+      value: `${summary.currentOpenTableCount}`,
+      helper: `${summary.currentPaymentPendingCount} ${copy.paymentPending}`,
+      icon: 'restaurant-outline',
+      tone: summary.currentPaymentPendingCount > 0 ? 'warning' : 'neutral',
+    },
+    {
+      label: copy.openBalance,
+      value: formatMinor(summary.currentOpenBalanceMinor, report.currencyCode, language),
+      helper: `${summary.activeWaiterCount} ${copy.activeWaiters}`,
+      icon: 'time-outline',
+      tone: 'warning',
+    },
+    {
+      label: copy.averageReceipt,
+      value: formatMinor(summary.averageReceiptMinor, report.currencyCode, language),
+      helper: `${summary.servedTableCount} ${copy.servedTables}`,
+      icon: 'analytics-outline',
+    },
+    {
+      label: copy.cancellations,
+      value: `${summary.cancelledItemCount}`,
+      helper: formatMinor(summary.cancelledValueMinor, report.currencyCode, language),
+      icon: 'close-circle-outline',
+      tone: summary.cancelledItemCount > 0 ? 'warning' : 'neutral',
+    },
+  ];
+}
+
+function reportCopy(language: 'tr' | 'bg' | 'en') {
+  if (language === 'tr') {
+    return {
+      title: 'Yönetici raporu',
+      subtitle: 'Canlı operasyonu ve garson katkısını doğrulanmış server kayıtlarıyla izle.',
+      serverConfirmed: 'Server doğrulamalı',
+      unavailable: 'Rapor kullanılamıyor',
+      onlineRequired: 'Yönetici raporu için internet bağlantısı gerekli.',
+      managerRequired: 'Bu rapor yalnız yöneticiler tarafından görüntülenebilir.',
+      loadFailed: 'Yönetici raporu yüklenemedi.',
+      branch: 'Şube',
+      today: 'Bugün',
+      sevenDays: '7 gün',
+      thirtyDays: '30 gün',
+      dateFrom: 'Başlangıç',
+      dateTo: 'Bitiş',
+      apply: 'Uygula',
+      waiterFilter: 'Garson filtresi',
+      allWaiters: 'Tüm garsonlar',
+      invalidRange: 'Tarih aralığını kontrol et',
+      tryAgain: 'Tekrar deneyin.',
+      branchFailed: 'Şube değiştirilemedi',
+      exportFailed: 'Rapor dışa aktarılamadı',
+      retry: 'Tekrar dene',
+      loading: 'Rapor yükleniyor',
+      contributionView: 'katkı görünümü',
+      branchOverview: 'Şube özeti',
+      exportCsv: 'CSV indir',
+      dailyContribution: 'Günlük garson katkısı',
+      dailyRevenue: 'Günlük doğrulanmış ciro',
+      waiterContributions: 'Garson katkıları',
+      notLeaderboard: 'Bu liste puan tablosu değildir; satır ve ödeme kaynaklarını açıklar.',
+      cancellationContext: 'İptal bağlamı',
+      noCancellations: 'Seçili dönemde iptal işlemi yok.',
+      definitions: 'Metrik tanımları',
+      revenueDefinition:
+        'Ciro yalnız issued fişlere bağlı confirmed payment allocation toplamıdır.',
+      contributionDefinition:
+        'Garson katkısı, iptal edilmemiş ürün satırının created_by alanına göre hesaplanır.',
+      paymentDefinition:
+        'Alınan ödeme ayrıca payment.created_by üzerinden gösterilir; masa tek garsona yazılmaz.',
+      activeTimeDefinition:
+        'Gözlenen süre bordro vardiyası değil, ilk ve son kayıtlı aksiyon arasındaki süredir.',
+      waiterContribution: 'Garson ciro katkısı',
+      confirmedRevenue: 'Doğrulanmış ciro',
+      itemAttribution: 'Ürün satırı created_by',
+      confirmedOnly: 'Yalnız confirmed ödemeler',
+      receipts: 'Kapanan fiş',
+      paymentsShort: 'ödeme',
+      openTables: 'Açık masa',
+      paymentPending: 'ödeme bekliyor',
+      openBalance: 'Açık bakiye',
+      activeWaiters: 'aktif garson',
+      averageReceipt: 'Ortalama fiş',
+      servedTables: 'servis verilen masa',
+      cancellations: 'İptal',
+    };
+  }
+  if (language === 'bg') {
+    return {
+      title: 'Управленски отчет',
+      subtitle: 'Следете операцията и приноса чрез потвърдени сървърни данни.',
+      serverConfirmed: 'Потвърдено от сървъра',
+      unavailable: 'Отчетът не е достъпен',
+      onlineRequired: 'За управленския отчет е необходим интернет.',
+      managerRequired: 'Този отчет е само за мениджъри.',
+      loadFailed: 'Отчетът не можа да се зареди.',
+      branch: 'Обект',
+      today: 'Днес',
+      sevenDays: '7 дни',
+      thirtyDays: '30 дни',
+      dateFrom: 'Начало',
+      dateTo: 'Край',
+      apply: 'Приложи',
+      waiterFilter: 'Филтър по сервитьор',
+      allWaiters: 'Всички сервитьори',
+      invalidRange: 'Проверете периода',
+      tryAgain: 'Опитайте отново.',
+      branchFailed: 'Обектът не можа да се смени',
+      exportFailed: 'Отчетът не можа да се експортира',
+      retry: 'Опитай отново',
+      loading: 'Зареждане на отчет',
+      contributionView: 'изглед на приноса',
+      branchOverview: 'Обобщение за обекта',
+      exportCsv: 'Изтегли CSV',
+      dailyContribution: 'Дневен принос',
+      dailyRevenue: 'Дневен потвърден оборот',
+      waiterContributions: 'Принос на сервитьорите',
+      notLeaderboard: 'Това не е класация; показва произхода на редовете и плащанията.',
+      cancellationContext: 'Контекст на анулиранията',
+      noCancellations: 'Няма анулирания за периода.',
+      definitions: 'Дефиниции',
+      revenueDefinition: 'Оборотът е сборът от потвърдени разпределения към издадени разписки.',
+      contributionDefinition: 'Приносът е по created_by на неанулираните редове.',
+      paymentDefinition:
+        'Плащанията са отделно по payment.created_by; масата няма един собственик.',
+      activeTimeDefinition:
+        'Наблюдаваното време е между първото и последното действие, не работна смяна.',
+      waiterContribution: 'Принос към оборота',
+      confirmedRevenue: 'Потвърден оборот',
+      itemAttribution: 'created_by на реда',
+      confirmedOnly: 'Само потвърдени плащания',
+      receipts: 'Разписки',
+      paymentsShort: 'плащания',
+      openTables: 'Отворени маси',
+      paymentPending: 'чакат плащане',
+      openBalance: 'Отворен баланс',
+      activeWaiters: 'активни сервитьори',
+      averageReceipt: 'Средна разписка',
+      servedTables: 'обслужени маси',
+      cancellations: 'Анулирания',
+    };
+  }
+  return {
+    title: 'Manager report',
+    subtitle: 'Track live operations and waiter contribution from server-confirmed records.',
+    serverConfirmed: 'Server confirmed',
+    unavailable: 'Report unavailable',
+    onlineRequired: 'An internet connection is required for manager reporting.',
+    managerRequired: 'This report is available to managers only.',
+    loadFailed: 'The manager report could not be loaded.',
+    branch: 'Branch',
+    today: 'Today',
+    sevenDays: '7 days',
+    thirtyDays: '30 days',
+    dateFrom: 'Start',
+    dateTo: 'End',
+    apply: 'Apply',
+    waiterFilter: 'Waiter filter',
+    allWaiters: 'All waiters',
+    invalidRange: 'Check the date range',
+    tryAgain: 'Try again.',
+    branchFailed: 'Branch could not be changed',
+    exportFailed: 'Report could not be exported',
+    retry: 'Try again',
+    loading: 'Loading report',
+    contributionView: 'contribution view',
+    branchOverview: 'Branch overview',
+    exportCsv: 'Download CSV',
+    dailyContribution: 'Daily waiter contribution',
+    dailyRevenue: 'Daily confirmed revenue',
+    waiterContributions: 'Waiter contributions',
+    notLeaderboard: 'This is not a leaderboard; it explains item and payment attribution.',
+    cancellationContext: 'Cancellation context',
+    noCancellations: 'No cancellation actions in this period.',
+    definitions: 'Metric definitions',
+    revenueDefinition: 'Revenue is confirmed payment allocations linked to issued receipts.',
+    contributionDefinition: 'Waiter contribution follows created_by on non-cancelled item rows.',
+    paymentDefinition:
+      'Payments handled follow payment.created_by; a table is not assigned to one owner.',
+    activeTimeDefinition: 'Observed time spans first to last action and is not a payroll shift.',
+    waiterContribution: 'Waiter revenue contribution',
+    confirmedRevenue: 'Confirmed revenue',
+    itemAttribution: 'Item row created_by',
+    confirmedOnly: 'Confirmed payments only',
+    receipts: 'Closed receipts',
+    paymentsShort: 'payments',
+    openTables: 'Open tables',
+    paymentPending: 'awaiting payment',
+    openBalance: 'Open balance',
+    activeWaiters: 'active waiters',
+    averageReceipt: 'Average receipt',
+    servedTables: 'tables served',
+    cancellations: 'Cancellations',
+  };
 }

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -210,6 +210,16 @@ export type Database = {
         };
         Returns: Json;
       };
+      get_manager_report: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_date_from: string;
+          requested_date_to: string;
+          requested_waiter_id?: string | null;
+        };
+        Returns: Json;
+      };
       list_active_session_participants: {
         Args: {
           requested_organization_id: string;

--- a/supabase/migrations/20260727014000_manager_reports.sql
+++ b/supabase/migrations/20260727014000_manager_reports.sql
@@ -1,0 +1,510 @@
+-- Auditable manager reporting from immutable receipts and confirmed ledgers.
+
+create index payments_branch_status_confirmed_idx
+  on public.payments (branch_id, status, confirmed_at desc, created_by);
+create index order_items_branch_creator_created_idx
+  on public.order_items (branch_id, created_by, created_at desc);
+create index order_items_branch_cancellation_idx
+  on public.order_items (branch_id, cancelled_at desc, cancelled_by)
+  where status = 'cancelled';
+create index session_participants_branch_activity_idx
+  on public.session_participants (branch_id, last_action_at desc, user_id);
+
+create or replace function public.get_manager_report(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_date_from date,
+  requested_date_to date,
+  requested_waiter_id uuid default null
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+declare
+  branch_row public.branches;
+  report_json jsonb;
+begin
+  if (select auth.uid()) is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  if requested_date_from is null
+    or requested_date_to is null
+    or requested_date_from > requested_date_to
+    or requested_date_to - requested_date_from > 366 then
+    raise exception using errcode = '22023', message = 'invalid_report_date_range';
+  end if;
+
+  select branch.*
+  into branch_row
+  from public.branches as branch
+  where branch.organization_id = requested_organization_id
+    and branch.id = requested_branch_id
+    and branch.deleted_at is null;
+  if branch_row.id is null then
+    raise exception using errcode = '22023', message = 'report_branch_not_found';
+  end if;
+
+  with
+  period_receipts as (
+    select receipt.*
+    from public.receipts as receipt
+    where receipt.organization_id = requested_organization_id
+      and receipt.branch_id = requested_branch_id
+      and receipt.business_date between requested_date_from and requested_date_to
+      and receipt.status = 'issued'
+  ),
+  item_lines as (
+    select
+      receipt.id as receipt_id,
+      receipt.business_date,
+      item.id as order_item_id,
+      item.table_session_id,
+      item.created_by,
+      item.created_at,
+      item.quantity,
+      (
+        (
+          item.unit_price_minor
+          + coalesce(modifier_total.amount_minor, 0)
+        ) * item.quantity
+      )::bigint as amount_minor
+    from period_receipts as receipt
+    join public.order_items as item
+      on item.organization_id = receipt.organization_id
+     and item.branch_id = receipt.branch_id
+     and item.check_id = receipt.check_id
+     and item.status <> 'cancelled'
+     and item.deleted_at is null
+    left join lateral (
+      select sum(modifier.price_delta_minor * modifier.quantity) as amount_minor
+      from public.order_item_modifiers as modifier
+      where modifier.organization_id = item.organization_id
+        and modifier.branch_id = item.branch_id
+        and modifier.order_item_id = item.id
+    ) as modifier_total on true
+  ),
+  period_allocations as (
+    select
+      receipt.business_date,
+      allocation.payment_id,
+      allocation.check_id,
+      allocation.amount_minor,
+      payment.created_by,
+      payment.confirmed_at,
+      payment.table_session_id
+    from period_receipts as receipt
+    join public.payment_allocations as allocation
+      on allocation.organization_id = receipt.organization_id
+     and allocation.branch_id = receipt.branch_id
+     and allocation.check_id = receipt.check_id
+    join public.payments as payment
+      on payment.organization_id = allocation.organization_id
+     and payment.branch_id = allocation.branch_id
+     and payment.id = allocation.payment_id
+     and payment.status = 'confirmed'
+  ),
+  payment_totals as (
+    select
+      allocation.payment_id,
+      min(allocation.business_date) as business_date,
+      allocation.created_by,
+      allocation.confirmed_at,
+      allocation.table_session_id,
+      sum(allocation.amount_minor)::bigint as amount_minor
+    from period_allocations as allocation
+    group by
+      allocation.payment_id,
+      allocation.created_by,
+      allocation.confirmed_at,
+      allocation.table_session_id
+  ),
+  cancellations as (
+    select
+      item.id as order_item_id,
+      item.table_session_id,
+      item.name_snapshot,
+      item.created_by,
+      creator.display_name as created_by_display_name,
+      item.cancelled_by,
+      canceller.display_name as cancelled_by_display_name,
+      item.cancelled_at,
+      reason.name as reason_name,
+      restaurant_table.label as table_label,
+      (
+        (
+          item.unit_price_minor
+          + coalesce(modifier_total.amount_minor, 0)
+        ) * item.quantity
+      )::bigint as amount_minor,
+      (
+        timezone(branch_row.timezone, item.cancelled_at)
+        - (branch_row.business_day_cutoff - time '00:00')
+      )::date as business_date
+    from public.order_items as item
+    join public.profiles as creator on creator.id = item.created_by
+    join public.profiles as canceller on canceller.id = item.cancelled_by
+    join public.cancellation_reasons as reason
+      on reason.organization_id = item.organization_id
+     and reason.branch_id = item.branch_id
+     and reason.id = item.cancellation_reason_id
+    join public.restaurant_tables as restaurant_table
+      on restaurant_table.organization_id = item.organization_id
+     and restaurant_table.branch_id = item.branch_id
+     and restaurant_table.id = item.original_table_id
+    left join lateral (
+      select sum(modifier.price_delta_minor * modifier.quantity) as amount_minor
+      from public.order_item_modifiers as modifier
+      where modifier.organization_id = item.organization_id
+        and modifier.branch_id = item.branch_id
+        and modifier.order_item_id = item.id
+    ) as modifier_total on true
+    where item.organization_id = requested_organization_id
+      and item.branch_id = requested_branch_id
+      and item.status = 'cancelled'
+      and item.cancelled_at is not null
+      and item.deleted_at is null
+      and (
+        timezone(branch_row.timezone, item.cancelled_at)
+        - (branch_row.business_day_cutoff - time '00:00')
+      )::date between requested_date_from and requested_date_to
+  ),
+  contributors as (
+    select item.created_by as user_id from item_lines as item
+    union
+    select payment.created_by as user_id from payment_totals as payment
+    union
+    select cancellation.cancelled_by as user_id from cancellations as cancellation
+  ),
+  waiter_stats as (
+    select
+      contributor.user_id,
+      profile.display_name,
+      (
+        select count(*)
+        from item_lines as item
+        where item.created_by = contributor.user_id
+      )::bigint as item_rows,
+      coalesce((
+        select sum(item.quantity)
+        from item_lines as item
+        where item.created_by = contributor.user_id
+      ), 0) as item_quantity,
+      coalesce((
+        select sum(item.amount_minor)
+        from item_lines as item
+        where item.created_by = contributor.user_id
+      ), 0)::bigint as contributed_revenue_minor,
+      coalesce((
+        select sum(payment.amount_minor)
+        from payment_totals as payment
+        where payment.created_by = contributor.user_id
+      ), 0)::bigint as payment_handled_minor,
+      (
+        select count(*)
+        from payment_totals as payment
+        where payment.created_by = contributor.user_id
+      )::bigint as payment_count,
+      (
+        select count(distinct served.table_session_id)
+        from (
+          select item.table_session_id
+          from item_lines as item
+          where item.created_by = contributor.user_id
+          union all
+          select payment.table_session_id
+          from payment_totals as payment
+          where payment.created_by = contributor.user_id
+        ) as served
+      )::bigint as tables_served,
+      (
+        select count(*)
+        from cancellations as cancellation
+        where cancellation.cancelled_by = contributor.user_id
+      )::bigint as cancellation_count,
+      coalesce((
+        select sum(cancellation.amount_minor)
+        from cancellations as cancellation
+        where cancellation.cancelled_by = contributor.user_id
+      ), 0)::bigint as cancellation_value_minor,
+      (
+        select count(distinct item.table_session_id)
+        from item_lines as item
+        join public.table_sessions as session
+          on session.organization_id = requested_organization_id
+         and session.branch_id = requested_branch_id
+         and session.id = item.table_session_id
+        where item.created_by = contributor.user_id
+          and session.opened_by <> contributor.user_id
+      )::bigint as helped_table_count,
+      activity.first_action_at,
+      activity.last_action_at,
+      coalesce(
+        ceil(
+          extract(epoch from activity.last_action_at - activity.first_action_at)
+          / 60
+        ),
+        0
+      )::integer as observed_active_minutes
+    from contributors as contributor
+    join public.profiles as profile on profile.id = contributor.user_id
+    left join lateral (
+      select
+        min(action.occurred_at) as first_action_at,
+        max(action.occurred_at) as last_action_at
+      from (
+        select item.created_at as occurred_at
+        from item_lines as item
+        where item.created_by = contributor.user_id
+        union all
+        select payment.confirmed_at
+        from payment_totals as payment
+        where payment.created_by = contributor.user_id
+        union all
+        select cancellation.cancelled_at
+        from cancellations as cancellation
+        where cancellation.cancelled_by = contributor.user_id
+      ) as action
+    ) as activity on true
+    where requested_waiter_id is null
+      or contributor.user_id = requested_waiter_id
+  ),
+  report_days as (
+    select generate_series(
+      requested_date_from::timestamp,
+      requested_date_to::timestamp,
+      interval '1 day'
+    )::date as business_date
+  ),
+  daily_stats as (
+    select
+      day.business_date,
+      coalesce((
+        select sum(allocation.amount_minor)
+        from period_allocations as allocation
+        where allocation.business_date = day.business_date
+      ), 0)::bigint as confirmed_revenue_minor,
+      (
+        select count(*)
+        from period_receipts as receipt
+        where receipt.business_date = day.business_date
+      )::bigint as receipt_count,
+      (
+        select count(*)
+        from cancellations as cancellation
+        where cancellation.business_date = day.business_date
+      )::bigint as cancellation_count,
+      case
+        when requested_waiter_id is null then null
+        else coalesce((
+          select sum(item.amount_minor)
+          from item_lines as item
+          where item.business_date = day.business_date
+            and item.created_by = requested_waiter_id
+        ), 0)::bigint
+      end as selected_waiter_contribution_minor
+    from report_days as day
+  ),
+  active_check_balances as (
+    select
+      check_row.id,
+      check_row.table_session_id,
+      greatest(
+        coalesce((
+          select sum(
+            (
+              item.unit_price_minor
+              + coalesce((
+                select sum(modifier.price_delta_minor * modifier.quantity)
+                from public.order_item_modifiers as modifier
+                where modifier.organization_id = item.organization_id
+                  and modifier.branch_id = item.branch_id
+                  and modifier.order_item_id = item.id
+              ), 0)
+            ) * item.quantity
+          )
+          from public.order_items as item
+          where item.organization_id = check_row.organization_id
+            and item.branch_id = check_row.branch_id
+            and item.check_id = check_row.id
+            and item.status <> 'cancelled'
+            and item.deleted_at is null
+        ), 0)
+        - coalesce((
+          select sum(allocation.amount_minor)
+          from public.payment_allocations as allocation
+          join public.payments as payment
+            on payment.organization_id = allocation.organization_id
+           and payment.branch_id = allocation.branch_id
+           and payment.id = allocation.payment_id
+           and payment.status = 'confirmed'
+          where allocation.organization_id = check_row.organization_id
+            and allocation.branch_id = check_row.branch_id
+            and allocation.check_id = check_row.id
+        ), 0),
+        0
+      )::bigint as remaining_minor
+    from public.checks as check_row
+    where check_row.organization_id = requested_organization_id
+      and check_row.branch_id = requested_branch_id
+      and check_row.status in ('open', 'partially_paid')
+      and check_row.deleted_at is null
+  )
+  select jsonb_build_object(
+    'generatedAt', now(),
+    'organizationId', requested_organization_id,
+    'branchId', requested_branch_id,
+    'branchName', branch_row.name,
+    'currencyCode', branch_row.currency_code,
+    'dateFrom', requested_date_from,
+    'dateTo', requested_date_to,
+    'selectedWaiterId', requested_waiter_id,
+    'summary', jsonb_build_object(
+      'confirmedRevenueMinor', coalesce((
+        select sum(allocation.amount_minor) from period_allocations as allocation
+      ), 0)::bigint,
+      'receiptCount', (select count(*) from period_receipts),
+      'confirmedPaymentCount', (select count(*) from payment_totals),
+      'servedTableCount', (
+        select count(distinct receipt.table_session_id) from period_receipts as receipt
+      ),
+      'averageReceiptMinor', coalesce((
+        select round(avg(receipt.total_minor)) from period_receipts as receipt
+      ), 0)::bigint,
+      'cancelledItemCount', (select count(*) from cancellations),
+      'cancelledValueMinor', coalesce((
+        select sum(cancellation.amount_minor) from cancellations as cancellation
+      ), 0)::bigint,
+      'selectedWaiterContributionMinor', case
+        when requested_waiter_id is null then null
+        else coalesce((
+          select sum(item.amount_minor)
+          from item_lines as item
+          where item.created_by = requested_waiter_id
+        ), 0)::bigint
+      end,
+      'selectedWaiterPaymentHandledMinor', case
+        when requested_waiter_id is null then null
+        else coalesce((
+          select sum(payment.amount_minor)
+          from payment_totals as payment
+          where payment.created_by = requested_waiter_id
+        ), 0)::bigint
+      end,
+      'currentOpenTableCount', (
+        select count(distinct session.table_id)
+        from public.table_sessions as session
+        where session.organization_id = requested_organization_id
+          and session.branch_id = requested_branch_id
+          and session.status in ('open', 'payment_pending')
+          and session.deleted_at is null
+      ),
+      'currentPaymentPendingCount', (
+        select count(*)
+        from public.table_sessions as session
+        where session.organization_id = requested_organization_id
+          and session.branch_id = requested_branch_id
+          and session.status = 'payment_pending'
+          and session.deleted_at is null
+      ),
+      'currentOpenBalanceMinor', coalesce((
+        select sum(balance.remaining_minor) from active_check_balances as balance
+      ), 0)::bigint,
+      'activeWaiterCount', (
+        select count(distinct participant.user_id)
+        from public.session_participants as participant
+        where participant.organization_id = requested_organization_id
+          and participant.branch_id = requested_branch_id
+          and participant.last_action_at >= now() - interval '15 minutes'
+      )
+    ),
+    'waiters', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'userId', waiter.user_id,
+          'displayName', waiter.display_name,
+          'itemRows', waiter.item_rows,
+          'itemQuantity', waiter.item_quantity,
+          'contributedRevenueMinor', waiter.contributed_revenue_minor,
+          'paymentHandledMinor', waiter.payment_handled_minor,
+          'paymentCount', waiter.payment_count,
+          'tablesServed', waiter.tables_served,
+          'cancellationCount', waiter.cancellation_count,
+          'cancellationValueMinor', waiter.cancellation_value_minor,
+          'helpedTableCount', waiter.helped_table_count,
+          'firstActionAt', waiter.first_action_at,
+          'lastActionAt', waiter.last_action_at,
+          'observedActiveMinutes', waiter.observed_active_minutes
+        )
+        order by waiter.contributed_revenue_minor desc, waiter.display_name
+      )
+      from waiter_stats as waiter
+    ), '[]'::jsonb),
+    'daily', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'businessDate', daily.business_date,
+          'confirmedRevenueMinor', daily.confirmed_revenue_minor,
+          'receiptCount', daily.receipt_count,
+          'cancellationCount', daily.cancellation_count,
+          'selectedWaiterContributionMinor',
+            daily.selected_waiter_contribution_minor
+        )
+        order by daily.business_date
+      )
+      from daily_stats as daily
+    ), '[]'::jsonb),
+    'cancellations', coalesce((
+      select jsonb_agg(to_jsonb(context) order by context."cancelledAt" desc)
+      from (
+        select
+          cancellation.order_item_id as "orderItemId",
+          cancellation.table_label as "tableLabel",
+          cancellation.name_snapshot as "itemName",
+          cancellation.reason_name as "reasonName",
+          cancellation.created_by as "createdBy",
+          cancellation.created_by_display_name as "createdByDisplayName",
+          cancellation.cancelled_by as "cancelledBy",
+          cancellation.cancelled_by_display_name as "cancelledByDisplayName",
+          cancellation.cancelled_at as "cancelledAt",
+          cancellation.amount_minor as "excludedAmountMinor"
+        from cancellations as cancellation
+        where requested_waiter_id is null
+          or cancellation.cancelled_by = requested_waiter_id
+        order by cancellation.cancelled_at desc
+        limit 20
+      ) as context
+    ), '[]'::jsonb),
+    'definitions', jsonb_build_object(
+      'confirmedRevenue', 'confirmed payment allocations for issued receipts',
+      'waiterContribution', 'non-cancelled immutable item value grouped by order_items.created_by',
+      'paymentsHandled', 'confirmed payment allocation value grouped by payments.created_by',
+      'cancellations', 'cancel action grouped by order_items.cancelled_by; excluded from revenue',
+      'observedActiveMinutes', 'elapsed time between first and last observed action; not a payroll shift'
+    )
+  )
+  into report_json;
+
+  return report_json;
+end;
+$$;
+
+revoke execute on function public.get_manager_report(
+  uuid,
+  uuid,
+  date,
+  date,
+  uuid
+) from public, anon;
+grant execute on function public.get_manager_report(
+  uuid,
+  uuid,
+  date,
+  date,
+  uuid
+) to authenticated;

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(83);
+select plan(93);
 
 insert into auth.users (
   instance_id,
@@ -1602,6 +1602,157 @@ select throws_ok(
   '42501',
   'branch_access_denied',
   'a user cannot search another branch receipt archive'
+);
+
+reset role;
+update public.memberships
+set role = 'manager'
+where organization_id = '25000000-0000-4000-8000-000000000001'
+  and branch_id = '35000000-0000-4000-8000-000000000001'
+  and user_id = '15000000-0000-4000-8000-000000000001';
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select is(
+  (
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts)
+    ) -> 'summary' ->> 'confirmedRevenueMinor'
+  )::bigint,
+  1000::bigint,
+  'manager revenue is derived only from confirmed allocations for issued receipts'
+);
+select is(
+  (
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts)
+    ) -> 'summary' ->> 'receiptCount'
+  )::bigint,
+  2::bigint,
+  'manager reporting counts immutable issued receipts'
+);
+select is(
+  (
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts)
+    ) -> 'summary' ->> 'cancelledItemCount'
+  )::bigint,
+  1::bigint,
+  'manager reporting retains cancellation events outside confirmed revenue'
+);
+select is(
+  (
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts)
+    ) -> 'summary' ->> 'cancelledValueMinor'
+  )::bigint,
+  1000::bigint,
+  'cancelled value includes immutable quantity and modifier prices'
+);
+select is(
+  jsonb_array_length(
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts)
+    ) -> 'waiters'
+  ),
+  2,
+  'every contributing waiter receives an auditable report row'
+);
+select is(
+  (
+    select (waiter ->> 'contributedRevenueMinor')::bigint
+    from jsonb_array_elements(
+      public.get_manager_report(
+        '25000000-0000-4000-8000-000000000001',
+        '35000000-0000-4000-8000-000000000001',
+        (select min(business_date) from public.receipts),
+        (select max(business_date) from public.receipts)
+      ) -> 'waiters'
+    ) as waiter
+    where waiter ->> 'displayName' = 'Second Waiter'
+  ),
+  500::bigint,
+  'item contribution follows the waiter who entered the order'
+);
+select is(
+  (
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts),
+      '15000000-0000-4000-8000-000000000001'
+    ) -> 'summary' ->> 'selectedWaiterContributionMinor'
+  )::bigint,
+  500::bigint,
+  'a waiter filter excludes their cancelled items from contribution'
+);
+select is(
+  (
+    select sum((day ->> 'confirmedRevenueMinor')::bigint)
+    from jsonb_array_elements(
+      public.get_manager_report(
+        '25000000-0000-4000-8000-000000000001',
+        '35000000-0000-4000-8000-000000000001',
+        (select min(business_date) from public.receipts),
+        (select max(business_date) from public.receipts)
+      ) -> 'daily'
+    ) as day
+  ),
+  1000::numeric,
+  'daily confirmed totals reconcile to the report total'
+);
+select is(
+  (
+    public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (select min(business_date) from public.receipts),
+      (select max(business_date) from public.receipts)
+    ) -> 'cancellations' -> 0 ->> 'reasonName'
+  ),
+  'Müşteri vazgeçti',
+  'the manager can audit the exact cancellation reason and context'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+select throws_ok(
+  $$
+    select public.get_manager_report(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      current_date,
+      current_date
+    )
+  $$,
+  '42501',
+  'manager_role_required',
+  'waiters cannot access manager reporting'
 );
 
 select * from finish();


### PR DESCRIPTION
## Summary
- replace the legacy analytics surface with a responsive, server-confirmed manager dashboard
- attribute contribution, payments, cancellations, help, and observed activity without treating the report as payroll
- add branch/date/waiter filters, daily totals, cancellation context, CSV export, and live operational KPIs
- enforce manager-only tenant access in a stable Supabase RPC with supporting indexes

## Validation
- npm run typecheck
- targeted ESLint with zero warnings
- 39 Jest suites / 179 tests / 1 snapshot
- web export
- 4 Playwright Chromium flows
- 93 pgTAP assertions (database CI)

Closes #26

Stacked on #53; merge that PR first.