### PR TITLE
feat(ai): add manager-reviewed menu assistant

### DIFF
--- a/e2e/app-shell.spec.ts
+++ b/e2e/app-shell.spec.ts
@@ -104,3 +104,35 @@ test('opens the manager report with auditable filters and offline recovery', asy
     ),
   ).toBeVisible();
 });
+
+test('keeps manual menu editing available when the AI assistant is offline', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  await page
+    .getByText(/Menü|Меню|Menu/i)
+    .last()
+    .click();
+  await expect(page.getByText(/Menü merkezi|Меню център|Menu hub/i).first()).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /AI ile ürün ekle|Добави с AI|Add with AI/i }),
+  ).toBeDisabled();
+  await expect(
+    page.getByText(/AI yalnız taslak hazırlar|AI създава само чернова|AI creates a draft only/i),
+  ).toBeVisible();
+
+  await page
+    .getByRole('button', { name: /Elle ürün ekle|Добави ръчно|Add manually/i })
+    .first()
+    .click();
+  await expect(
+    page
+      .getByRole('heading', {
+        name: /^(Ürün ekle|Добави артикул|Add item)$/i,
+      })
+      .last(),
+  ).toBeVisible();
+  await expect(page.getByLabel(/Ürün adı|Име|Item name/i)).toBeVisible();
+  await expect(page.getByLabel(/Fiyat|Цена|Price/i)).toBeVisible();
+  await expect(page.getByText(/Seçenek grupları|Групи опции|Option groups/i)).toBeVisible();
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,12 @@ module.exports = defineConfig([
     },
   },
   {
+    files: ['supabase/functions/**/*.ts'],
+    languageOptions: {
+      globals: globals.deno,
+    },
+  },
+  {
     files: [
       'jest.setup.js',
       '**/*.test.{ts,tsx}',

--- a/src/data/runtime/OrderiaDataContext.tsx
+++ b/src/data/runtime/OrderiaDataContext.tsx
@@ -12,7 +12,9 @@ import { AppState, Platform } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
 import {
   BranchId,
+  CurrencyCode,
   DeviceId,
+  MenuItemId,
   MutationId,
   OrganizationId,
   Receipt,
@@ -25,6 +27,13 @@ import {
   SupabasePaymentGateway,
 } from '../../features/payments';
 import { ManagerReport, ManagerReportGateway } from '../../features/manager-reports';
+import {
+  CatalogSnapshot,
+  EditableCatalogItem,
+  MenuAiDraft,
+  MenuCatalogGateway,
+  MenuLocale,
+} from '../../features/menu-management';
 import {
   ReceiptArchiveCursor,
   ReceiptArchiveFilters,
@@ -85,6 +94,23 @@ export interface OrderiaDataContextValue {
     pageSize?: number,
   ): Promise<ReceiptArchivePage>;
   loadManagerReport(dateFrom: string, dateTo: string, waiterId?: UserId): Promise<ManagerReport>;
+  loadCatalog(): Promise<CatalogSnapshot>;
+  generateMenuAiDraft(
+    text: string,
+    currencyCode: CurrencyCode,
+    locale: MenuLocale,
+    clientRequestId?: string,
+  ): Promise<MenuAiDraft>;
+  publishMenuAiDraft(
+    draftId: string,
+    expectedVersion: number,
+    item: EditableCatalogItem,
+  ): Promise<MenuItemId>;
+  saveCatalogItem(
+    item: EditableCatalogItem,
+    existing?: { readonly id: MenuItemId; readonly version: number },
+  ): Promise<MenuItemId>;
+  setCatalogAvailability(itemIds: readonly MenuItemId[], isAvailable: boolean): Promise<number>;
 }
 
 interface OrderiaDataProviderProps {
@@ -347,6 +373,76 @@ export function OrderiaDataProvider({
     [client, scope],
   );
 
+  const loadCatalog = useCallback(async (): Promise<CatalogSnapshot> => {
+    if (!client || !scope) throw new Error('Cloud catalog is unavailable');
+    return new MenuCatalogGateway(client).load(scope);
+  }, [client, scope]);
+
+  const generateMenuAiDraft = useCallback(
+    async (
+      text: string,
+      currencyCode: CurrencyCode,
+      locale: MenuLocale,
+      clientRequestId?: string,
+    ): Promise<MenuAiDraft> => {
+      if (!client || !scope) throw new Error('Cloud menu assistant is unavailable');
+      return new MenuCatalogGateway(client).generateDraft({
+        ...scope,
+        text,
+        currencyCode,
+        locale,
+        ...(clientRequestId ? { clientRequestId } : {}),
+      });
+    },
+    [client, scope],
+  );
+
+  const publishMenuAiDraft = useCallback(
+    async (
+      draftId: string,
+      expectedVersion: number,
+      item: EditableCatalogItem,
+    ): Promise<MenuItemId> => {
+      if (!client || !scope) throw new Error('Cloud menu assistant is unavailable');
+      const result = await new MenuCatalogGateway(client).publishDraft(
+        scope,
+        draftId,
+        expectedVersion,
+        item,
+      );
+      await refresh();
+      return result.itemId;
+    },
+    [client, refresh, scope],
+  );
+
+  const saveCatalogItem = useCallback(
+    async (
+      item: EditableCatalogItem,
+      existing?: { readonly id: MenuItemId; readonly version: number },
+    ): Promise<MenuItemId> => {
+      if (!client || !scope) throw new Error('Cloud catalog is unavailable');
+      const itemId = await new MenuCatalogGateway(client).saveItem(scope, item, existing);
+      await refresh();
+      return itemId;
+    },
+    [client, refresh, scope],
+  );
+
+  const setCatalogAvailability = useCallback(
+    async (itemIds: readonly MenuItemId[], isAvailable: boolean): Promise<number> => {
+      if (!client || !scope) throw new Error('Cloud catalog is unavailable');
+      const count = await new MenuCatalogGateway(client).setAvailability(
+        scope,
+        itemIds,
+        isAvailable,
+      );
+      await refresh();
+      return count;
+    },
+    [client, refresh, scope],
+  );
+
   useEffect(() => {
     if (!database || !scope || !client) return;
 
@@ -442,21 +538,31 @@ export function OrderiaDataProvider({
       prepareReceiptPdf,
       searchReceiptArchive,
       loadManagerReport,
+      loadCatalog,
+      generateMenuAiDraft,
+      publishMenuAiDraft,
+      saveCatalogItem,
+      setCatalogAvailability,
     }),
     [
       client,
       confirmCheckPayments,
       database,
       errorMessage,
+      generateMenuAiDraft,
       lastSuccessfulSyncAt,
+      loadCatalog,
       loadManagerReport,
       prepareReceiptPdf,
+      publishMenuAiDraft,
       readiness,
       refresh,
       resolveActiveParticipants,
       resolveProfileNames,
       revision,
       searchReceiptArchive,
+      saveCatalogItem,
+      setCatalogAvailability,
       scope,
       sync,
       transferOrMergeTableSession,

--- a/src/features/menu-management/__tests__/menuCatalogGateway.test.ts
+++ b/src/features/menu-management/__tests__/menuCatalogGateway.test.ts
@@ -1,0 +1,140 @@
+import { EditableCatalogItem, MenuAiDraft } from '../menuManagementTypes';
+import { MenuCatalogGateway } from '../menuCatalogGateway';
+
+describe('MenuCatalogGateway', () => {
+  it('generates a schema-validated draft through the protected Edge Function', async () => {
+    const invoke = jest.fn().mockResolvedValue({ data: draft, error: null });
+    const gateway = new MenuCatalogGateway({ functions: { invoke } } as never);
+
+    await expect(
+      gateway.generateDraft({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        text: 'Patates kızartması - 4 euro',
+        currencyCode: 'EUR' as never,
+        locale: 'tr',
+        clientRequestId: 'request-1',
+      }),
+    ).resolves.toEqual(draft);
+    expect(invoke).toHaveBeenCalledWith('menu-ai-draft', {
+      body: {
+        organizationId: 'organization-1',
+        branchId: 'branch-1',
+        clientRequestId: 'request-1',
+        input: 'Patates kızartması - 4 euro',
+        currencyCode: 'EUR',
+        locale: 'tr',
+      },
+    });
+  });
+
+  it('rejects a draft that presents an AI allergen suggestion as verified', async () => {
+    const invoke = jest.fn().mockResolvedValue({
+      data: {
+        ...draft,
+        suggestion: {
+          ...draft.suggestion,
+          allergenSuggestions: [{ code: 'MILK', status: 'contains', reason: 'AI guess' }],
+        },
+      },
+      error: null,
+    });
+    const gateway = new MenuCatalogGateway({ functions: { invoke } } as never);
+
+    await expect(
+      gateway.generateDraft({
+        organizationId: 'organization-1' as never,
+        branchId: 'branch-1' as never,
+        text: 'Cheese fries',
+        currencyCode: 'EUR' as never,
+        locale: 'en',
+      }),
+    ).rejects.toThrow('invalid draft');
+  });
+
+  it('publishes only the manager-reviewed payload and supports bulk availability', async () => {
+    const rpc = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: { status: 'published', item: { id: 'item-1' } },
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: 2, error: null });
+    const gateway = new MenuCatalogGateway({ rpc } as never);
+
+    await expect(
+      gateway.publishDraft(
+        {
+          organizationId: 'organization-1' as never,
+          branchId: 'branch-1' as never,
+        },
+        'draft-1',
+        2,
+        reviewedItem,
+      ),
+    ).resolves.toEqual({ itemId: 'item-1', status: 'published' });
+    expect(rpc).toHaveBeenNthCalledWith(
+      1,
+      'publish_menu_ai_draft',
+      expect.objectContaining({
+        requested_request_id: 'draft-1',
+        requested_expected_version: 2,
+        requested_reviewed_payload: reviewedItem,
+      }),
+    );
+
+    await expect(
+      gateway.setAvailability(
+        {
+          organizationId: 'organization-1' as never,
+          branchId: 'branch-1' as never,
+        },
+        ['item-1' as never, 'item-2' as never],
+        false,
+      ),
+    ).resolves.toBe(2);
+  });
+});
+
+const draft: MenuAiDraft = {
+  id: 'draft-1',
+  status: 'ready',
+  version: 2,
+  replayed: false,
+  suggestion: {
+    schemaVersion: 1,
+    item: {
+      name: 'Patates kızartması',
+      description: 'Çıtır patates',
+      priceMinor: 400,
+      currencyCode: 'EUR' as never,
+      categoryName: 'Atıştırmalık',
+      prepTimeMinutes: 8,
+    },
+    translations: [
+      { locale: 'tr', name: 'Patates kızartması', description: 'Çıtır patates' },
+      { locale: 'bg', name: 'Пържени картофи', description: null },
+      { locale: 'en', name: 'French fries', description: null },
+    ],
+    modifierGroups: [],
+    allergenSuggestions: [
+      { code: 'MILK', status: 'unknown', reason: 'Verify optional cheese with supplier data.' },
+    ],
+    warnings: ['Verify allergens before publishing.'],
+  },
+};
+
+const reviewedItem: EditableCatalogItem = {
+  categoryName: 'Atıştırmalık',
+  name: 'Patates kızartması',
+  description: 'Çıtır patates',
+  priceMinor: 400,
+  currencyCode: 'EUR' as never,
+  taxRateBasisPoints: 0,
+  isActive: true,
+  isAvailable: true,
+  prepTimeMinutes: 8,
+  translations: draft.suggestion.translations,
+  modifierGroups: [],
+  confirmedAllergens: [{ code: 'MILK', presence: 'may_contain' }],
+};

--- a/src/features/menu-management/index.ts
+++ b/src/features/menu-management/index.ts
@@ -1,0 +1,2 @@
+export * from './menuCatalogGateway';
+export * from './menuManagementTypes';

--- a/src/features/menu-management/menuCatalogGateway.ts
+++ b/src/features/menu-management/menuCatalogGateway.ts
@@ -1,0 +1,265 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import uuid from 'react-native-uuid';
+import {
+  BranchId,
+  CurrencyCode,
+  MenuCategoryId,
+  MenuItemId,
+  ModifierGroupId,
+  ModifierOptionId,
+  OrganizationId,
+  toDomainId,
+} from '../../domain';
+import { Database, Json } from '../../services/supabase';
+import {
+  CatalogItem,
+  CatalogModifierGroup,
+  CatalogSnapshot,
+  EditableCatalogItem,
+  MenuAiDraft,
+  MenuAiSuggestion,
+  MenuLocale,
+} from './menuManagementTypes';
+
+interface MenuScope {
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+}
+
+export class MenuCatalogGateway {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async load(scope: MenuScope): Promise<CatalogSnapshot> {
+    const branchFilter = `branch_id.is.null,branch_id.eq.${scope.branchId}`;
+    const [categoriesResult, itemsResult, groupsResult, optionsResult, translationsResult] =
+      await Promise.all([
+        this.client
+          .from('menu_categories')
+          .select('*')
+          .eq('organization_id', scope.organizationId)
+          .or(branchFilter)
+          .is('deleted_at', null)
+          .order('sort_order'),
+        this.client
+          .from('menu_items')
+          .select('*')
+          .eq('organization_id', scope.organizationId)
+          .or(branchFilter)
+          .is('deleted_at', null)
+          .order('name'),
+        this.client
+          .from('modifier_groups')
+          .select('*')
+          .eq('organization_id', scope.organizationId)
+          .or(branchFilter)
+          .is('deleted_at', null)
+          .order('sort_order'),
+        this.client
+          .from('modifier_options')
+          .select('*')
+          .eq('organization_id', scope.organizationId)
+          .or(branchFilter)
+          .is('deleted_at', null)
+          .order('sort_order'),
+        this.client
+          .from('menu_item_translations')
+          .select('*')
+          .eq('organization_id', scope.organizationId)
+          .or(branchFilter),
+      ]);
+    const error =
+      categoriesResult.error ??
+      itemsResult.error ??
+      groupsResult.error ??
+      optionsResult.error ??
+      translationsResult.error;
+    if (error) throw error;
+
+    const optionsByGroup = new Map<string, CatalogModifierGroup['options']>();
+    for (const option of optionsResult.data ?? []) {
+      const mapped = {
+        id: toDomainId<ModifierOptionId>(option.id),
+        name: option.name,
+        priceDeltaMinor: option.price_delta_minor,
+        isDefault: option.is_default,
+        isActive: option.is_active,
+        sortOrder: option.sort_order,
+      };
+      optionsByGroup.set(option.modifier_group_id, [
+        ...(optionsByGroup.get(option.modifier_group_id) ?? []),
+        mapped,
+      ]);
+    }
+    const groupsByItem = new Map<string, CatalogModifierGroup[]>();
+    for (const group of groupsResult.data ?? []) {
+      const mapped: CatalogModifierGroup = {
+        id: toDomainId<ModifierGroupId>(group.id),
+        name: group.name,
+        selectionType: group.selection_type,
+        minimumChoices: group.minimum_choices,
+        maximumChoices: group.maximum_choices,
+        isRequired: group.is_required,
+        sortOrder: group.sort_order,
+        options: optionsByGroup.get(group.id) ?? [],
+      };
+      groupsByItem.set(group.menu_item_id, [
+        ...(groupsByItem.get(group.menu_item_id) ?? []),
+        mapped,
+      ]);
+    }
+
+    const items: CatalogItem[] = (itemsResult.data ?? []).map((item) => ({
+      id: toDomainId<MenuItemId>(item.id),
+      categoryId: toDomainId<MenuCategoryId>(item.category_id),
+      name: item.name,
+      ...(item.description ? { description: item.description } : {}),
+      priceMinor: item.price_minor,
+      currencyCode: item.currency_code as CurrencyCode,
+      taxRateBasisPoints: item.tax_rate_basis_points,
+      isActive: item.is_active,
+      isAvailable: item.is_available,
+      ...(item.prep_time_minutes !== null ? { prepTimeMinutes: item.prep_time_minutes } : {}),
+      isOrganizationWide: item.branch_id === null,
+      version: item.version,
+      translations: (translationsResult.data ?? [])
+        .filter((translation) => translation.menu_item_id === item.id)
+        .map((translation) => ({
+          locale: translation.locale,
+          name: translation.name,
+          description: translation.description,
+        })),
+      modifierGroups: groupsByItem.get(item.id) ?? [],
+    }));
+
+    return {
+      ...scope,
+      categories: (categoriesResult.data ?? []).map((category) => ({
+        id: toDomainId<MenuCategoryId>(category.id),
+        name: category.name,
+        sortOrder: category.sort_order,
+        isActive: category.is_active,
+      })),
+      items,
+    };
+  }
+
+  async generateDraft(
+    input: MenuScope & {
+      readonly text: string;
+      readonly currencyCode: CurrencyCode;
+      readonly locale: MenuLocale;
+      readonly clientRequestId?: string;
+    },
+  ): Promise<MenuAiDraft> {
+    const clientRequestId = input.clientRequestId ?? String(uuid.v4());
+    const { data, error } = await this.client.functions.invoke('menu-ai-draft', {
+      body: {
+        organizationId: input.organizationId,
+        branchId: input.branchId,
+        clientRequestId,
+        input: input.text,
+        currencyCode: input.currencyCode,
+        locale: input.locale,
+      },
+    });
+    if (error) throw new Error(error.message || 'Menu assistant is unavailable');
+    if (!isMenuAiDraft(data)) throw new Error('Menu assistant returned an invalid draft');
+    return data;
+  }
+
+  async publishDraft(
+    scope: MenuScope,
+    draftId: string,
+    expectedVersion: number,
+    item: EditableCatalogItem,
+  ): Promise<{ readonly itemId: MenuItemId; readonly status: 'published' }> {
+    const { data, error } = await this.client.rpc('publish_menu_ai_draft', {
+      requested_organization_id: scope.organizationId,
+      requested_branch_id: scope.branchId,
+      requested_request_id: draftId,
+      requested_expected_version: expectedVersion,
+      requested_reviewed_payload: item as unknown as Json,
+    });
+    if (error) throw error;
+    if (!isRecord(data) || data.status !== 'published' || !isRecord(data.item)) {
+      throw new Error('Published catalog item response is invalid');
+    }
+    return {
+      itemId: toDomainId<MenuItemId>(requiredString(data.item.id)),
+      status: 'published',
+    };
+  }
+
+  async saveItem(
+    scope: MenuScope,
+    item: EditableCatalogItem,
+    existing?: { readonly id: MenuItemId; readonly version: number },
+  ): Promise<MenuItemId> {
+    const { data, error } = await this.client.rpc('save_catalog_item', {
+      requested_organization_id: scope.organizationId,
+      requested_branch_id: scope.branchId,
+      requested_item_id: existing?.id ?? null,
+      requested_expected_version: existing?.version ?? null,
+      requested_payload: item as unknown as Json,
+    });
+    if (error) throw error;
+    if (!isRecord(data)) throw new Error('Saved catalog item response is invalid');
+    return toDomainId<MenuItemId>(requiredString(data.id));
+  }
+
+  async setAvailability(
+    scope: MenuScope,
+    itemIds: readonly MenuItemId[],
+    isAvailable: boolean,
+  ): Promise<number> {
+    const { data, error } = await this.client.rpc('bulk_set_menu_item_availability', {
+      requested_organization_id: scope.organizationId,
+      requested_branch_id: scope.branchId,
+      requested_item_ids: [...itemIds],
+      requested_is_available: isAvailable,
+    });
+    if (error) throw error;
+    return data;
+  }
+}
+
+function isMenuAiDraft(value: unknown): value is MenuAiDraft {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    value.status === 'ready' &&
+    typeof value.version === 'number' &&
+    typeof value.replayed === 'boolean' &&
+    isMenuAiSuggestion(value.suggestion)
+  );
+}
+
+function isMenuAiSuggestion(value: unknown): value is MenuAiSuggestion {
+  return (
+    isRecord(value) &&
+    value.schemaVersion === 1 &&
+    isRecord(value.item) &&
+    typeof value.item.name === 'string' &&
+    typeof value.item.categoryName === 'string' &&
+    typeof value.item.priceMinor === 'number' &&
+    typeof value.item.currencyCode === 'string' &&
+    Array.isArray(value.translations) &&
+    Array.isArray(value.modifierGroups) &&
+    Array.isArray(value.allergenSuggestions) &&
+    value.allergenSuggestions.every(
+      (allergen) => isRecord(allergen) && allergen.status === 'unknown',
+    ) &&
+    Array.isArray(value.warnings)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error('Required catalog response field is missing');
+  }
+  return value;
+}

--- a/src/features/menu-management/menuManagementTypes.ts
+++ b/src/features/menu-management/menuManagementTypes.ts
@@ -1,0 +1,144 @@
+import {
+  BranchId,
+  CurrencyCode,
+  MenuCategoryId,
+  MenuItemId,
+  ModifierGroupId,
+  ModifierOptionId,
+  OrganizationId,
+} from '../../domain';
+
+export type MenuLocale = 'tr' | 'bg' | 'en';
+export type AllergenPresence = 'contains' | 'may_contain' | 'free_from';
+
+export interface MenuTranslationDraft {
+  readonly locale: MenuLocale;
+  readonly name: string;
+  readonly description: string | null;
+}
+
+export interface MenuModifierOptionDraft {
+  readonly name: string;
+  readonly priceDeltaMinor: number;
+  readonly isDefault: boolean;
+  readonly sortOrder: number;
+}
+
+export interface MenuModifierGroupDraft {
+  readonly name: string;
+  readonly selectionType: 'single' | 'multiple';
+  readonly minimumChoices: number;
+  readonly maximumChoices: number | null;
+  readonly isRequired: boolean;
+  readonly sortOrder: number;
+  readonly options: readonly MenuModifierOptionDraft[];
+}
+
+export interface MenuAllergenSuggestion {
+  readonly code: string;
+  readonly status: 'unknown';
+  readonly reason: string;
+}
+
+export interface ConfirmedMenuAllergen {
+  readonly code: string;
+  readonly presence: AllergenPresence;
+}
+
+export interface MenuAiSuggestion {
+  readonly schemaVersion: 1;
+  readonly item: {
+    readonly name: string;
+    readonly description: string | null;
+    readonly priceMinor: number;
+    readonly currencyCode: CurrencyCode;
+    readonly categoryName: string;
+    readonly prepTimeMinutes: number | null;
+  };
+  readonly translations: readonly MenuTranslationDraft[];
+  readonly modifierGroups: readonly MenuModifierGroupDraft[];
+  readonly allergenSuggestions: readonly MenuAllergenSuggestion[];
+  readonly warnings: readonly string[];
+}
+
+export interface EditableCatalogItem {
+  readonly categoryId?: MenuCategoryId;
+  readonly categoryName?: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly priceMinor: number;
+  readonly currencyCode: CurrencyCode;
+  readonly taxRateBasisPoints: number;
+  readonly isActive: boolean;
+  readonly isAvailable: boolean;
+  readonly prepTimeMinutes: number | null;
+  readonly translations: readonly MenuTranslationDraft[];
+  readonly modifierGroups: readonly MenuModifierGroupDraft[];
+  readonly confirmedAllergens: readonly ConfirmedMenuAllergen[];
+}
+
+export interface CatalogCategory {
+  readonly id: MenuCategoryId;
+  readonly name: string;
+  readonly sortOrder: number;
+  readonly isActive: boolean;
+}
+
+export interface CatalogModifierOption extends MenuModifierOptionDraft {
+  readonly id: ModifierOptionId;
+  readonly isActive: boolean;
+}
+
+export interface CatalogModifierGroup extends Omit<MenuModifierGroupDraft, 'options'> {
+  readonly id: ModifierGroupId;
+  readonly options: readonly CatalogModifierOption[];
+}
+
+export interface CatalogItem {
+  readonly id: MenuItemId;
+  readonly categoryId: MenuCategoryId;
+  readonly name: string;
+  readonly description?: string;
+  readonly priceMinor: number;
+  readonly currencyCode: CurrencyCode;
+  readonly taxRateBasisPoints: number;
+  readonly isActive: boolean;
+  readonly isAvailable: boolean;
+  readonly prepTimeMinutes?: number;
+  readonly isOrganizationWide: boolean;
+  readonly version: number;
+  readonly translations: readonly MenuTranslationDraft[];
+  readonly modifierGroups: readonly CatalogModifierGroup[];
+}
+
+export interface CatalogSnapshot {
+  readonly organizationId: OrganizationId;
+  readonly branchId: BranchId;
+  readonly categories: readonly CatalogCategory[];
+  readonly items: readonly CatalogItem[];
+}
+
+export interface MenuAiDraft {
+  readonly id: string;
+  readonly status: 'ready';
+  readonly version: number;
+  readonly suggestion: MenuAiSuggestion;
+  readonly replayed: boolean;
+}
+
+export function editableItemFromSuggestion(suggestion: MenuAiSuggestion): EditableCatalogItem {
+  return {
+    categoryName: suggestion.item.categoryName,
+    name: suggestion.item.name,
+    description: suggestion.item.description,
+    priceMinor: suggestion.item.priceMinor,
+    currencyCode: suggestion.item.currencyCode,
+    taxRateBasisPoints: 0,
+    isActive: true,
+    isAvailable: true,
+    prepTimeMinutes: suggestion.item.prepTimeMinutes,
+    translations: suggestion.translations,
+    modifierGroups: suggestion.modifierGroups,
+    confirmedAllergens: [],
+  };
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -18,6 +18,7 @@ import {
   EditTableScreen,
   HistoryScreen,
   MenuScreen,
+  MenuAssistantScreen,
   QRMenuScreen,
   SettingsScreen,
   ShiftBoardScreen,
@@ -29,6 +30,7 @@ export type RootStackParamList = {
   MainTabs: undefined;
   TableDetail: { tableId: string };
   AddMenuItem: { categoryId?: string; itemId?: string };
+  MenuAssistant: undefined;
   AddHall: { hallId?: string };
   EditTable: { tableId: string };
   AddCategory: { categoryId?: string };
@@ -185,6 +187,14 @@ export default function AppNavigator() {
           options={{
             presentation: 'modal',
             title: t.addMenuItem,
+          }}
+        />
+        <Stack.Screen
+          component={MenuAssistantScreen}
+          name="MenuAssistant"
+          options={{
+            headerShown: false,
+            presentation: 'modal',
           }}
         />
         <Stack.Screen

--- a/src/screens/AddMenuItemScreen.tsx
+++ b/src/screens/AddMenuItemScreen.tsx
@@ -1,410 +1,823 @@
-import React, { useState, useRef } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
-  View,
-  Text,
-  TextInput,
-  ScrollView,
+  Alert,
   KeyboardAvoidingView,
   Platform,
-  Alert,
-  TouchableOpacity,
-  FlatList,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation, useRoute, RouteProp } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import BottomSheet from '@gorhom/bottom-sheet';
-
+import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
+import { useOrderiaData } from '../data/runtime';
+import {
+  ServiceButton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+  useAdaptiveLayout,
+} from '../design-system';
+import { CurrencyCode, MenuCategoryId, MenuItemId, toDomainId } from '../domain';
+import {
+  CatalogSnapshot,
+  EditableCatalogItem,
+  MenuModifierGroupDraft,
+  MenuTranslationDraft,
+} from '../features/menu-management';
 import { useLocalization } from '../i18n';
-import { useMenuStore } from '../stores';
-import { PrimaryButton, SurfaceCard, ActionSheet, ActionSheetAction } from '../components';
 import { RootStackParamList } from '../navigation/AppNavigator';
-import { MenuItem } from '../types';
+import { useMenuStore } from '../stores';
 
-type AddMenuItemRouteProp = RouteProp<RootStackParamList, 'AddMenuItem'>;
-type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+type ScreenRoute = RouteProp<RootStackParamList, 'AddMenuItem'>;
+type Navigation = NativeStackNavigationProp<RootStackParamList>;
 
 export default function AddMenuItemScreen() {
-  const navigation = useNavigation<NavigationProp>();
-  const route = useRoute<AddMenuItemRouteProp>();
-  const { colors } = useTheme();
-  const { t, currency } = useLocalization();
-
-  const { categories, addMenuItem, menuItems, updateMenuItem, deleteMenuItem } = useMenuStore();
-  const { categoryId, itemId } = route.params || {};
-
-  // Check if we're editing an existing item
-  const editingItem = itemId ? menuItems.find((item) => item.id === itemId) : null;
-  const isEditing = !!editingItem;
-
-  const [name, setName] = useState(editingItem?.name || '');
-  const [price, setPrice] = useState(editingItem?.price?.toString() || '');
-  const [description, setDescription] = useState(editingItem?.description || '');
-  const [selectedCategoryId, setSelectedCategoryId] = useState(
-    categoryId || editingItem?.categoryId || '',
+  const route = useRoute<ScreenRoute>();
+  const navigation = useNavigation<Navigation>();
+  const auth = useAuth();
+  const { tokens } = useTheme();
+  const { language } = useLocalization();
+  const layout = useAdaptiveLayout();
+  const { loadCatalog, mode, saveCatalogItem, sync } = useOrderiaData();
+  const legacy = useMenuStore();
+  const copy = editorCopy(language);
+  const [catalog, setCatalog] = useState<CatalogSnapshot>();
+  const [name, setName] = useState('');
+  const [price, setPrice] = useState('');
+  const [description, setDescription] = useState('');
+  const [prepTime, setPrepTime] = useState('');
+  const [categoryId, setCategoryId] = useState<MenuCategoryId | undefined>(
+    route.params?.categoryId ? toDomainId<MenuCategoryId>(route.params.categoryId) : undefined,
   );
-  const [loading, setLoading] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const [translations, setTranslations] = useState<MenuTranslationDraft[]>([
+    { locale: 'tr', name: '', description: null },
+    { locale: 'bg', name: '', description: null },
+    { locale: 'en', name: '', description: null },
+  ]);
+  const [modifierGroups, setModifierGroups] = useState<MenuModifierGroupDraft[]>([]);
+  const [loading, setLoading] = useState(mode === 'cloud');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string>();
+  const [initializedItemId, setInitializedItemId] = useState<string>();
+  const itemId = route.params?.itemId ? toDomainId<MenuItemId>(route.params.itemId) : undefined;
+  const existingCloudItem = catalog?.items.find((item) => item.id === itemId);
+  const existingLegacyItem = legacy.menuItems.find((item) => item.id === itemId);
+  const currencyCode = (auth.activeBranch?.currency_code ?? 'EUR') as CurrencyCode;
+  const isManager = auth.activeMembership?.role === 'manager' || auth.status === 'unconfigured';
 
-  // Action sheet for menu item actions
-  const [showItemActions, setShowItemActions] = useState(false);
-  const [selectedMenuItem, setSelectedMenuItem] = useState<MenuItem | null>(null);
-  const actionSheetRef = useRef<BottomSheet>(null);
+  const categories = useMemo(
+    () =>
+      catalog?.categories ??
+      legacy.categories.map((category) => ({
+        id: toDomainId<MenuCategoryId>(category.id),
+        name: category.name,
+        sortOrder: category.order,
+        isActive: true,
+      })),
+    [catalog?.categories, legacy.categories],
+  );
 
-  const handleSave = async () => {
-    if (!name.trim()) {
-      Alert.alert(t.error, t.productNameRequired);
-      return;
-    }
-
-    if (!price.trim()) {
-      Alert.alert(t.error, t.priceRequired);
-      return;
-    }
-
-    if (!selectedCategoryId) {
-      Alert.alert(t.error, t.categoryRequired);
-      return;
-    }
-
-    const priceValue = parseFloat(price);
-    if (isNaN(priceValue) || priceValue <= 0) {
-      Alert.alert(t.error, t.validPriceRequired);
-      return;
-    }
-
-    setLoading(true);
-    try {
-      if (isEditing && editingItem) {
-        updateMenuItem(editingItem.id, {
-          categoryId: selectedCategoryId,
-          name: name.trim(),
-          price: Math.round(priceValue * 100), // Convert to cents
-          description: description.trim() || undefined,
-        });
-      } else {
-        addMenuItem({
-          categoryId: selectedCategoryId,
-          name: name.trim(),
-          price: Math.round(priceValue * 100), // Convert to cents
-          description: description.trim() || undefined,
-        });
-      }
-
-      // Clear form if adding new item
-      if (!isEditing) {
-        setName('');
-        setPrice('');
-        setDescription('');
-        setSelectedCategoryId(categoryId || '');
-      } else {
-        navigation.goBack();
-      }
-    } catch (error) {
-      Alert.alert(t.error, t.itemAddError);
-    } finally {
+  useEffect(() => {
+    if (mode !== 'cloud') {
       setLoading(false);
+      return;
+    }
+    let active = true;
+    void loadCatalog()
+      .then((next) => {
+        if (active) setCatalog(next);
+      })
+      .catch((loadError) => {
+        if (active) setError(loadError instanceof Error ? loadError.message : copy.loadFailed);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [copy.loadFailed, loadCatalog, mode]);
+
+  useEffect(() => {
+    const existing = existingCloudItem;
+    if (!existing || initializedItemId === existing.id) return;
+    setName(existing.name);
+    setPrice((existing.priceMinor / 100).toFixed(2));
+    setDescription(existing.description ?? '');
+    setPrepTime(existing.prepTimeMinutes?.toString() ?? '');
+    setCategoryId(existing.categoryId);
+    setTranslations(
+      (['tr', 'bg', 'en'] as const).map(
+        (locale) =>
+          existing.translations.find((translation) => translation.locale === locale) ?? {
+            locale,
+            name: '',
+            description: null,
+          },
+      ),
+    );
+    setModifierGroups(
+      existing.modifierGroups.map((group) => ({
+        name: group.name,
+        selectionType: group.selectionType,
+        minimumChoices: group.minimumChoices,
+        maximumChoices: group.maximumChoices,
+        isRequired: group.isRequired,
+        sortOrder: group.sortOrder,
+        options: group.options.map((option) => ({
+          name: option.name,
+          priceDeltaMinor: option.priceDeltaMinor,
+          isDefault: option.isDefault,
+          sortOrder: option.sortOrder,
+        })),
+      })),
+    );
+    setInitializedItemId(existing.id);
+  }, [existingCloudItem, initializedItemId]);
+
+  useEffect(() => {
+    const existing = existingLegacyItem;
+    if (mode === 'cloud' || !existing || initializedItemId === existing.id) return;
+    setName(existing.name);
+    setPrice((existing.price / 100).toFixed(2));
+    setDescription(existing.description ?? '');
+    setCategoryId(toDomainId<MenuCategoryId>(existing.categoryId));
+    setInitializedItemId(existing.id);
+  }, [existingLegacyItem, initializedItemId, mode]);
+
+  const save = async () => {
+    const priceMinor = Math.round(Number(price.replace(',', '.')) * 100);
+    if (!name.trim() || !Number.isFinite(priceMinor) || priceMinor < 0) {
+      setError(copy.namePriceRequired);
+      return;
+    }
+    if (!categoryId && !newCategoryName.trim()) {
+      setError(copy.categoryRequired);
+      return;
+    }
+    setSaving(true);
+    setError(undefined);
+    try {
+      if (mode === 'cloud') {
+        if (!sync.online) throw new Error(copy.onlineRequired);
+        const payload: EditableCatalogItem = {
+          ...(categoryId ? { categoryId } : { categoryName: newCategoryName.trim() }),
+          name: name.trim(),
+          description: description.trim() || null,
+          priceMinor,
+          currencyCode,
+          taxRateBasisPoints: 0,
+          isActive: existingCloudItem?.isActive ?? true,
+          isAvailable: existingCloudItem?.isAvailable ?? true,
+          prepTimeMinutes: prepTime ? Math.min(1440, Number(prepTime) || 0) : null,
+          translations: translations.filter((translation) => translation.name.trim()),
+          modifierGroups,
+          confirmedAllergens: [],
+        };
+        await saveCatalogItem(
+          payload,
+          existingCloudItem
+            ? { id: existingCloudItem.id, version: existingCloudItem.version }
+            : undefined,
+        );
+      } else if (existingLegacyItem) {
+        legacy.updateMenuItem(existingLegacyItem.id, {
+          categoryId: categoryId as string,
+          name: name.trim(),
+          description: description.trim() || undefined,
+          price: priceMinor,
+        });
+      } else {
+        let resolvedCategoryId = categoryId as string | undefined;
+        if (!resolvedCategoryId) {
+          resolvedCategoryId = legacy.addCategory({ name: newCategoryName.trim() }).id;
+        }
+        legacy.addMenuItem({
+          categoryId: resolvedCategoryId,
+          name: name.trim(),
+          description: description.trim() || undefined,
+          price: priceMinor,
+        });
+      }
+      Alert.alert(copy.saved, copy.savedBody, [
+        { text: copy.done, onPress: () => navigation.goBack() },
+      ]);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : copy.saveFailed);
+    } finally {
+      setSaving(false);
     }
   };
 
-  const handleMenuItemLongPress = (item: MenuItem) => {
-    setSelectedMenuItem(item);
-    setShowItemActions(true);
-  };
-
-  const handleEditMenuItem = (item: MenuItem) => {
-    setShowItemActions(false);
-    setSelectedMenuItem(null);
-    navigation.navigate('AddMenuItem', { categoryId: item.categoryId, itemId: item.id });
-  };
-
-  const handleDeleteMenuItem = (item: MenuItem) => {
-    setShowItemActions(false);
-    setSelectedMenuItem(null);
-
-    Alert.alert(
-      t.confirmDelete || 'Confirm Delete',
-      `Are you sure you want to delete "${item.name}"?`,
-      [
-        {
-          text: t.cancel || 'Cancel',
-          style: 'cancel',
-        },
-        {
-          text: t.delete || 'Delete',
-          style: 'destructive',
-          onPress: () => {
-            try {
-              deleteMenuItem(item.id);
-            } catch (error) {
-              Alert.alert(t.error, t.genericError);
-            }
-          },
-        },
-      ],
-    );
-  };
-
-  const getMenuItemActions = (): ActionSheetAction[] => [
-    {
-      id: 'edit',
-      title: t.edit || 'Edit',
-      icon: 'pencil',
-      onPress: () => selectedMenuItem && handleEditMenuItem(selectedMenuItem),
-    },
-    {
-      id: 'delete',
-      title: t.delete || 'Delete',
-      icon: 'trash',
-      destructive: true,
-      onPress: () => selectedMenuItem && handleDeleteMenuItem(selectedMenuItem),
-    },
-  ];
-
-  const renderMenuItem = ({ item }: { item: MenuItem }) => {
-    const category = categories.find((cat) => cat.id === item.categoryId);
+  if (!isManager) {
     return (
-      <TouchableOpacity onLongPress={() => handleMenuItemLongPress(item)}>
-        <SurfaceCard style={{ marginBottom: 8 }} variant="outlined">
-          <View
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-            }}
-          >
-            <View style={{ flex: 1 }}>
-              <Text style={{ fontSize: 16, fontWeight: '600', color: colors.text }}>
-                {item.name}
-              </Text>
-              {category && (
-                <Text style={{ fontSize: 12, color: colors.textSubtle, marginTop: 2 }}>
-                  {category.name}
-                </Text>
-              )}
-              {item.description && (
-                <Text style={{ fontSize: 14, color: colors.textSubtle, marginTop: 4 }}>
-                  {item.description}
-                </Text>
-              )}
-            </View>
-            <Text style={{ fontSize: 16, fontWeight: '600', color: colors.text }}>
-              {currency}
-              {(item.price / 100).toFixed(2)}
-            </Text>
-          </View>
-        </SurfaceCard>
-      </TouchableOpacity>
+      <SafeAreaView style={{ backgroundColor: tokens.colors.bg, flex: 1 }}>
+        <ServiceEmptyEditor
+          body={copy.managerOnly}
+          close={() => navigation.goBack()}
+          title={copy.unavailable}
+        />
+      </SafeAreaView>
     );
-  };
+  }
 
   return (
     <SafeAreaView
-      style={{ flex: 1, backgroundColor: colors.bg }}
-      edges={['bottom', 'left', 'right']}
+      edges={['top', 'left', 'right', 'bottom']}
+      style={{ backgroundColor: tokens.colors.bg, flex: 1 }}
     >
       <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={{ flex: 1 }}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       >
-        <View style={{ flex: 1, padding: 16, backgroundColor: colors.bg }}>
-          {/* Add/Edit Form */}
-          <SurfaceCard style={{ marginBottom: 16 }}>
-            <Text
-              style={{
-                fontSize: 18,
-                fontWeight: '600',
-                color: colors.text,
-                marginBottom: 16,
-              }}
+        <ScrollView
+          contentContainerStyle={{
+            alignSelf: 'center',
+            gap: tokens.space.lg,
+            maxWidth: 960,
+            padding: layout.horizontalPadding,
+            paddingBottom: tokens.space.xxl,
+            width: '100%',
+          }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View
+            style={{
+              alignItems: 'center',
+              flexDirection: 'row',
+              gap: tokens.space.sm,
+            }}
+          >
+            <Pressable
+              accessibilityLabel={copy.close}
+              accessibilityRole="button"
+              hitSlop={12}
+              onPress={() => navigation.goBack()}
+              style={{ padding: tokens.space.xs }}
             >
-              {isEditing ? t.editMenuItem || 'Edit Menu Item' : t.addMenuItem || 'Add Menu Item'}
-            </Text>
-
-            <Text
-              style={{
-                fontSize: 14,
-                color: colors.textSubtle,
-                marginBottom: 8,
-              }}
-            >
-              {t.productName} *
-            </Text>
-            <TextInput
-              style={{
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderRadius: 8,
-                paddingHorizontal: 12,
-                paddingVertical: 10,
-                fontSize: 16,
-                color: colors.text,
-                backgroundColor: colors.surface,
-                marginBottom: 16,
-              }}
-              value={name}
-              onChangeText={setName}
-              placeholder={t.enterProductName}
-              placeholderTextColor={colors.textSubtle}
-              autoFocus={isEditing}
-            />
-
-            <Text
-              style={{
-                fontSize: 14,
-                color: colors.textSubtle,
-                marginBottom: 8,
-              }}
-            >
-              {t.priceLabel} ({currency === 'TRY' ? '₺' : currency === 'BGN' ? 'лв' : '€'}) *
-            </Text>
-            <TextInput
-              style={{
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderRadius: 8,
-                paddingHorizontal: 12,
-                paddingVertical: 10,
-                fontSize: 16,
-                color: colors.text,
-                backgroundColor: colors.surface,
-                marginBottom: 16,
-              }}
-              value={price}
-              onChangeText={setPrice}
-              placeholder="0.00"
-              placeholderTextColor={colors.textSubtle}
-              keyboardType="decimal-pad"
-            />
-
-            <Text
-              style={{
-                fontSize: 14,
-                color: colors.textSubtle,
-                marginBottom: 8,
-              }}
-            >
-              {t.description}
-            </Text>
-            <TextInput
-              style={{
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderRadius: 8,
-                paddingHorizontal: 12,
-                paddingVertical: 10,
-                fontSize: 16,
-                color: colors.text,
-                backgroundColor: colors.surface,
-                marginBottom: 16,
-                minHeight: 80,
-              }}
-              value={description}
-              onChangeText={setDescription}
-              placeholder={t.productDescription}
-              placeholderTextColor={colors.textSubtle}
-              multiline
-              textAlignVertical="top"
-            />
-
-            <Text
-              style={{
-                fontSize: 14,
-                color: colors.textSubtle,
-                marginBottom: 8,
-              }}
-            >
-              {t.category} *
-            </Text>
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              style={{ marginBottom: 16 }}
-            >
-              {categories.map((category) => (
-                <TouchableOpacity
-                  key={category.id}
-                  style={{
-                    backgroundColor:
-                      selectedCategoryId === category.id ? colors.primary : colors.surface,
-                    paddingHorizontal: 16,
-                    paddingVertical: 10,
-                    borderRadius: 20,
-                    marginRight: 8,
-                    borderWidth: 1,
-                    borderColor:
-                      selectedCategoryId === category.id ? colors.primary : colors.border,
-                  }}
-                  onPress={() => setSelectedCategoryId(category.id)}
-                >
-                  <Text
-                    style={{
-                      color:
-                        selectedCategoryId === category.id ? colors.primaryContrast : colors.text,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {category.name}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
-
-            <View style={{ flexDirection: 'row', gap: 12 }}>
-              <PrimaryButton
-                title={t.cancel}
-                variant="outline"
-                onPress={() => navigation.goBack()}
-                style={{ flex: 1 }}
-              />
-              <PrimaryButton
-                title={isEditing ? t.update : t.save}
-                onPress={handleSave}
-                loading={loading}
-                disabled={!name.trim() || !price.trim() || !selectedCategoryId}
-                style={{ flex: 1 }}
-              />
-            </View>
-          </SurfaceCard>
-
-          {/* Existing Menu Items List */}
-          {!isEditing && menuItems.length > 0 && (
+              <Ionicons name="close" size={28} color={tokens.colors.text} />
+            </Pressable>
             <View style={{ flex: 1 }}>
               <Text
-                style={{
-                  fontSize: 16,
-                  fontWeight: '600',
-                  color: colors.text,
-                  marginBottom: 12,
-                }}
+                accessibilityRole="header"
+                style={[tokens.typography.title, { color: tokens.colors.text }]}
               >
-                Existing Menu Items
+                {itemId ? copy.editTitle : copy.addTitle}
               </Text>
-              <FlatList
-                data={menuItems}
-                renderItem={renderMenuItem}
-                keyExtractor={(item) => item.id}
-                showsVerticalScrollIndicator={false}
+              <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                {copy.subtitle}
+              </Text>
+            </View>
+            <ServiceStatusPill
+              label={mode === 'cloud' ? copy.cloud : copy.deviceOnly}
+              tone={mode === 'cloud' ? 'success' : 'neutral'}
+            />
+          </View>
+
+          {error ? (
+            <ServiceSurface
+              accessibilityLiveRegion="polite"
+              style={{ borderColor: tokens.colors.error }}
+              variant="outlined"
+            >
+              <Text style={[tokens.typography.body, { color: tokens.colors.error }]}>{error}</Text>
+            </ServiceSurface>
+          ) : null}
+
+          <ServiceSurface style={{ gap: tokens.space.md }} variant="raised">
+            <Text style={[tokens.typography.sectionTitle, { color: tokens.colors.text }]}>
+              {copy.basics}
+            </Text>
+            <ServiceTextField
+              autoFocus={!itemId}
+              editable={!loading}
+              label={copy.name}
+              onChangeText={setName}
+              value={name}
+            />
+            <View
+              style={{
+                flexDirection: layout.mode === 'compact' ? 'column' : 'row',
+                gap: tokens.space.sm,
+              }}
+            >
+              <ServiceTextField
+                containerStyle={{ flex: 1 }}
+                keyboardType="decimal-pad"
+                label={`${copy.price} (${currencyCode})`}
+                onChangeText={setPrice}
+                value={price}
+              />
+              <ServiceTextField
+                containerStyle={{ flex: 1 }}
+                keyboardType="number-pad"
+                label={copy.prep}
+                onChangeText={setPrepTime}
+                value={prepTime}
               />
             </View>
-          )}
-
-          {/* Action Sheet */}
-          {selectedMenuItem && (
-            <ActionSheet
-              ref={actionSheetRef}
-              title={selectedMenuItem.name}
-              subtitle="Actions for this menu item"
-              actions={getMenuItemActions()}
-              isVisible={showItemActions}
-              onClose={() => {
-                setShowItemActions(false);
-                setSelectedMenuItem(null);
-              }}
+            <ServiceTextField
+              inputStyle={{ minHeight: 84, textAlignVertical: 'top' }}
+              label={copy.description}
+              multiline
+              onChangeText={setDescription}
+              value={description}
             />
-          )}
-        </View>
+          </ServiceSurface>
+
+          <ServiceSurface style={{ gap: tokens.space.md }}>
+            <Text style={[tokens.typography.sectionTitle, { color: tokens.colors.text }]}>
+              {copy.category}
+            </Text>
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+              {categories.map((category) => (
+                <EditorChip
+                  key={category.id}
+                  active={categoryId === category.id}
+                  label={category.name}
+                  onPress={() => {
+                    setCategoryId(category.id);
+                    setNewCategoryName('');
+                  }}
+                />
+              ))}
+            </View>
+            <ServiceTextField
+              helperText={copy.newCategoryHelp}
+              label={copy.newCategory}
+              onChangeText={(value) => {
+                setNewCategoryName(value);
+                if (value) setCategoryId(undefined);
+              }}
+              value={newCategoryName}
+            />
+          </ServiceSurface>
+
+          <ServiceSurface style={{ gap: tokens.space.md }}>
+            <Text style={[tokens.typography.sectionTitle, { color: tokens.colors.text }]}>
+              {copy.translations}
+            </Text>
+            {translations.map((translation, index) => (
+              <View key={translation.locale} style={{ gap: tokens.space.xs }}>
+                <ServiceStatusPill label={translation.locale.toUpperCase()} />
+                <ServiceTextField
+                  label={copy.localizedName}
+                  onChangeText={(value) =>
+                    setTranslations((current) =>
+                      current.map((entry, entryIndex) =>
+                        entryIndex === index ? { ...entry, name: value } : entry,
+                      ),
+                    )
+                  }
+                  value={translation.name}
+                />
+                <ServiceTextField
+                  label={copy.localizedDescription}
+                  onChangeText={(value) =>
+                    setTranslations((current) =>
+                      current.map((entry, entryIndex) =>
+                        entryIndex === index ? { ...entry, description: value || null } : entry,
+                      ),
+                    )
+                  }
+                  value={translation.description ?? ''}
+                />
+              </View>
+            ))}
+          </ServiceSurface>
+
+          <ServiceSurface style={{ gap: tokens.space.md }}>
+            <View
+              style={{
+                alignItems: 'center',
+                flexDirection: 'row',
+                gap: tokens.space.sm,
+                justifyContent: 'space-between',
+              }}
+            >
+              <View style={{ flex: 1 }}>
+                <Text style={[tokens.typography.sectionTitle, { color: tokens.colors.text }]}>
+                  {copy.options}
+                </Text>
+                <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                  {copy.optionsHelp}
+                </Text>
+              </View>
+              <ServiceButton
+                icon="add-outline"
+                label={copy.addGroup}
+                onPress={() =>
+                  setModifierGroups((current) => [
+                    ...current,
+                    {
+                      name: '',
+                      selectionType: 'single',
+                      minimumChoices: 0,
+                      maximumChoices: 1,
+                      isRequired: false,
+                      sortOrder: current.length,
+                      options: [],
+                    },
+                  ])
+                }
+                variant="outline"
+              />
+            </View>
+            {modifierGroups.map((group, groupIndex) => (
+              <ServiceSurface key={groupIndex} style={{ gap: tokens.space.sm }} variant="muted">
+                <View style={{ flexDirection: 'row', gap: tokens.space.sm }}>
+                  <ServiceTextField
+                    containerStyle={{ flex: 1 }}
+                    label={copy.groupName}
+                    onChangeText={(value) =>
+                      setModifierGroups((current) =>
+                        current.map((entry, index) =>
+                          index === groupIndex ? { ...entry, name: value } : entry,
+                        ),
+                      )
+                    }
+                    value={group.name}
+                  />
+                  <Pressable
+                    accessibilityLabel={copy.removeGroup}
+                    accessibilityRole="button"
+                    onPress={() =>
+                      setModifierGroups((current) =>
+                        current.filter((_, index) => index !== groupIndex),
+                      )
+                    }
+                    style={{ alignSelf: 'flex-end', padding: tokens.space.sm }}
+                  >
+                    <Ionicons name="trash-outline" size={22} color={tokens.colors.error} />
+                  </Pressable>
+                </View>
+                <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+                  <EditorChip
+                    active={group.selectionType === 'single'}
+                    label={copy.single}
+                    onPress={() =>
+                      updateGroup(setModifierGroups, groupIndex, {
+                        selectionType: 'single',
+                        maximumChoices: 1,
+                      })
+                    }
+                  />
+                  <EditorChip
+                    active={group.selectionType === 'multiple'}
+                    label={copy.multiple}
+                    onPress={() =>
+                      updateGroup(setModifierGroups, groupIndex, {
+                        selectionType: 'multiple',
+                        maximumChoices: null,
+                      })
+                    }
+                  />
+                  <EditorChip
+                    active={group.isRequired}
+                    label={copy.required}
+                    onPress={() =>
+                      updateGroup(setModifierGroups, groupIndex, {
+                        isRequired: !group.isRequired,
+                        minimumChoices: group.isRequired ? 0 : 1,
+                      })
+                    }
+                  />
+                </View>
+                {group.options.map((option, optionIndex) => (
+                  <View key={optionIndex} style={{ flexDirection: 'row', gap: tokens.space.xs }}>
+                    <ServiceTextField
+                      containerStyle={{ flex: 2 }}
+                      label={copy.optionName}
+                      onChangeText={(value) =>
+                        updateOption(setModifierGroups, groupIndex, optionIndex, { name: value })
+                      }
+                      value={option.name}
+                    />
+                    <ServiceTextField
+                      containerStyle={{ flex: 1 }}
+                      keyboardType="decimal-pad"
+                      label={copy.extraPrice}
+                      onChangeText={(value) =>
+                        updateOption(setModifierGroups, groupIndex, optionIndex, {
+                          priceDeltaMinor: Math.round(Number(value.replace(',', '.')) * 100) || 0,
+                        })
+                      }
+                      value={(option.priceDeltaMinor / 100).toFixed(2)}
+                    />
+                    <Pressable
+                      accessibilityLabel={copy.removeOption}
+                      accessibilityRole="button"
+                      onPress={() =>
+                        setModifierGroups((current) =>
+                          current.map((entry, index) =>
+                            index === groupIndex
+                              ? {
+                                  ...entry,
+                                  options: entry.options.filter(
+                                    (_, currentOptionIndex) => currentOptionIndex !== optionIndex,
+                                  ),
+                                }
+                              : entry,
+                          ),
+                        )
+                      }
+                      style={{ alignSelf: 'flex-end', padding: tokens.space.sm }}
+                    >
+                      <Ionicons name="close-circle-outline" size={24} color={tokens.colors.error} />
+                    </Pressable>
+                  </View>
+                ))}
+                <ServiceButton
+                  icon="add-outline"
+                  label={copy.addOption}
+                  onPress={() =>
+                    setModifierGroups((current) =>
+                      current.map((entry, index) =>
+                        index === groupIndex
+                          ? {
+                              ...entry,
+                              options: [
+                                ...entry.options,
+                                {
+                                  name: '',
+                                  priceDeltaMinor: 0,
+                                  isDefault: false,
+                                  sortOrder: entry.options.length,
+                                },
+                              ],
+                            }
+                          : entry,
+                      ),
+                    )
+                  }
+                  variant="ghost"
+                />
+              </ServiceSurface>
+            ))}
+          </ServiceSurface>
+
+          <View
+            style={{
+              flexDirection: layout.mode === 'compact' ? 'column-reverse' : 'row',
+              gap: tokens.space.sm,
+              justifyContent: 'flex-end',
+            }}
+          >
+            <ServiceButton
+              label={copy.cancel}
+              onPress={() => navigation.goBack()}
+              size="large"
+              variant="ghost"
+            />
+            <ServiceButton
+              disabled={
+                !name.trim() ||
+                !price.trim() ||
+                (!categoryId && !newCategoryName.trim()) ||
+                modifierGroups.some(
+                  (group) =>
+                    !group.name.trim() || group.options.some((option) => !option.name.trim()),
+                )
+              }
+              icon="checkmark-outline"
+              label={itemId ? copy.update : copy.save}
+              loading={saving}
+              onPress={() => void save()}
+              size="large"
+            />
+          </View>
+        </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
+}
+
+function updateGroup(
+  setGroups: React.Dispatch<React.SetStateAction<MenuModifierGroupDraft[]>>,
+  index: number,
+  patch: Partial<MenuModifierGroupDraft>,
+) {
+  setGroups((current) =>
+    current.map((group, groupIndex) => (groupIndex === index ? { ...group, ...patch } : group)),
+  );
+}
+
+function updateOption(
+  setGroups: React.Dispatch<React.SetStateAction<MenuModifierGroupDraft[]>>,
+  groupIndex: number,
+  optionIndex: number,
+  patch: Partial<MenuModifierGroupDraft['options'][number]>,
+) {
+  setGroups((current) =>
+    current.map((group, currentGroupIndex) =>
+      currentGroupIndex === groupIndex
+        ? {
+            ...group,
+            options: group.options.map((option, currentOptionIndex) =>
+              currentOptionIndex === optionIndex ? { ...option, ...patch } : option,
+            ),
+          }
+        : group,
+    ),
+  );
+}
+
+function EditorChip({
+  active,
+  label,
+  onPress,
+}: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly onPress: () => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={{
+        backgroundColor: active ? tokens.colors.primary : tokens.colors.surface,
+        borderColor: active ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.full,
+        borderWidth: 1,
+        justifyContent: 'center',
+        minHeight: tokens.sizing.minimumTarget,
+        paddingHorizontal: tokens.space.md,
+      }}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: active ? tokens.colors.primaryContrast : tokens.colors.text },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function ServiceEmptyEditor({
+  body,
+  close,
+  title,
+}: {
+  readonly body: string;
+  readonly close: () => void;
+  readonly title: string;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View style={{ gap: tokens.space.md, padding: tokens.space.lg }}>
+      <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>{title}</Text>
+      <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>{body}</Text>
+      <ServiceButton label="OK" onPress={close} />
+    </View>
+  );
+}
+
+function editorCopy(language: 'tr' | 'bg' | 'en') {
+  if (language === 'tr') {
+    return {
+      addTitle: 'Ürün ekle',
+      editTitle: 'Ürünü düzenle',
+      subtitle: 'Serviste gereken bütün seçenekleri tek ekranda hazırla.',
+      close: 'Kapat',
+      cloud: 'Buluta kaydolur',
+      deviceOnly: 'Yalnız cihaz',
+      loadFailed: 'Menü yüklenemedi.',
+      basics: 'Temel bilgiler',
+      name: 'Ürün adı',
+      price: 'Fiyat',
+      prep: 'Hazırlık (dk)',
+      description: 'Açıklama',
+      category: 'Kategori',
+      newCategory: 'Yeni kategori',
+      newCategoryHelp: 'Mevcut kategori seçmek yerine yeni bir ad yazabilirsin.',
+      translations: 'Çeviriler',
+      localizedName: 'Çevrilmiş ad',
+      localizedDescription: 'Çevrilmiş açıklama',
+      options: 'Seçenek grupları',
+      optionsHelp: 'Örn. peynirli/peynirsiz veya pişirme derecesi.',
+      addGroup: 'Grup ekle',
+      groupName: 'Grup adı',
+      removeGroup: 'Grubu kaldır',
+      single: 'Tek seçim',
+      multiple: 'Çoklu seçim',
+      required: 'Zorunlu',
+      optionName: 'Seçenek',
+      extraPrice: 'Ek fiyat',
+      removeOption: 'Seçeneği kaldır',
+      addOption: 'Seçenek ekle',
+      cancel: 'Vazgeç',
+      save: 'Ürünü kaydet',
+      update: 'Değişiklikleri kaydet',
+      namePriceRequired: 'Geçerli ürün adı ve fiyat gir.',
+      categoryRequired: 'Bir kategori seç veya yeni kategori yaz.',
+      onlineRequired: 'Bulut menüyü kaydetmek için internete bağlan.',
+      saved: 'Menü güncellendi',
+      savedBody: 'Ürün ve seçenekleri kaydedildi.',
+      done: 'Tamam',
+      saveFailed: 'Ürün kaydedilemedi.',
+      managerOnly: 'Menüyü yalnız yöneticiler değiştirebilir.',
+      unavailable: 'Düzenleme kullanılamıyor',
+    } as const;
+  }
+  if (language === 'bg') {
+    return {
+      addTitle: 'Добави артикул',
+      editTitle: 'Редактирай артикул',
+      subtitle: 'Подгответе всички опции за бързо обслужване.',
+      close: 'Затвори',
+      cloud: 'Запис в облака',
+      deviceOnly: 'Само устройство',
+      loadFailed: 'Менюто не се зареди.',
+      basics: 'Основни данни',
+      name: 'Име',
+      price: 'Цена',
+      prep: 'Приготвяне (мин)',
+      description: 'Описание',
+      category: 'Категория',
+      newCategory: 'Нова категория',
+      newCategoryHelp: 'Може да въведете нова вместо да изберете съществуваща.',
+      translations: 'Преводи',
+      localizedName: 'Преведено име',
+      localizedDescription: 'Преведено описание',
+      options: 'Групи опции',
+      optionsHelp: 'Напр. със/без сирене или степен на изпичане.',
+      addGroup: 'Добави група',
+      groupName: 'Име на група',
+      removeGroup: 'Премахни групата',
+      single: 'Един избор',
+      multiple: 'Много избори',
+      required: 'Задължително',
+      optionName: 'Опция',
+      extraPrice: 'Доплащане',
+      removeOption: 'Премахни опцията',
+      addOption: 'Добави опция',
+      cancel: 'Отказ',
+      save: 'Запази артикула',
+      update: 'Запази промените',
+      namePriceRequired: 'Въведете валидни име и цена.',
+      categoryRequired: 'Изберете или въведете категория.',
+      onlineRequired: 'Свържете се с интернет за запис в облака.',
+      saved: 'Менюто е обновено',
+      savedBody: 'Артикулът и опциите са записани.',
+      done: 'Готово',
+      saveFailed: 'Артикулът не се запази.',
+      managerOnly: 'Само мениджъри могат да променят менюто.',
+      unavailable: 'Редакцията не е достъпна',
+    } as const;
+  }
+  return {
+    addTitle: 'Add item',
+    editTitle: 'Edit item',
+    subtitle: 'Prepare every option needed for fast service.',
+    close: 'Close',
+    cloud: 'Saved to cloud',
+    deviceOnly: 'Device only',
+    loadFailed: 'The menu could not be loaded.',
+    basics: 'Basics',
+    name: 'Item name',
+    price: 'Price',
+    prep: 'Prep time (min)',
+    description: 'Description',
+    category: 'Category',
+    newCategory: 'New category',
+    newCategoryHelp: 'Enter a new name instead of selecting an existing category.',
+    translations: 'Translations',
+    localizedName: 'Localized name',
+    localizedDescription: 'Localized description',
+    options: 'Option groups',
+    optionsHelp: 'For example, with/without cheese or cooking preference.',
+    addGroup: 'Add group',
+    groupName: 'Group name',
+    removeGroup: 'Remove group',
+    single: 'Single choice',
+    multiple: 'Multiple choices',
+    required: 'Required',
+    optionName: 'Option',
+    extraPrice: 'Extra price',
+    removeOption: 'Remove option',
+    addOption: 'Add option',
+    cancel: 'Cancel',
+    save: 'Save item',
+    update: 'Save changes',
+    namePriceRequired: 'Enter a valid item name and price.',
+    categoryRequired: 'Select or enter a category.',
+    onlineRequired: 'Connect to the internet to save the cloud menu.',
+    saved: 'Menu updated',
+    savedBody: 'The item and its options were saved.',
+    done: 'Done',
+    saveFailed: 'The item could not be saved.',
+    managerOnly: 'Only managers can change the menu.',
+    unavailable: 'Editing unavailable',
+  } as const;
 }

--- a/src/screens/MenuAssistantScreen.tsx
+++ b/src/screens/MenuAssistantScreen.tsx
@@ -1,0 +1,754 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../contexts/AuthContext';
+import { useTheme } from '../contexts/ThemeContext';
+import { useOrderiaData } from '../data/runtime';
+import {
+  ServiceButton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+  useAdaptiveLayout,
+} from '../design-system';
+import { CurrencyCode } from '../domain';
+import {
+  AllergenPresence,
+  EditableCatalogItem,
+  MenuAiDraft,
+  editableItemFromSuggestion,
+} from '../features/menu-management';
+import { useLocalization } from '../i18n';
+import { RootStackParamList } from '../navigation/AppNavigator';
+
+type Navigation = NativeStackNavigationProp<RootStackParamList>;
+
+export default function MenuAssistantScreen() {
+  const navigation = useNavigation<Navigation>();
+  const auth = useAuth();
+  const { tokens } = useTheme();
+  const { language } = useLocalization();
+  const layout = useAdaptiveLayout();
+  const { generateMenuAiDraft, mode, publishMenuAiDraft, sync } = useOrderiaData();
+  const copy = assistantCopy(language);
+  const [prompt, setPrompt] = useState('');
+  const [draft, setDraft] = useState<MenuAiDraft>();
+  const [item, setItem] = useState<EditableCatalogItem>();
+  const [allergens, setAllergens] = useState<Record<string, AllergenPresence | undefined>>({});
+  const [reviewConfirmed, setReviewConfirmed] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [publishing, setPublishing] = useState(false);
+  const [error, setError] = useState<string>();
+  const isManager = auth.activeMembership?.role === 'manager';
+  const cloudReady = mode === 'cloud' && sync.online;
+  const currencyCode = (auth.activeBranch?.currency_code ?? 'EUR') as CurrencyCode;
+
+  const confirmedAllergens = useMemo(
+    () =>
+      Object.entries(allergens)
+        .filter((entry): entry is [string, AllergenPresence] => Boolean(entry[1]))
+        .map(([code, presence]) => ({ code, presence })),
+    [allergens],
+  );
+
+  const generate = async () => {
+    if (!isManager) {
+      setError(copy.managerOnly);
+      return;
+    }
+    if (!cloudReady) {
+      setError(copy.onlineOnly);
+      return;
+    }
+    if (prompt.trim().length < 3) {
+      setError(copy.promptRequired);
+      return;
+    }
+    setGenerating(true);
+    setError(undefined);
+    try {
+      const next = await generateMenuAiDraft(prompt.trim(), currencyCode, language);
+      setDraft(next);
+      setItem(editableItemFromSuggestion(next.suggestion));
+      setAllergens({});
+      setReviewConfirmed(false);
+    } catch (generationError) {
+      setError(generationError instanceof Error ? generationError.message : copy.unavailable);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const publish = async () => {
+    if (!draft || !item || !reviewConfirmed) return;
+    setPublishing(true);
+    setError(undefined);
+    try {
+      await publishMenuAiDraft(draft.id, draft.version, {
+        ...item,
+        confirmedAllergens,
+      });
+      Alert.alert(copy.published, copy.publishedBody, [
+        { text: copy.done, onPress: () => navigation.goBack() },
+      ]);
+    } catch (publishError) {
+      setError(publishError instanceof Error ? publishError.message : copy.publishFailed);
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  return (
+    <SafeAreaView
+      edges={['top', 'left', 'right', 'bottom']}
+      style={{ backgroundColor: tokens.colors.bg, flex: 1 }}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={{ flex: 1 }}
+      >
+        <ScrollView
+          contentContainerStyle={{
+            alignSelf: 'center',
+            gap: tokens.space.lg,
+            maxWidth: 960,
+            padding: layout.horizontalPadding,
+            paddingBottom: tokens.space.xxl,
+            width: '100%',
+          }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View
+            style={{
+              alignItems: 'center',
+              flexDirection: 'row',
+              gap: tokens.space.sm,
+              justifyContent: 'space-between',
+            }}
+          >
+            <Pressable
+              accessibilityLabel={copy.close}
+              accessibilityRole="button"
+              hitSlop={12}
+              onPress={() => navigation.goBack()}
+              style={{ padding: tokens.space.xs }}
+            >
+              <Ionicons name="close" size={28} color={tokens.colors.text} />
+            </Pressable>
+            <View style={{ flex: 1 }}>
+              <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+                {copy.title}
+              </Text>
+              <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                {copy.subtitle}
+              </Text>
+            </View>
+            <ServiceStatusPill
+              label={draft ? copy.review : copy.draftOnly}
+              tone={draft ? 'warning' : 'info'}
+            />
+          </View>
+
+          <ServiceSurface style={{ gap: tokens.space.md }} variant="raised">
+            <View style={{ flexDirection: 'row', gap: tokens.space.sm }}>
+              <View
+                style={{
+                  alignItems: 'center',
+                  backgroundColor: tokens.colors.accentSoft,
+                  borderRadius: tokens.radius.medium,
+                  height: 48,
+                  justifyContent: 'center',
+                  width: 48,
+                }}
+              >
+                <Ionicons name="sparkles" size={24} color={tokens.colors.accent} />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                  {copy.oneLine}
+                </Text>
+                <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                  {copy.example}
+                </Text>
+              </View>
+            </View>
+            <ServiceTextField
+              label={copy.prompt}
+              multiline
+              onChangeText={setPrompt}
+              placeholder={copy.placeholder}
+              inputStyle={{ minHeight: 88, textAlignVertical: 'top' }}
+              value={prompt}
+            />
+            <ServiceButton
+              disabled={!cloudReady || !isManager || prompt.trim().length < 3}
+              fullWidth
+              icon="sparkles"
+              label={copy.generate}
+              loading={generating}
+              onPress={() => void generate()}
+              size="large"
+              variant="accent"
+            />
+            {!cloudReady || !isManager ? (
+              <Text style={[tokens.typography.caption, { color: tokens.colors.warning }]}>
+                {isManager ? copy.onlineOnly : copy.managerOnly}
+              </Text>
+            ) : null}
+          </ServiceSurface>
+
+          {error ? (
+            <ServiceSurface
+              accessibilityLiveRegion="polite"
+              style={{ borderColor: tokens.colors.error, gap: tokens.space.sm }}
+              variant="outlined"
+            >
+              <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.error }]}>
+                {copy.unavailable}
+              </Text>
+              <Text style={[tokens.typography.body, { color: tokens.colors.text }]}>{error}</Text>
+              <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                {copy.manualUnaffected}
+              </Text>
+            </ServiceSurface>
+          ) : null}
+
+          {draft && item ? (
+            <>
+              <ServiceSurface style={{ gap: tokens.space.sm }} variant="outlined">
+                <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                  {copy.reviewChanges}
+                </Text>
+                <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                  {copy.source}: “{prompt.trim()}”
+                </Text>
+                {draft.suggestion.warnings.map((warning) => (
+                  <View key={warning} style={{ flexDirection: 'row', gap: tokens.space.xs }}>
+                    <Ionicons name="warning-outline" size={18} color={tokens.colors.warning} />
+                    <Text
+                      style={[tokens.typography.caption, { color: tokens.colors.text, flex: 1 }]}
+                    >
+                      {warning}
+                    </Text>
+                  </View>
+                ))}
+              </ServiceSurface>
+
+              <ServiceSurface style={{ gap: tokens.space.md }}>
+                <SectionTitle title={copy.product} />
+                <View
+                  style={{
+                    flexDirection: layout.mode === 'compact' ? 'column' : 'row',
+                    gap: tokens.space.sm,
+                  }}
+                >
+                  <ServiceTextField
+                    containerStyle={{ flex: 2 }}
+                    label={copy.name}
+                    onChangeText={(name) => setItem((current) => current && { ...current, name })}
+                    value={item.name}
+                  />
+                  <ServiceTextField
+                    containerStyle={{ flex: 1 }}
+                    keyboardType="decimal-pad"
+                    label={`${copy.price} (${currencyCode})`}
+                    onChangeText={(value) =>
+                      setItem((current) =>
+                        current
+                          ? {
+                              ...current,
+                              priceMinor: Math.max(
+                                0,
+                                Math.round(Number(value.replace(',', '.')) * 100) || 0,
+                              ),
+                            }
+                          : current,
+                      )
+                    }
+                    value={(item.priceMinor / 100).toFixed(2)}
+                  />
+                </View>
+                <ServiceTextField
+                  label={copy.category}
+                  onChangeText={(categoryName) =>
+                    setItem((current) =>
+                      current ? { ...current, categoryId: undefined, categoryName } : current,
+                    )
+                  }
+                  value={item.categoryName ?? ''}
+                />
+                <ServiceTextField
+                  inputStyle={{ minHeight: 72, textAlignVertical: 'top' }}
+                  label={copy.description}
+                  multiline
+                  onChangeText={(description) =>
+                    setItem((current) => current && { ...current, description })
+                  }
+                  value={item.description ?? ''}
+                />
+                <ServiceTextField
+                  containerStyle={{ maxWidth: 240 }}
+                  keyboardType="number-pad"
+                  label={copy.prep}
+                  onChangeText={(value) =>
+                    setItem((current) =>
+                      current
+                        ? {
+                            ...current,
+                            prepTimeMinutes: value ? Math.min(1440, Number(value) || 0) : null,
+                          }
+                        : current,
+                    )
+                  }
+                  value={item.prepTimeMinutes?.toString() ?? ''}
+                />
+              </ServiceSurface>
+
+              <ServiceSurface style={{ gap: tokens.space.md }}>
+                <SectionTitle title={copy.translations} />
+                {item.translations.map((translation, index) => (
+                  <View key={translation.locale} style={{ gap: tokens.space.xs }}>
+                    <ServiceStatusPill label={translation.locale.toUpperCase()} tone="neutral" />
+                    <ServiceTextField
+                      label={copy.name}
+                      onChangeText={(name) =>
+                        setItem((current) =>
+                          current
+                            ? {
+                                ...current,
+                                translations: current.translations.map((entry, entryIndex) =>
+                                  entryIndex === index ? { ...entry, name } : entry,
+                                ),
+                              }
+                            : current,
+                        )
+                      }
+                      value={translation.name}
+                    />
+                    <ServiceTextField
+                      label={copy.description}
+                      onChangeText={(description) =>
+                        setItem((current) =>
+                          current
+                            ? {
+                                ...current,
+                                translations: current.translations.map((entry, entryIndex) =>
+                                  entryIndex === index ? { ...entry, description } : entry,
+                                ),
+                              }
+                            : current,
+                        )
+                      }
+                      value={translation.description ?? ''}
+                    />
+                  </View>
+                ))}
+              </ServiceSurface>
+
+              <ServiceSurface style={{ gap: tokens.space.md }}>
+                <SectionTitle title={copy.modifiers} />
+                {item.modifierGroups.length === 0 ? (
+                  <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                    {copy.noModifiers}
+                  </Text>
+                ) : (
+                  item.modifierGroups.map((group, groupIndex) => (
+                    <View
+                      key={`${group.name}-${groupIndex}`}
+                      style={{
+                        borderColor: tokens.colors.borderLight,
+                        borderTopWidth: groupIndex ? 1 : 0,
+                        gap: tokens.space.xs,
+                        paddingTop: groupIndex ? tokens.space.sm : 0,
+                      }}
+                    >
+                      <View
+                        style={{
+                          alignItems: 'center',
+                          flexDirection: 'row',
+                          gap: tokens.space.sm,
+                        }}
+                      >
+                        <Text
+                          style={[
+                            tokens.typography.bodyStrong,
+                            { color: tokens.colors.text, flex: 1 },
+                          ]}
+                        >
+                          {group.name}
+                        </Text>
+                        <Pressable
+                          accessibilityLabel={`${copy.remove} ${group.name}`}
+                          accessibilityRole="button"
+                          onPress={() =>
+                            setItem((current) =>
+                              current
+                                ? {
+                                    ...current,
+                                    modifierGroups: current.modifierGroups.filter(
+                                      (_, index) => index !== groupIndex,
+                                    ),
+                                  }
+                                : current,
+                            )
+                          }
+                          style={{ padding: tokens.space.sm }}
+                        >
+                          <Ionicons name="trash-outline" size={20} color={tokens.colors.error} />
+                        </Pressable>
+                      </View>
+                      <Text
+                        style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}
+                      >
+                        {group.selectionType} · {group.isRequired ? copy.required : copy.optional}
+                      </Text>
+                      {group.options.map((option) => (
+                        <Text
+                          key={`${group.name}-${option.name}`}
+                          style={[tokens.typography.body, { color: tokens.colors.text }]}
+                        >
+                          • {option.name}{' '}
+                          {option.priceDeltaMinor
+                            ? `(${option.priceDeltaMinor > 0 ? '+' : ''}${(
+                                option.priceDeltaMinor / 100
+                              ).toFixed(2)} ${currencyCode})`
+                            : ''}
+                        </Text>
+                      ))}
+                    </View>
+                  ))
+                )}
+              </ServiceSurface>
+
+              <ServiceSurface style={{ gap: tokens.space.md }} variant="outlined">
+                <View style={{ flexDirection: 'row', gap: tokens.space.sm }}>
+                  <Ionicons
+                    name="shield-checkmark-outline"
+                    size={24}
+                    color={tokens.colors.warning}
+                  />
+                  <View style={{ flex: 1 }}>
+                    <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+                      {copy.allergens}
+                    </Text>
+                    <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+                      {copy.allergenWarning}
+                    </Text>
+                  </View>
+                </View>
+                {draft.suggestion.allergenSuggestions.length === 0 ? (
+                  <Text style={[tokens.typography.body, { color: tokens.colors.textSubtle }]}>
+                    {copy.noAllergenSuggestion}
+                  </Text>
+                ) : (
+                  draft.suggestion.allergenSuggestions.map((suggestion) => (
+                    <View
+                      key={suggestion.code}
+                      style={{
+                        backgroundColor: tokens.colors.surfaceAlt,
+                        borderRadius: tokens.radius.medium,
+                        gap: tokens.space.xs,
+                        padding: tokens.space.sm,
+                      }}
+                    >
+                      <View
+                        style={{
+                          alignItems: 'center',
+                          flexDirection: 'row',
+                          gap: tokens.space.sm,
+                        }}
+                      >
+                        <Text
+                          style={[
+                            tokens.typography.bodyStrong,
+                            { color: tokens.colors.text, flex: 1 },
+                          ]}
+                        >
+                          {suggestion.code}
+                        </Text>
+                        <ServiceStatusPill
+                          label={
+                            allergens[suggestion.code]
+                              ? copy[allergens[suggestion.code] as AllergenPresence]
+                              : copy.unknown
+                          }
+                          tone={allergens[suggestion.code] ? 'warning' : 'neutral'}
+                        />
+                      </View>
+                      <Text
+                        style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}
+                      >
+                        {suggestion.reason}
+                      </Text>
+                      <View
+                        style={{
+                          flexDirection: 'row',
+                          flexWrap: 'wrap',
+                          gap: tokens.space.xs,
+                        }}
+                      >
+                        {(['contains', 'may_contain', 'free_from'] as const).map((presence) => (
+                          <ChoiceChip
+                            key={presence}
+                            active={allergens[suggestion.code] === presence}
+                            label={copy[presence]}
+                            onPress={() =>
+                              setAllergens((current) => ({
+                                ...current,
+                                [suggestion.code]:
+                                  current[suggestion.code] === presence ? undefined : presence,
+                              }))
+                            }
+                          />
+                        ))}
+                      </View>
+                    </View>
+                  ))
+                )}
+              </ServiceSurface>
+
+              <Pressable
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: reviewConfirmed }}
+                onPress={() => setReviewConfirmed((current) => !current)}
+                style={{
+                  alignItems: 'flex-start',
+                  backgroundColor: tokens.colors.surface,
+                  borderColor: reviewConfirmed ? tokens.colors.primary : tokens.colors.border,
+                  borderRadius: tokens.radius.medium,
+                  borderWidth: 2,
+                  flexDirection: 'row',
+                  gap: tokens.space.sm,
+                  minHeight: tokens.sizing.minimumTarget,
+                  padding: tokens.space.md,
+                }}
+              >
+                <Ionicons
+                  name={reviewConfirmed ? 'checkbox' : 'square-outline'}
+                  size={24}
+                  color={reviewConfirmed ? tokens.colors.primary : tokens.colors.textMuted}
+                />
+                <Text style={[tokens.typography.body, { color: tokens.colors.text, flex: 1 }]}>
+                  {copy.confirmReview}
+                </Text>
+              </Pressable>
+              <ServiceButton
+                disabled={
+                  !reviewConfirmed ||
+                  !item.name.trim() ||
+                  !item.categoryName?.trim() ||
+                  item.priceMinor < 0
+                }
+                fullWidth
+                icon="checkmark-circle-outline"
+                label={copy.publish}
+                loading={publishing}
+                onPress={() => void publish()}
+                size="large"
+              />
+            </>
+          ) : null}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+function SectionTitle({ title }: { readonly title: string }) {
+  const { tokens } = useTheme();
+  return (
+    <Text style={[tokens.typography.sectionTitle, { color: tokens.colors.text }]}>{title}</Text>
+  );
+}
+
+function ChoiceChip({
+  active,
+  label,
+  onPress,
+}: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly onPress: () => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      style={{
+        backgroundColor: active ? tokens.colors.primary : tokens.colors.surface,
+        borderColor: active ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.full,
+        borderWidth: 1,
+        justifyContent: 'center',
+        minHeight: tokens.sizing.minimumTarget,
+        paddingHorizontal: tokens.space.md,
+      }}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: active ? tokens.colors.primaryContrast : tokens.colors.text },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function assistantCopy(language: 'tr' | 'bg' | 'en') {
+  if (language === 'tr') {
+    return {
+      title: 'Menü asistanı',
+      subtitle: 'Bir cümleden düzenlenebilir taslak oluştur.',
+      close: 'Kapat',
+      draftOnly: 'Yalnız taslak',
+      review: 'Onay bekliyor',
+      oneLine: 'Ürünü doğal dille yaz',
+      example: 'Örnek: “Patates kızartması - 4 euro, peynirli seçeneği +1 euro”',
+      prompt: 'Ürün bilgisi',
+      placeholder: 'Ürün, fiyat, seçenek ve kısa not…',
+      generate: 'Taslak oluştur',
+      managerOnly: 'AI menü asistanını yalnız yöneticiler kullanabilir.',
+      onlineOnly: 'AI taslağı için internet bağlantısı gerekli.',
+      promptRequired: 'En az 3 karakter yaz.',
+      unavailable: 'AI şu anda kullanılamıyor',
+      manualUnaffected: 'Normal menü düzenleme çalışmaya devam eder.',
+      reviewChanges: 'Taslağı kontrol et ve düzenle',
+      source: 'Kaynak',
+      product: 'Ürün',
+      name: 'Ad',
+      price: 'Fiyat',
+      category: 'Kategori',
+      description: 'Açıklama',
+      prep: 'Hazırlık süresi (dk)',
+      translations: 'Çeviriler',
+      modifiers: 'Seçenekler',
+      noModifiers: 'AI bu ürün için seçenek önermedi.',
+      remove: 'Kaldır',
+      required: 'zorunlu',
+      optional: 'isteğe bağlı',
+      allergens: 'Alerjen doğrulaması',
+      allergenWarning:
+        'AI önerileri bilinmiyor durumundadır. Reçete veya tedarikçi belgesini görmeden işaretleme.',
+      noAllergenSuggestion: 'Alerjen önerisi yok. Bu, alerjen içermediği anlamına gelmez.',
+      unknown: 'Bilinmiyor',
+      contains: 'İçerir',
+      may_contain: 'İçerebilir',
+      free_from: 'İçermez',
+      confirmReview:
+        'Ürün, fiyat ve seçenekleri kontrol ettim. İşaretlediğim alerjenler için güvenilir kaynağı doğruladım.',
+      publish: 'Onayla ve yayınla',
+      publishFailed: 'Menü ürünü yayınlanamadı.',
+      published: 'Ürün yayınlandı',
+      publishedBody: 'Onaylanan taslak aktif şube menüsüne eklendi.',
+      done: 'Tamam',
+    } as const;
+  }
+  if (language === 'bg') {
+    return {
+      title: 'Меню асистент',
+      subtitle: 'Създайте редактируема чернова от едно изречение.',
+      close: 'Затвори',
+      draftOnly: 'Само чернова',
+      review: 'Чака преглед',
+      oneLine: 'Опишете артикула естествено',
+      example: 'Пример: „Пържени картофи - 4 евро, сирене +1 евро“',
+      prompt: 'Информация за артикула',
+      placeholder: 'Артикул, цена, опции и кратка бележка…',
+      generate: 'Създай чернова',
+      managerOnly: 'Само мениджъри могат да използват AI асистента.',
+      onlineOnly: 'За AI чернова е необходим интернет.',
+      promptRequired: 'Въведете поне 3 знака.',
+      unavailable: 'AI не е достъпен',
+      manualUnaffected: 'Обикновеното редактиране на менюто остава достъпно.',
+      reviewChanges: 'Прегледайте и редактирайте черновата',
+      source: 'Източник',
+      product: 'Артикул',
+      name: 'Име',
+      price: 'Цена',
+      category: 'Категория',
+      description: 'Описание',
+      prep: 'Приготвяне (мин)',
+      translations: 'Преводи',
+      modifiers: 'Опции',
+      noModifiers: 'AI не предложи опции.',
+      remove: 'Премахни',
+      required: 'задължително',
+      optional: 'по избор',
+      allergens: 'Проверка на алергени',
+      allergenWarning:
+        'AI предложенията са неизвестни. Не ги потвърждавайте без рецепта или документ от доставчик.',
+      noAllergenSuggestion: 'Няма предложение. Това не означава, че няма алергени.',
+      unknown: 'Неизвестно',
+      contains: 'Съдържа',
+      may_contain: 'Може да съдържа',
+      free_from: 'Не съдържа',
+      confirmReview:
+        'Проверих артикула, цената и опциите. Потвърдих надежден източник за маркираните алергени.',
+      publish: 'Потвърди и публикувай',
+      publishFailed: 'Артикулът не можа да се публикува.',
+      published: 'Артикулът е публикуван',
+      publishedBody: 'Одобрената чернова е добавена към менюто на обекта.',
+      done: 'Готово',
+    } as const;
+  }
+  return {
+    title: 'Menu assistant',
+    subtitle: 'Turn one sentence into an editable draft.',
+    close: 'Close',
+    draftOnly: 'Draft only',
+    review: 'Needs review',
+    oneLine: 'Describe the item naturally',
+    example: 'Example: “French fries - 4 euro, cheese option +1 euro”',
+    prompt: 'Item details',
+    placeholder: 'Item, price, options, and a short note…',
+    generate: 'Generate draft',
+    managerOnly: 'Only managers can use the AI menu assistant.',
+    onlineOnly: 'An internet connection is required for an AI draft.',
+    promptRequired: 'Enter at least 3 characters.',
+    unavailable: 'AI is unavailable',
+    manualUnaffected: 'Normal menu editing remains available.',
+    reviewChanges: 'Review and edit the draft',
+    source: 'Source',
+    product: 'Item',
+    name: 'Name',
+    price: 'Price',
+    category: 'Category',
+    description: 'Description',
+    prep: 'Prep time (min)',
+    translations: 'Translations',
+    modifiers: 'Options',
+    noModifiers: 'AI did not suggest options for this item.',
+    remove: 'Remove',
+    required: 'required',
+    optional: 'optional',
+    allergens: 'Allergen verification',
+    allergenWarning:
+      'AI suggestions remain unknown. Do not confirm them without a recipe or supplier document.',
+    noAllergenSuggestion: 'No suggestion. This does not mean the item is allergen-free.',
+    unknown: 'Unknown',
+    contains: 'Contains',
+    may_contain: 'May contain',
+    free_from: 'Free from',
+    confirmReview:
+      'I checked the item, price, and options. I verified a reliable source for every marked allergen.',
+    publish: 'Approve and publish',
+    publishFailed: 'The menu item could not be published.',
+    published: 'Item published',
+    publishedBody: 'The approved draft was added to the active branch menu.',
+    done: 'Done',
+  } as const;
+}

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -1,521 +1,623 @@
-import React, { useState, useRef } from 'react';
-import { View, Text, FlatList, TouchableOpacity, Alert, ScrollView, TextInput } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
-import BottomSheet from '@gorhom/bottom-sheet';
-
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Pressable, RefreshControl, ScrollView, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../contexts/AuthContext';
 import { useTheme } from '../contexts/ThemeContext';
-import { useLocalization } from '../i18n';
-import { useMenuStore } from '../stores';
+import { useOrderiaData } from '../data/runtime';
 import {
-  PrimaryButton,
-  SurfaceCard,
-  ActionSheet,
-  ActionSheetAction,
-  ProductSearch,
-} from '../components';
+  ServiceButton,
+  ServiceEmptyState,
+  ServiceSkeleton,
+  ServiceStatusPill,
+  ServiceSurface,
+  ServiceTextField,
+  useAdaptiveLayout,
+} from '../design-system';
+import { CurrencyCode, MenuCategoryId, MenuItemId, toDomainId } from '../domain';
+import { CatalogItem, CatalogSnapshot } from '../features/menu-management';
+import { useLocalization } from '../i18n';
 import { RootStackParamList } from '../navigation/AppNavigator';
-import { Category, MenuItem } from '../types';
-import { useDebounceSearch, searchMenuItems } from '../utils/searchUtils';
+import { useMenuStore } from '../stores';
 
-type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+type Navigation = NativeStackNavigationProp<RootStackParamList>;
 
 export default function MenuScreen() {
-  const navigation = useNavigation<NavigationProp>();
-  const { colors } = useTheme();
-  const { t, formatPrice } = useLocalization();
+  const navigation = useNavigation<Navigation>();
+  const auth = useAuth();
+  const { tokens } = useTheme();
+  const { language } = useLocalization();
+  const layout = useAdaptiveLayout();
+  const { loadCatalog, mode, revision, setCatalogAvailability, sync } = useOrderiaData();
+  const legacy = useMenuStore();
+  const copy = menuCopy(language);
+  const [catalog, setCatalog] = useState<CatalogSnapshot>();
+  const [selectedCategoryId, setSelectedCategoryId] = useState<MenuCategoryId>();
+  const [selectedItemIds, setSelectedItemIds] = useState<readonly MenuItemId[]>([]);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(mode === 'cloud');
+  const [refreshing, setRefreshing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string>();
+  const isManager = auth.activeMembership?.role === 'manager' || auth.status === 'unconfigured';
 
-  const {
-    categories,
-    menuItems,
-    addCategory,
-    updateMenuItem,
-    deleteMenuItem,
-    deleteCategory,
-    toggleMenuItemActive,
-    getCategoriesWithItems,
-  } = useMenuStore();
-
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
-    categories.length > 0 ? categories[0].id : null,
+  const localCatalog = useMemo(
+    () =>
+      legacySnapshot(
+        legacy.categories,
+        legacy.menuItems,
+        auth.activeBranch?.organization_id,
+        auth.activeBranch?.id,
+        (auth.activeBranch?.currency_code ?? 'EUR') as CurrencyCode,
+      ),
+    [
+      auth.activeBranch?.currency_code,
+      auth.activeBranch?.id,
+      auth.activeBranch?.organization_id,
+      legacy.categories,
+      legacy.menuItems,
+    ],
   );
+  const displayedCatalog = catalog ?? localCatalog;
 
-  // Use debounced search for better performance
-  const { searchQuery, setSearchQuery, debouncedQuery } = useDebounceSearch('', 300);
-
-  // Product search modal state
-  const [showProductSearch, setShowProductSearch] = useState(false);
-
-  // Action sheet for menu items
-  const [selectedMenuItem, setSelectedMenuItem] = useState<MenuItem | null>(null);
-  const [showItemActions, setShowItemActions] = useState(false);
-  const actionSheetRef = useRef<BottomSheet>(null);
-
-  // Action sheet for categories
-  const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
-  const [showCategoryActions, setShowCategoryActions] = useState(false);
-  const categoryActionSheetRef = useRef<BottomSheet>(null);
-
-  const handleAddCategory = () => {
-    navigation.navigate('AddCategory', {});
-  };
-
-  const handleEditCategory = (categoryId: string) => {
-    navigation.navigate('AddCategory', { categoryId });
-  };
-
-  const handleDeleteCategory = (category: Category) => {
-    const itemCount = menuItems.filter((item) => item.categoryId === category.id).length;
-    const confirmMessage =
-      itemCount > 0
-        ? `${t.deleteCategoryConfirm} Bu kategoride ${itemCount} ürün var ve hepsi silinecek.`
-        : t.deleteCategoryConfirm;
-
-    Alert.alert(t.deleteCategory, confirmMessage, [
-      { text: t.cancel, style: 'cancel' },
-      {
-        text: t.delete,
-        style: 'destructive',
-        onPress: () => {
-          deleteCategory(category.id);
-          Alert.alert(t.success, t.categoryDeleted);
-          // If we just deleted the selected category, reset selection
-          if (selectedCategoryId === category.id) {
-            setSelectedCategoryId(
-              categories.length > 1
-                ? categories.find((c) => c.id !== category.id)?.id || null
-                : null,
-            );
-          }
-        },
-      },
-    ]);
-  };
-
-  const handleAddMenuItem = () => {
-    if (!selectedCategoryId) {
-      Alert.alert(t.error, t.selectCategoryFirst);
+  const refreshCatalog = useCallback(async () => {
+    if (mode !== 'cloud') {
+      setCatalog(undefined);
+      setLoading(false);
+      setRefreshing(false);
       return;
     }
-    navigation.navigate('AddMenuItem', { categoryId: selectedCategoryId });
-  };
+    try {
+      const next = await loadCatalog();
+      setCatalog(next);
+      setError(undefined);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : copy.loadFailed);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [copy.loadFailed, loadCatalog, mode]);
 
-  const handleDeleteMenuItem = (item: MenuItem) => {
-    Alert.alert(t.deleteItem, `"${item.name}" ${t.deleteItemConfirm}`, [
-      { text: t.cancel, style: 'cancel' },
-      {
-        text: t.delete,
-        style: 'destructive',
-        onPress: () => deleteMenuItem(item.id),
-      },
-    ]);
-  };
-
-  const handleEditMenuItem = (menuItem: MenuItem) => {
-    navigation.navigate('AddMenuItem', { categoryId: menuItem.categoryId, itemId: menuItem.id });
-    setShowItemActions(false);
-  };
-
-  const handleToggleItemStatus = (menuItem: MenuItem) => {
-    updateMenuItem(menuItem.id, { isActive: !menuItem.isActive });
-    setShowItemActions(false);
-  };
-
-  const handleItemLongPress = (menuItem: MenuItem) => {
-    setSelectedMenuItem(menuItem);
-    setShowItemActions(true);
-  };
-
-  const handleCategoryLongPress = (category: Category) => {
-    setSelectedCategory(category);
-    setShowCategoryActions(true);
-  };
-
-  // Define action sheet actions for menu items
-  const getItemActions = (menuItem: MenuItem): ActionSheetAction[] => [
-    {
-      id: 'edit',
-      title: t.edit || 'Edit',
-      icon: 'pencil',
-      onPress: () => handleEditMenuItem(menuItem),
-    },
-    {
-      id: 'toggle',
-      title: menuItem.isActive ? 'Deactivate' : 'Activate',
-      icon: menuItem.isActive ? 'eye-off' : 'eye',
-      onPress: () => handleToggleItemStatus(menuItem),
-    },
-    {
-      id: 'delete',
-      title: t.delete || 'Delete',
-      icon: 'trash',
-      destructive: true,
-      onPress: () => handleDeleteMenuItem(menuItem),
-    },
-  ];
-
-  // Define action sheet actions for categories
-  const getCategoryActions = (category: Category): ActionSheetAction[] => [
-    {
-      id: 'edit',
-      title: t.edit || 'Edit',
-      icon: 'pencil',
-      onPress: () => {
-        handleEditCategory(category.id);
-        setShowCategoryActions(false);
-      },
-    },
-    {
-      id: 'delete',
-      title: t.delete || 'Delete',
-      icon: 'trash',
-      destructive: true,
-      onPress: () => {
-        handleDeleteCategory(category);
-        setShowCategoryActions(false);
-      },
-    },
-  ];
-
-  // Use improved search with debouncing
-  const filteredMenuItems = searchMenuItems(
-    menuItems,
-    debouncedQuery,
-    selectedCategoryId || undefined,
+  useFocusEffect(
+    useCallback(() => {
+      void refreshCatalog();
+    }, [refreshCatalog]),
   );
+  useEffect(() => {
+    if (revision > 0) void refreshCatalog();
+  }, [refreshCatalog, revision]);
 
-  const renderCategoryTab = (category: Category) => {
-    const isSelected = selectedCategoryId === category.id;
-    const itemCount = menuItems.filter((item) => item.categoryId === category.id).length;
+  const duplicateIds = useMemo(
+    () => findDuplicateIds(displayedCatalog.items),
+    [displayedCatalog.items],
+  );
+  const visibleItems = useMemo(() => {
+    const normalizedQuery = normalize(query);
+    return displayedCatalog.items.filter(
+      (item) =>
+        (!selectedCategoryId || item.categoryId === selectedCategoryId) &&
+        (!normalizedQuery ||
+          normalize(item.name).includes(normalizedQuery) ||
+          normalize(item.description ?? '').includes(normalizedQuery)),
+    );
+  }, [displayedCatalog.items, query, selectedCategoryId]);
 
-    return (
-      <View key={category.id} style={{ marginRight: 8, position: 'relative' }}>
-        <TouchableOpacity
-          onPress={() => {
-            setSelectedCategoryId(category.id);
-          }}
-          onLongPress={() => handleCategoryLongPress(category)}
-          style={{
-            paddingHorizontal: 16,
-            paddingVertical: 20,
-            borderRadius: 20,
-            backgroundColor: isSelected ? colors.primary : colors.surfaceAlt,
-            borderWidth: 1,
-            borderColor: isSelected ? colors.primary : colors.border,
-          }}
-        >
-          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <Text
-              style={{
-                color: isSelected ? '#FFFFFF' : colors.text,
-                fontWeight: isSelected ? '600' : '400',
-                fontSize: 14,
-              }}
-            >
-              {category.name}
-            </Text>
-            {itemCount > 0 && (
-              <View
-                style={{
-                  backgroundColor: isSelected ? '#FFFFFF' : colors.primary,
-                  borderRadius: 10,
-                  minWidth: 18,
-                  height: 18,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  marginLeft: 6,
-                }}
-              >
-                <Text
-                  style={{
-                    color: isSelected ? colors.primary : '#FFFFFF',
-                    fontSize: 10,
-                    fontWeight: '600',
-                  }}
-                >
-                  {itemCount}
-                </Text>
-              </View>
-            )}
-          </View>
-        </TouchableOpacity>
-      </View>
+  const toggleSelection = (itemId: MenuItemId) => {
+    if (!isManager || mode !== 'cloud') return;
+    setSelectedItemIds((current) =>
+      current.includes(itemId)
+        ? current.filter((selectedId) => selectedId !== itemId)
+        : [...current, itemId],
     );
   };
 
-  const renderMenuItem = ({ item }: { item: MenuItem }) => {
-    return (
-      <TouchableOpacity onLongPress={() => handleItemLongPress(item)} activeOpacity={0.7}>
-        <SurfaceCard style={{ marginBottom: 8 }} variant="outlined">
-          <View
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-            }}
-          >
-            <View style={{ flex: 1, marginRight: 12 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 2 }}>
-                <Text
-                  style={{
-                    fontSize: 16,
-                    fontWeight: '600',
-                    color: item.isActive ? colors.text : colors.textSubtle,
-                    textDecorationLine: item.isActive ? 'none' : 'line-through',
-                    flex: 1,
-                  }}
-                >
-                  {item.name}
-                </Text>
-                {!item.isActive && (
-                  <View
-                    style={{
-                      backgroundColor: colors.textSubtle + '20',
-                      paddingHorizontal: 6,
-                      paddingVertical: 2,
-                      borderRadius: 4,
-                      marginLeft: 8,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        fontSize: 10,
-                        color: colors.textSubtle,
-                        fontWeight: '600',
-                      }}
-                    >
-                      INACTIVE
-                    </Text>
-                  </View>
-                )}
-              </View>
-
-              {item.description && (
-                <Text
-                  style={{
-                    fontSize: 14,
-                    color: colors.textSubtle,
-                    marginBottom: 4,
-                  }}
-                >
-                  {item.description}
-                </Text>
-              )}
-
-              <Text
-                style={{
-                  fontSize: 18,
-                  fontWeight: '700',
-                  color: colors.primary,
-                }}
-              >
-                {formatPrice(item.price)}
-              </Text>
-            </View>
-
-            <View style={{ alignItems: 'center' }}>
-              <Ionicons name="ellipsis-vertical" size={20} color={colors.textSubtle} />
-              <Text
-                style={{
-                  fontSize: 10,
-                  color: colors.textSubtle,
-                  marginTop: 2,
-                }}
-              >
-                Hold
-              </Text>
-            </View>
-          </View>
-        </SurfaceCard>
-      </TouchableOpacity>
-    );
+  const applyAvailability = async (isAvailable: boolean) => {
+    if (!selectedItemIds.length) return;
+    setSaving(true);
+    try {
+      await setCatalogAvailability(selectedItemIds, isAvailable);
+      setSelectedItemIds([]);
+      await refreshCatalog();
+    } catch (saveError) {
+      Alert.alert(
+        copy.updateFailed,
+        saveError instanceof Error ? saveError.message : copy.tryAgain,
+      );
+    } finally {
+      setSaving(false);
+    }
   };
 
   return (
     <SafeAreaView
-      style={{ flex: 1, backgroundColor: colors.bg }}
-      edges={['bottom', 'left', 'right']}
+      edges={['top', 'left', 'right']}
+      style={{ backgroundColor: tokens.colors.bg, flex: 1 }}
     >
-      <View style={{ flex: 1 }}>
-        {/* Search Bar */}
-        <View style={{ padding: 16, paddingBottom: 8, backgroundColor: colors.bg }}>
+      <ScrollView
+        contentContainerStyle={{
+          alignSelf: 'center',
+          gap: tokens.space.lg,
+          maxWidth: tokens.sizing.contentMaximumWidth,
+          paddingBottom: tokens.space.xxl,
+          paddingHorizontal: layout.horizontalPadding,
+          paddingTop: tokens.space.lg,
+          width: '100%',
+        }}
+        refreshControl={
+          <RefreshControl
+            onRefresh={() => {
+              setRefreshing(true);
+              void refreshCatalog();
+            }}
+            refreshing={refreshing}
+            tintColor={tokens.colors.primary}
+          />
+        }
+      >
+        <View
+          style={{
+            alignItems: layout.mode === 'compact' ? 'stretch' : 'center',
+            flexDirection: layout.mode === 'compact' ? 'column' : 'row',
+            gap: tokens.space.md,
+            justifyContent: 'space-between',
+          }}
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={[tokens.typography.title, { color: tokens.colors.text }]}>
+              {copy.title}
+            </Text>
+            <Text
+              style={[
+                tokens.typography.body,
+                { color: tokens.colors.textSubtle, marginTop: tokens.space.xs },
+              ]}
+            >
+              {isManager ? copy.managerSubtitle : copy.waiterSubtitle}
+            </Text>
+          </View>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+            <ServiceStatusPill
+              icon={sync.online ? 'cloud-done-outline' : 'cloud-offline-outline'}
+              label={mode === 'cloud' ? copy.cloudCatalog : copy.deviceCatalog}
+              tone={mode === 'cloud' && sync.online ? 'success' : 'neutral'}
+            />
+            {isManager ? (
+              <ServiceButton
+                disabled={mode !== 'cloud' || !sync.online}
+                icon="sparkles"
+                label={copy.aiAssistant}
+                onPress={() => navigation.navigate('MenuAssistant')}
+                variant="accent"
+              />
+            ) : null}
+          </View>
+        </View>
+
+        <ServiceTextField
+          label={copy.search}
+          onChangeText={setQuery}
+          placeholder={copy.searchPlaceholder}
+          value={query}
+        />
+
+        <ScrollView
+          horizontal
+          contentContainerStyle={{ gap: tokens.space.xs }}
+          showsHorizontalScrollIndicator={false}
+        >
+          <CategoryChip
+            active={!selectedCategoryId}
+            label={`${copy.all} · ${displayedCatalog.items.length}`}
+            onPress={() => setSelectedCategoryId(undefined)}
+          />
+          {displayedCatalog.categories.map((category) => (
+            <CategoryChip
+              key={category.id}
+              active={selectedCategoryId === category.id}
+              label={`${category.name} · ${
+                displayedCatalog.items.filter((item) => item.categoryId === category.id).length
+              }`}
+              onPress={() => setSelectedCategoryId(category.id)}
+            />
+          ))}
+        </ScrollView>
+
+        {selectedItemIds.length > 0 ? (
+          <ServiceSurface
+            style={{
+              alignItems: layout.mode === 'compact' ? 'stretch' : 'center',
+              flexDirection: layout.mode === 'compact' ? 'column' : 'row',
+              gap: tokens.space.sm,
+            }}
+            variant="raised"
+          >
+            <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text, flex: 1 }]}>
+              {selectedItemIds.length} {copy.selected}
+            </Text>
+            <ServiceButton
+              disabled={saving}
+              icon="eye-outline"
+              label={copy.makeAvailable}
+              onPress={() => void applyAvailability(true)}
+              variant="outline"
+            />
+            <ServiceButton
+              disabled={saving}
+              icon="eye-off-outline"
+              label={copy.markSoldOut}
+              onPress={() => void applyAvailability(false)}
+              variant="danger"
+            />
+          </ServiceSurface>
+        ) : null}
+
+        {error ? (
+          <ServiceSurface
+            style={{ borderColor: tokens.colors.warning, gap: tokens.space.xs }}
+            variant="outlined"
+          >
+            <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.warning }]}>
+              {copy.cachedCatalog}
+            </Text>
+            <Text style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}>
+              {error}
+            </Text>
+          </ServiceSurface>
+        ) : null}
+
+        {loading && !catalog ? (
+          <View style={{ gap: tokens.space.sm }}>
+            {[0, 1, 2].map((index) => (
+              <ServiceSkeleton key={index} height={112} />
+            ))}
+          </View>
+        ) : visibleItems.length === 0 ? (
+          <ServiceEmptyState
+            action={
+              isManager
+                ? {
+                    label: copy.addManually,
+                    onPress: () => navigation.navigate('AddMenuItem', {}),
+                  }
+                : undefined
+            }
+            body={query ? copy.noSearchResult : copy.emptyBody}
+            icon="restaurant-outline"
+            title={query ? copy.noResult : copy.emptyTitle}
+          />
+        ) : (
           <View
             style={{
               flexDirection: 'row',
-              backgroundColor: colors.surfaceAlt,
-              borderRadius: 8,
-              paddingHorizontal: 12,
-              alignItems: 'center',
+              flexWrap: 'wrap',
+              gap: tokens.space.sm,
             }}
           >
-            <Ionicons name="search" size={20} color={colors.textSubtle} />
-            <TextInput
-              style={{
-                flex: 1,
-                paddingVertical: 12,
-                paddingHorizontal: 8,
-                fontSize: 16,
-                color: colors.text,
-              }}
-              placeholder={t.searchItems}
-              placeholderTextColor={colors.textSubtle}
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-              autoCorrect={false}
-              autoCapitalize="none"
-            />
-            {searchQuery.length > 0 && (
-              <TouchableOpacity
-                onPress={() => setSearchQuery('')}
-                style={{
-                  padding: 4,
-                  marginLeft: 4,
-                  borderRadius: 12,
-                  backgroundColor: colors.textSubtle + '20',
-                }}
-              >
-                <Ionicons name="close" size={16} color={colors.textSubtle} />
-              </TouchableOpacity>
-            )}
-          </View>
-        </View>
-
-        {/* Category Tabs */}
-        <View style={{ paddingHorizontal: 16, paddingBottom: 8 }}>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingRight: 16 }}
-          >
-            {categories.map(renderCategoryTab)}
-            <TouchableOpacity
-              onPress={handleAddCategory}
-              style={{
-                paddingHorizontal: 16,
-                paddingVertical: 8,
-                borderRadius: 20,
-                backgroundColor: colors.surfaceAlt,
-                borderWidth: 1,
-                borderColor: colors.border,
-                borderStyle: 'dashed',
-                flexDirection: 'row',
-                alignItems: 'center',
-              }}
-            >
-              <Ionicons name="add" size={16} color={colors.textSubtle} />
-              <Text
-                style={{
-                  color: colors.textSubtle,
-                  fontSize: 14,
-                  marginLeft: 4,
-                }}
-              >
-                {t.addCategory}
-              </Text>
-            </TouchableOpacity>
-          </ScrollView>
-        </View>
-
-        {/* Menu Items */}
-        <View style={{ flex: 1, paddingHorizontal: 16 }}>
-          {categories.length === 0 ? (
-            <SurfaceCard style={{ padding: 32 }}>
-              <Text
-                style={{
-                  textAlign: 'center',
-                  color: colors.textSubtle,
-                  fontSize: 16,
-                  marginBottom: 16,
-                }}
-              >
-                {t.noCategoriesYet}
-              </Text>
-              <PrimaryButton title={t.addFirstCategory} onPress={handleAddCategory} fullWidth />
-            </SurfaceCard>
-          ) : filteredMenuItems.length === 0 ? (
-            <SurfaceCard style={{ padding: 32 }}>
-              <View style={{ alignItems: 'center' }}>
-                <Ionicons
-                  name={debouncedQuery ? 'search' : 'restaurant-outline'}
-                  size={48}
-                  color={colors.textSubtle}
-                  style={{ marginBottom: 16 }}
-                />
-                <Text
-                  style={{
-                    textAlign: 'center',
-                    color: colors.textSubtle,
-                    fontSize: 16,
-                    marginBottom: 8,
-                  }}
-                >
-                  {debouncedQuery ? t.noItemsFound : t.noCategoryItems}
-                </Text>
-                {debouncedQuery ? (
-                  <Text
-                    style={{
-                      textAlign: 'center',
-                      color: colors.textSubtle,
-                      fontSize: 14,
-                      fontStyle: 'italic',
-                    }}
-                  >
-                    Try adjusting your search query
-                  </Text>
-                ) : (
-                  <PrimaryButton title={t.addFirstItem} onPress={handleAddMenuItem} fullWidth />
-                )}
-              </View>
-            </SurfaceCard>
-          ) : (
-            <FlatList
-              data={filteredMenuItems}
-              renderItem={renderMenuItem}
-              keyExtractor={(item) => item.id}
-              showsVerticalScrollIndicator={false}
-            />
-          )}
-        </View>
-
-        {/* Add Menu Item Button */}
-        {categories.length > 0 && (
-          <View style={{ padding: 16, paddingTop: 8 }}>
-            <PrimaryButton title={t.addNewItem} onPress={handleAddMenuItem} fullWidth />
+            {visibleItems.map((item) => (
+              <CatalogItemCard
+                key={item.id}
+                duplicate={duplicateIds.has(item.id)}
+                editable={isManager && !item.isOrganizationWide}
+                item={item}
+                managerSelectable={isManager && mode === 'cloud' && !item.isOrganizationWide}
+                onLongPress={() =>
+                  navigation.navigate('AddMenuItem', {
+                    categoryId: item.categoryId,
+                    itemId: item.id,
+                  })
+                }
+                onPress={() => toggleSelection(item.id)}
+                selected={selectedItemIds.includes(item.id)}
+                width={
+                  layout.mode === 'expanded' ? '32%' : layout.mode === 'medium' ? '48%' : '100%'
+                }
+              />
+            ))}
           </View>
         )}
-      </View>
 
-      {/* Action Sheet for Menu Items */}
-      {selectedMenuItem && (
-        <ActionSheet
-          ref={actionSheetRef}
-          title={selectedMenuItem.name}
-          subtitle={`Actions for this menu item`}
-          actions={getItemActions(selectedMenuItem)}
-          isVisible={showItemActions}
-          onClose={() => {
-            setShowItemActions(false);
-            setSelectedMenuItem(null);
-          }}
-        />
-      )}
-
-      {/* Action Sheet for Categories */}
-      {selectedCategory && (
-        <ActionSheet
-          ref={categoryActionSheetRef}
-          title={selectedCategory.name}
-          subtitle={`Actions for this category`}
-          actions={getCategoryActions(selectedCategory)}
-          isVisible={showCategoryActions}
-          onClose={() => {
-            setShowCategoryActions(false);
-            setSelectedCategory(null);
-          }}
-        />
-      )}
+        {isManager ? (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.sm }}>
+            <ServiceButton
+              icon="add-outline"
+              label={copy.addManually}
+              onPress={() => navigation.navigate('AddMenuItem', {})}
+              size="large"
+              variant="outline"
+            />
+            <Text
+              style={[
+                tokens.typography.caption,
+                { color: tokens.colors.textSubtle, flexBasis: 260, flexGrow: 1 },
+              ]}
+            >
+              {copy.aiBoundary}
+            </Text>
+          </View>
+        ) : null}
+      </ScrollView>
     </SafeAreaView>
   );
+}
+
+function CatalogItemCard({
+  duplicate,
+  editable,
+  item,
+  managerSelectable,
+  onLongPress,
+  onPress,
+  selected,
+  width,
+}: {
+  readonly duplicate: boolean;
+  readonly editable: boolean;
+  readonly item: CatalogItem;
+  readonly managerSelectable: boolean;
+  readonly onLongPress: () => void;
+  readonly onPress: () => void;
+  readonly selected: boolean;
+  readonly width: `${number}%`;
+}) {
+  const { tokens } = useTheme();
+  const { language } = useLocalization();
+  const copy = menuCopy(language);
+  return (
+    <Pressable
+      accessibilityRole={managerSelectable ? 'checkbox' : editable ? 'button' : 'text'}
+      accessibilityState={managerSelectable ? { checked: selected } : undefined}
+      disabled={!managerSelectable && !editable}
+      onLongPress={editable ? onLongPress : undefined}
+      onPress={managerSelectable ? onPress : undefined}
+      style={{ flexBasis: width, flexGrow: 1, minWidth: 280 }}
+    >
+      <ServiceSurface
+        style={{
+          borderColor: selected ? tokens.colors.primary : tokens.colors.border,
+          borderWidth: selected ? 2 : 1,
+          gap: tokens.space.sm,
+          minHeight: tokens.sizing.tableCardMinimumHeight,
+        }}
+        variant="outlined"
+      >
+        <View style={{ alignItems: 'flex-start', flexDirection: 'row', gap: tokens.space.sm }}>
+          <View style={{ flex: 1 }}>
+            <Text style={[tokens.typography.subtitle, { color: tokens.colors.text }]}>
+              {item.name}
+            </Text>
+            {item.description ? (
+              <Text
+                numberOfLines={2}
+                style={[tokens.typography.caption, { color: tokens.colors.textSubtle }]}
+              >
+                {item.description}
+              </Text>
+            ) : null}
+          </View>
+          <Text style={[tokens.typography.bodyStrong, { color: tokens.colors.text }]}>
+            {(item.priceMinor / 100).toFixed(2)} {item.currencyCode}
+          </Text>
+          {managerSelectable ? (
+            <Ionicons
+              name={selected ? 'checkbox' : 'square-outline'}
+              size={24}
+              color={selected ? tokens.colors.primary : tokens.colors.textMuted}
+            />
+          ) : null}
+        </View>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: tokens.space.xs }}>
+          <ServiceStatusPill
+            label={item.isAvailable ? copy.available : copy.soldOut}
+            tone={item.isAvailable ? 'success' : 'error'}
+          />
+          {item.modifierGroups.length > 0 ? (
+            <ServiceStatusPill
+              label={`${item.modifierGroups.length} ${copy.optionGroup}`}
+              tone="info"
+            />
+          ) : null}
+          {item.isOrganizationWide ? (
+            <ServiceStatusPill label={copy.sharedItem} tone="neutral" />
+          ) : null}
+          {duplicate ? <ServiceStatusPill label={copy.possibleDuplicate} tone="warning" /> : null}
+        </View>
+      </ServiceSurface>
+    </Pressable>
+  );
+}
+
+function CategoryChip({
+  active,
+  label,
+  onPress,
+}: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly onPress: () => void;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      onPress={onPress}
+      style={{
+        backgroundColor: active ? tokens.colors.primary : tokens.colors.surface,
+        borderColor: active ? tokens.colors.primary : tokens.colors.border,
+        borderRadius: tokens.radius.full,
+        borderWidth: 1,
+        justifyContent: 'center',
+        minHeight: tokens.sizing.minimumTarget,
+        paddingHorizontal: tokens.space.md,
+      }}
+    >
+      <Text
+        style={[
+          tokens.typography.label,
+          { color: active ? tokens.colors.primaryContrast : tokens.colors.text },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function legacySnapshot(
+  categories: readonly { id: string; name: string; order: number }[],
+  items: readonly {
+    id: string;
+    categoryId: string;
+    name: string;
+    description?: string;
+    price: number;
+    isActive: boolean;
+  }[],
+  organizationId?: string,
+  branchId?: string,
+  currencyCode: CurrencyCode = 'EUR' as CurrencyCode,
+): CatalogSnapshot {
+  return {
+    organizationId: toDomainId(organizationId ?? 'local-organization'),
+    branchId: toDomainId(branchId ?? 'local-branch'),
+    categories: categories.map((category) => ({
+      id: toDomainId<MenuCategoryId>(category.id),
+      name: category.name,
+      sortOrder: category.order,
+      isActive: true,
+    })),
+    items: items.map((item) => ({
+      id: toDomainId<MenuItemId>(item.id),
+      categoryId: toDomainId<MenuCategoryId>(item.categoryId),
+      name: item.name,
+      ...(item.description ? { description: item.description } : {}),
+      priceMinor: item.price,
+      currencyCode,
+      taxRateBasisPoints: 0,
+      isActive: item.isActive,
+      isAvailable: item.isActive,
+      isOrganizationWide: false,
+      version: 1,
+      translations: [],
+      modifierGroups: [],
+    })),
+  };
+}
+
+function findDuplicateIds(items: readonly CatalogItem[]): ReadonlySet<MenuItemId> {
+  const groups = new Map<string, MenuItemId[]>();
+  for (const item of items) {
+    const key = `${item.categoryId}:${normalize(item.name)}`;
+    groups.set(key, [...(groups.get(key) ?? []), item.id]);
+  }
+  return new Set(
+    [...groups.values()].filter((group) => group.length > 1).flatMap((group) => group),
+  );
+}
+
+function normalize(value: string): string {
+  return value
+    .trim()
+    .toLocaleLowerCase('tr')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+function menuCopy(language: 'tr' | 'bg' | 'en') {
+  if (language === 'tr') {
+    return {
+      title: 'Menü merkezi',
+      managerSubtitle: 'Ürünleri, seçenekleri ve şube müsaitliğini tek yerden yönet.',
+      waiterSubtitle: 'Serviste kullanılabilen ürünleri ve seçenekleri gör.',
+      cloudCatalog: 'Bulut menü',
+      deviceCatalog: 'Cihaz menüsü',
+      aiAssistant: 'AI ile ürün ekle',
+      search: 'Menüde ara',
+      searchPlaceholder: 'Ürün veya açıklama…',
+      all: 'Tümü',
+      selected: 'ürün seçili',
+      makeAvailable: 'Satışa aç',
+      markSoldOut: 'Tükendi yap',
+      cachedCatalog: 'Son menü gösteriliyor',
+      loadFailed: 'Bulut menü yüklenemedi.',
+      updateFailed: 'Menü güncellenemedi',
+      tryAgain: 'Tekrar deneyin.',
+      addManually: 'Elle ürün ekle',
+      noSearchResult: 'Aramana uyan ürün bulunamadı.',
+      emptyBody: 'İlk ürünü elle veya AI taslağıyla ekleyebilirsin.',
+      noResult: 'Sonuç yok',
+      emptyTitle: 'Menü henüz boş',
+      available: 'Satışta',
+      soldOut: 'Tükendi',
+      optionGroup: 'seçenek grubu',
+      possibleDuplicate: 'Olası tekrar',
+      sharedItem: 'Tüm şubeler',
+      aiBoundary:
+        'AI yalnız taslak hazırlar. Yönetici kontrol edip onaylamadan hiçbir ürün yayınlanmaz.',
+    } as const;
+  }
+  if (language === 'bg') {
+    return {
+      title: 'Меню център',
+      managerSubtitle: 'Управлявайте артикули, опции и наличност на обекта.',
+      waiterSubtitle: 'Вижте наличните артикули и опции за обслужване.',
+      cloudCatalog: 'Облачно меню',
+      deviceCatalog: 'Меню на устройството',
+      aiAssistant: 'Добави с AI',
+      search: 'Търсене в менюто',
+      searchPlaceholder: 'Артикул или описание…',
+      all: 'Всички',
+      selected: 'избрани',
+      makeAvailable: 'В продажба',
+      markSoldOut: 'Изчерпано',
+      cachedCatalog: 'Показва се последното меню',
+      loadFailed: 'Облачното меню не се зареди.',
+      updateFailed: 'Менюто не се обнови',
+      tryAgain: 'Опитайте отново.',
+      addManually: 'Добави ръчно',
+      noSearchResult: 'Няма съвпадащи артикули.',
+      emptyBody: 'Добавете първия артикул ръчно или с AI чернова.',
+      noResult: 'Няма резултат',
+      emptyTitle: 'Менюто е празно',
+      available: 'Налично',
+      soldOut: 'Изчерпано',
+      optionGroup: 'групи опции',
+      possibleDuplicate: 'Възможен дубликат',
+      sharedItem: 'Всички обекти',
+      aiBoundary: 'AI създава само чернова. Нищо не се публикува без преглед от мениджър.',
+    } as const;
+  }
+  return {
+    title: 'Menu hub',
+    managerSubtitle: 'Manage items, options, and branch availability in one place.',
+    waiterSubtitle: 'See the items and options available during service.',
+    cloudCatalog: 'Cloud catalog',
+    deviceCatalog: 'Device catalog',
+    aiAssistant: 'Add with AI',
+    search: 'Search menu',
+    searchPlaceholder: 'Item or description…',
+    all: 'All',
+    selected: 'items selected',
+    makeAvailable: 'Make available',
+    markSoldOut: 'Mark sold out',
+    cachedCatalog: 'Showing the last menu',
+    loadFailed: 'The cloud catalog could not be loaded.',
+    updateFailed: 'Menu update failed',
+    tryAgain: 'Try again.',
+    addManually: 'Add manually',
+    noSearchResult: 'No items match your search.',
+    emptyBody: 'Add the first item manually or with an AI draft.',
+    noResult: 'No results',
+    emptyTitle: 'The menu is empty',
+    available: 'Available',
+    soldOut: 'Sold out',
+    optionGroup: 'option groups',
+    possibleDuplicate: 'Possible duplicate',
+    sharedItem: 'All branches',
+    aiBoundary: 'AI creates a draft only. Nothing is published without manager review.',
+  } as const;
 }

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -1,5 +1,6 @@
 export { default as TablesScreen } from './TablesScreen';
 export { default as MenuScreen } from './MenuScreen';
+export { default as MenuAssistantScreen } from './MenuAssistantScreen';
 export { default as HistoryScreen } from './HistoryScreen';
 export { default as SettingsScreen } from './SettingsScreen';
 export { default as TableDetailScreen } from './TableDetailScreen';

--- a/src/services/supabase/database.types.ts
+++ b/src/services/supabase/database.types.ts
@@ -112,6 +112,106 @@ export type ReceiptArchiveRow = {
   has_adjustment: boolean;
 };
 
+export type MenuCategoryRow = {
+  id: string;
+  organization_id: string;
+  branch_id: string | null;
+  name: string;
+  sort_order: number;
+  is_active: boolean;
+  version: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type MenuItemRow = {
+  id: string;
+  organization_id: string;
+  branch_id: string | null;
+  category_id: string;
+  name: string;
+  description: string | null;
+  price_minor: number;
+  currency_code: string;
+  tax_rate_basis_points: number;
+  is_active: boolean;
+  is_available: boolean;
+  prep_time_minutes: number | null;
+  version: number;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type ModifierGroupRow = {
+  id: string;
+  organization_id: string;
+  branch_id: string | null;
+  menu_item_id: string;
+  name: string;
+  selection_type: 'single' | 'multiple';
+  minimum_choices: number;
+  maximum_choices: number | null;
+  is_required: boolean;
+  sort_order: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type ModifierOptionRow = {
+  id: string;
+  organization_id: string;
+  branch_id: string | null;
+  modifier_group_id: string;
+  name: string;
+  price_delta_minor: number;
+  is_default: boolean;
+  is_active: boolean;
+  sort_order: number;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  deleted_at: string | null;
+};
+
+export type MenuItemTranslationRow = {
+  organization_id: string;
+  branch_id: string | null;
+  menu_item_id: string;
+  locale: 'tr' | 'bg' | 'en';
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MenuAiRequestRow = {
+  id: string;
+  organization_id: string;
+  branch_id: string;
+  client_request_id: string;
+  created_by: string;
+  input_text: string;
+  status: 'processing' | 'ready' | 'published' | 'rejected' | 'failed';
+  model: string;
+  suggestion_json: Json | null;
+  reviewed_json: Json | null;
+  error_code: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  latency_ms: number | null;
+  published_item_id: string | null;
+  version: number;
+  created_at: string;
+  completed_at: string | null;
+  published_at: string | null;
+};
+
 type TableDefinition<Row> = {
   Row: Row;
   Insert: Partial<Row>;
@@ -128,6 +228,12 @@ export type Database = {
       memberships: TableDefinition<MembershipRow>;
       devices: TableDefinition<DeviceRow>;
       sync_events: TableDefinition<SyncEventRow>;
+      menu_categories: TableDefinition<MenuCategoryRow>;
+      menu_items: TableDefinition<MenuItemRow>;
+      modifier_groups: TableDefinition<ModifierGroupRow>;
+      modifier_options: TableDefinition<ModifierOptionRow>;
+      menu_item_translations: TableDefinition<MenuItemTranslationRow>;
+      menu_ai_requests: TableDefinition<MenuAiRequestRow>;
     };
     Views: Record<never, never>;
     Functions: {
@@ -217,6 +323,35 @@ export type Database = {
           requested_date_from: string;
           requested_date_to: string;
           requested_waiter_id?: string | null;
+        };
+        Returns: Json;
+      };
+      bulk_set_menu_item_availability: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_item_ids: string[];
+          requested_is_available: boolean;
+        };
+        Returns: number;
+      };
+      publish_menu_ai_draft: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_request_id: string;
+          requested_expected_version: number;
+          requested_reviewed_payload: Json;
+        };
+        Returns: Json;
+      };
+      save_catalog_item: {
+        Args: {
+          requested_organization_id: string;
+          requested_branch_id: string;
+          requested_item_id: string | null;
+          requested_expected_version: number | null;
+          requested_payload: Json;
         };
         Returns: Json;
       };

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -385,6 +385,11 @@ deno_version = 2
 # [edge_runtime.secrets]
 # secret_key = "env(SECRET_VALUE)"
 
+[functions.menu-ai-draft]
+enabled = true
+verify_jwt = true
+entrypoint = "./functions/menu-ai-draft/index.ts"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -1,0 +1,4 @@
+# Server-only Edge Function secrets. Never prefix these with EXPO_PUBLIC_.
+OPENAI_API_KEY=replace-with-a-project-service-account-key
+OPENAI_MENU_MODEL=gpt-5.6-luna
+ORDERIA_ALLOWED_ORIGINS=https://app.example.com

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -1,0 +1,28 @@
+# Menu AI Edge Function
+
+`menu-ai-draft` turns a short manager prompt into a strict, editable catalog
+draft. It never publishes menu data. Publication happens later through the
+manager-only `publish_menu_ai_draft` transaction after explicit review.
+
+Set server-only secrets in each Supabase environment:
+
+```sh
+supabase secrets set OPENAI_API_KEY=... \
+  OPENAI_MENU_MODEL=gpt-5.6-luna \
+  ORDERIA_ALLOWED_ORIGINS=https://app.example.com
+```
+
+Deploy the authenticated function:
+
+```sh
+supabase functions deploy menu-ai-draft
+```
+
+`ORDERIA_ALLOWED_ORIGINS` accepts a comma-separated allowlist. Native requests
+do not send an Origin header. When the variable is omitted, only localhost web
+origins are accepted.
+
+The OpenAI key stays in the Edge Function runtime. The function uses the
+Responses API with strict Structured Outputs and `store: false`, records
+latency/token usage, and enforces per-user burst and per-organization daily
+quotas before calling the model.

--- a/supabase/functions/menu-ai-draft/index.ts
+++ b/supabase/functions/menu-ai-draft/index.ts
@@ -1,0 +1,496 @@
+const corsHeaders = {
+  'Access-Control-Allow-Headers': 'authorization, apikey, content-type, x-client-info',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+type JsonRecord = Record<string, unknown>;
+
+Deno.serve(async (request) => {
+  const startedAt = Date.now();
+  const origin = request.headers.get('origin');
+  const originHeader = allowedOrigin(origin);
+  const responseHeaders = { ...corsHeaders, 'Access-Control-Allow-Origin': originHeader };
+
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { headers: responseHeaders });
+  }
+  if (request.method !== 'POST') {
+    return jsonResponse({ code: 'method_not_allowed' }, 405, responseHeaders);
+  }
+  if (origin && originHeader === 'null') {
+    return jsonResponse({ code: 'origin_not_allowed' }, 403, responseHeaders);
+  }
+
+  const authorization = request.headers.get('authorization');
+  if (!authorization?.startsWith('Bearer ')) {
+    return jsonResponse({ code: 'authentication_required' }, 401, responseHeaders);
+  }
+
+  let requestId: string | undefined;
+  let scope: { organizationId: string; branchId: string } | undefined;
+  try {
+    const body = await request.json();
+    const input = parseInput(body);
+    scope = input;
+    const model = Deno.env.get('OPENAI_MENU_MODEL')?.trim() || 'gpt-5.6-luna';
+
+    const reservation = await rpc(
+      'reserve_menu_ai_request',
+      {
+        requested_organization_id: input.organizationId,
+        requested_branch_id: input.branchId,
+        requested_client_request_id: input.clientRequestId,
+        requested_input_text: input.input,
+        requested_model: model,
+      },
+      authorization,
+    );
+    requestId = requiredString(reservation.id, 'invalid_reservation');
+
+    if (reservation.replayed === true && reservation.status !== 'processing') {
+      const existing = await restSelect(
+        `menu_ai_requests?id=eq.${encodeURIComponent(requestId)}&select=id,status,version,suggestion_json,error_code`,
+        authorization,
+      );
+      const row = Array.isArray(existing) ? existing[0] : undefined;
+      if (isRecord(row)) {
+        return jsonResponse(
+          {
+            id: row.id,
+            status: row.status,
+            version: row.version,
+            suggestion: row.suggestion_json,
+            replayed: true,
+          },
+          200,
+          responseHeaders,
+        );
+      }
+    }
+
+    const openAiKey = Deno.env.get('OPENAI_API_KEY')?.trim();
+    if (!openAiKey) throw new PublicError('ai_unconfigured', 503);
+
+    const [categories, menuItems, allergens] = await Promise.all([
+      restSelect(
+        `menu_categories?organization_id=eq.${input.organizationId}&or=(branch_id.is.null,branch_id.eq.${input.branchId})&deleted_at=is.null&select=id,name&order=sort_order`,
+        authorization,
+      ),
+      restSelect(
+        `menu_items?organization_id=eq.${input.organizationId}&or=(branch_id.is.null,branch_id.eq.${input.branchId})&deleted_at=is.null&select=id,name,price_minor,category_id&limit=200`,
+        authorization,
+      ),
+      restSelect('allergens?select=code,name&order=code', authorization),
+    ]);
+
+    const apiResponse = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${openAiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        store: false,
+        reasoning: { effort: 'low' },
+        max_output_tokens: 1800,
+        safety_identifier: await safetyIdentifier(authorization),
+        input: [
+          {
+            role: 'system',
+            content: menuAssistantPrompt(input.currencyCode, input.locale),
+          },
+          {
+            role: 'user',
+            content: JSON.stringify({
+              request: input.input,
+              currencyCode: input.currencyCode,
+              existingCategories: categories,
+              existingItems: menuItems,
+              allowedAllergens: allergens,
+            }),
+          },
+        ],
+        text: {
+          format: {
+            type: 'json_schema',
+            name: 'orderia_menu_item_draft',
+            strict: true,
+            schema: menuDraftSchema(input.currencyCode),
+          },
+        },
+      }),
+      signal: AbortSignal.timeout(25_000),
+    });
+    const responseJson = await apiResponse.json();
+    if (!apiResponse.ok) {
+      console.error('menu-ai-draft OpenAI error', {
+        requestId,
+        status: apiResponse.status,
+        type: isRecord(responseJson.error) ? responseJson.error.type : undefined,
+      });
+      throw new PublicError(
+        apiResponse.status === 429 ? 'ai_rate_limited' : 'ai_generation_failed',
+        apiResponse.status === 429 ? 429 : 502,
+      );
+    }
+
+    const suggestion = JSON.parse(extractOutputText(responseJson));
+    assertSuggestion(suggestion, input.currencyCode);
+    const usage = isRecord(responseJson.usage) ? responseJson.usage : {};
+    const completed = await rpc(
+      'complete_menu_ai_request',
+      {
+        requested_organization_id: input.organizationId,
+        requested_branch_id: input.branchId,
+        requested_request_id: requestId,
+        requested_suggestion: suggestion,
+        requested_model: model,
+        requested_input_tokens: integerOrZero(usage.input_tokens),
+        requested_output_tokens: integerOrZero(usage.output_tokens),
+        requested_latency_ms: Date.now() - startedAt,
+      },
+      authorization,
+    );
+
+    return jsonResponse(
+      {
+        id: completed.id,
+        status: completed.status,
+        version: completed.version,
+        suggestion: completed.suggestion,
+        replayed: false,
+      },
+      200,
+      responseHeaders,
+    );
+  } catch (error) {
+    const publicError =
+      error instanceof PublicError ? error : new PublicError('menu_ai_unavailable', 502);
+    console.error('menu-ai-draft failed', {
+      code: publicError.code,
+      requestId,
+      message: error instanceof Error ? error.message : 'unknown',
+    });
+    if (requestId && scope) {
+      try {
+        await rpc(
+          'fail_menu_ai_request',
+          {
+            requested_organization_id: scope.organizationId,
+            requested_branch_id: scope.branchId,
+            requested_request_id: requestId,
+            requested_error_code: publicError.code,
+            requested_latency_ms: Date.now() - startedAt,
+          },
+          authorization,
+        );
+      } catch (failureAuditError) {
+        console.error('menu-ai-draft audit failure', {
+          requestId,
+          message: failureAuditError instanceof Error ? failureAuditError.message : 'unknown',
+        });
+      }
+    }
+    return jsonResponse({ code: publicError.code }, publicError.status, responseHeaders);
+  }
+});
+
+function parseInput(value: unknown) {
+  if (!isRecord(value)) throw new PublicError('invalid_request', 400);
+  const organizationId = requiredUuid(value.organizationId);
+  const branchId = requiredUuid(value.branchId);
+  const clientRequestId = requiredUuid(value.clientRequestId);
+  const input = requiredString(value.input, 'invalid_request').trim();
+  const currencyCode = requiredString(value.currencyCode, 'invalid_request');
+  const locale = requiredString(value.locale, 'invalid_request');
+  if (
+    input.length < 3 ||
+    input.length > 500 ||
+    !/^[A-Z]{3}$/.test(currencyCode) ||
+    !['tr', 'bg', 'en'].includes(locale)
+  ) {
+    throw new PublicError('invalid_request', 400);
+  }
+  return { organizationId, branchId, clientRequestId, input, currencyCode, locale };
+}
+
+function menuAssistantPrompt(currencyCode: string, locale: string): string {
+  return [
+    'You create one editable restaurant menu-item draft for Orderia.',
+    `The branch currency is ${currencyCode}; return integer minor units only.`,
+    `Write the primary item in the input language and translations for tr, bg, and en.`,
+    `Prefer the existing category names. The manager UI locale is ${locale}.`,
+    'Suggest practical modifier groups only when they make service faster.',
+    'Never state or infer an allergen as fact.',
+    'Every allergen suggestion must have status "unknown" and tell the manager to verify recipe or supplier data.',
+    'Do not publish, mutate data, or invent a currency conversion.',
+    'If information is ambiguous, choose an editable draft and add a short warning.',
+    'Do not include any keys outside the supplied schema.',
+  ].join(' ');
+}
+
+function menuDraftSchema(currencyCode: string): JsonRecord {
+  const nullableString = { anyOf: [{ type: 'string' }, { type: 'null' }] };
+  const nullableInteger = { anyOf: [{ type: 'integer' }, { type: 'null' }] };
+  return {
+    type: 'object',
+    additionalProperties: false,
+    required: [
+      'schemaVersion',
+      'item',
+      'translations',
+      'modifierGroups',
+      'allergenSuggestions',
+      'warnings',
+    ],
+    properties: {
+      schemaVersion: { type: 'integer', const: 1 },
+      item: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'name',
+          'description',
+          'priceMinor',
+          'currencyCode',
+          'categoryName',
+          'prepTimeMinutes',
+        ],
+        properties: {
+          name: { type: 'string', minLength: 1, maxLength: 160 },
+          description: nullableString,
+          priceMinor: { type: 'integer', minimum: 0, maximum: 999999999 },
+          currencyCode: { type: 'string', const: currencyCode },
+          categoryName: { type: 'string', minLength: 1, maxLength: 120 },
+          prepTimeMinutes: {
+            ...nullableInteger,
+            minimum: 0,
+            maximum: 1440,
+          },
+        },
+      },
+      translations: {
+        type: 'array',
+        minItems: 3,
+        maxItems: 3,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['locale', 'name', 'description'],
+          properties: {
+            locale: { type: 'string', enum: ['tr', 'bg', 'en'] },
+            name: { type: 'string', minLength: 1, maxLength: 160 },
+            description: nullableString,
+          },
+        },
+      },
+      modifierGroups: {
+        type: 'array',
+        maxItems: 10,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: [
+            'name',
+            'selectionType',
+            'minimumChoices',
+            'maximumChoices',
+            'isRequired',
+            'sortOrder',
+            'options',
+          ],
+          properties: {
+            name: { type: 'string', minLength: 1, maxLength: 120 },
+            selectionType: { type: 'string', enum: ['single', 'multiple'] },
+            minimumChoices: { type: 'integer', minimum: 0, maximum: 20 },
+            maximumChoices: {
+              anyOf: [{ type: 'integer', minimum: 1, maximum: 20 }, { type: 'null' }],
+            },
+            isRequired: { type: 'boolean' },
+            sortOrder: { type: 'integer', minimum: 0, maximum: 100 },
+            options: {
+              type: 'array',
+              maxItems: 20,
+              items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['name', 'priceDeltaMinor', 'isDefault', 'sortOrder'],
+                properties: {
+                  name: { type: 'string', minLength: 1, maxLength: 120 },
+                  priceDeltaMinor: {
+                    type: 'integer',
+                    minimum: -999999999,
+                    maximum: 999999999,
+                  },
+                  isDefault: { type: 'boolean' },
+                  sortOrder: { type: 'integer', minimum: 0, maximum: 100 },
+                },
+              },
+            },
+          },
+        },
+      },
+      allergenSuggestions: {
+        type: 'array',
+        maxItems: 14,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['code', 'status', 'reason'],
+          properties: {
+            code: { type: 'string', pattern: '^[A-Z0-9_]{1,32}$' },
+            status: { type: 'string', const: 'unknown' },
+            reason: { type: 'string', minLength: 1, maxLength: 240 },
+          },
+        },
+      },
+      warnings: {
+        type: 'array',
+        maxItems: 10,
+        items: { type: 'string', minLength: 1, maxLength: 240 },
+      },
+    },
+  };
+}
+
+async function rpc(name: string, body: JsonRecord, authorization: string) {
+  return apiFetch(`/rest/v1/rpc/${name}`, authorization, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function restSelect(path: string, authorization: string) {
+  return apiFetch(`/rest/v1/${path}`, authorization, { method: 'GET' });
+}
+
+async function apiFetch(path: string, authorization: string, init: RequestInit) {
+  const supabaseUrl = requiredEnv('SUPABASE_URL');
+  const anonKey = requiredEnv('SUPABASE_ANON_KEY');
+  const response = await fetch(`${supabaseUrl}${path}`, {
+    ...init,
+    headers: {
+      apikey: anonKey,
+      authorization,
+      'Content-Type': 'application/json',
+    },
+  });
+  const body = response.status === 204 ? null : await response.json();
+  if (!response.ok) {
+    const code =
+      isRecord(body) && typeof body.message === 'string' ? body.message : 'database_error';
+    throw new PublicError(code, response.status >= 500 ? 502 : response.status);
+  }
+  return body;
+}
+
+async function safetyIdentifier(authorization: string): Promise<string> {
+  const token = authorization.slice('Bearer '.length);
+  const subject = decodeJwtSubject(token);
+  const bytes = new TextEncoder().encode(`orderia-menu:${subject}`);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return `ord_${Array.from(new Uint8Array(digest))
+    .map((value) => value.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 32)}`;
+}
+
+function decodeJwtSubject(token: string): string {
+  try {
+    const payload = token.split('.')[1];
+    const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const parsed = JSON.parse(atob(normalized));
+    return requiredString(parsed.sub, 'invalid_token');
+  } catch {
+    throw new PublicError('invalid_token', 401);
+  }
+}
+
+function extractOutputText(response: unknown): string {
+  if (!isRecord(response)) throw new Error('invalid_openai_response');
+  if (typeof response.output_text === 'string') return response.output_text;
+  if (!Array.isArray(response.output)) throw new Error('missing_openai_output');
+  for (const output of response.output) {
+    if (!isRecord(output) || !Array.isArray(output.content)) continue;
+    for (const content of output.content) {
+      if (isRecord(content) && content.type === 'output_text' && typeof content.text === 'string') {
+        return content.text;
+      }
+    }
+  }
+  throw new Error('missing_openai_output_text');
+}
+
+function assertSuggestion(value: unknown, currencyCode: string): asserts value is JsonRecord {
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    !isRecord(value.item) ||
+    value.item.currencyCode !== currencyCode ||
+    !Number.isInteger(value.item.priceMinor) ||
+    !Array.isArray(value.translations) ||
+    !Array.isArray(value.modifierGroups) ||
+    !Array.isArray(value.allergenSuggestions) ||
+    !value.allergenSuggestions.every((entry) => isRecord(entry) && entry.status === 'unknown') ||
+    !Array.isArray(value.warnings)
+  ) {
+    throw new Error('invalid_structured_suggestion');
+  }
+}
+
+function allowedOrigin(origin: string | null): string {
+  if (!origin) return '*';
+  const configured = (Deno.env.get('ORDERIA_ALLOWED_ORIGINS') || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (configured.includes(origin)) return origin;
+  if (configured.length === 0 && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+    return origin;
+  }
+  return 'null';
+}
+
+function jsonResponse(body: JsonRecord, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...headers, 'Content-Type': 'application/json' },
+  });
+}
+
+function requiredEnv(name: string): string {
+  const value = Deno.env.get(name)?.trim();
+  if (!value) throw new Error(`missing_${name.toLowerCase()}`);
+  return value;
+}
+
+function requiredString(value: unknown, code: string): string {
+  if (typeof value !== 'string' || value.length === 0) throw new PublicError(code, 400);
+  return value;
+}
+
+function requiredUuid(value: unknown): string {
+  const text = requiredString(value, 'invalid_request');
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(text)) {
+    throw new PublicError('invalid_request', 400);
+  }
+  return text;
+}
+
+function integerOrZero(value: unknown): number {
+  return Number.isInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+class PublicError extends Error {
+  constructor(
+    readonly code: string,
+    readonly status: number,
+  ) {
+    super(code);
+  }
+}

--- a/supabase/migrations/20260727020000_menu_ai_assistant.sql
+++ b/supabase/migrations/20260727020000_menu_ai_assistant.sql
@@ -130,6 +130,22 @@ to authenticated;
 grant insert, update, delete on table public.menu_item_translations
 to authenticated;
 
+create or replace function private.normalize_catalog_name(value text)
+returns text
+language sql
+immutable
+set search_path = ''
+as $$
+  select lower(
+    regexp_replace(
+      trim(translate(coalesce(value, ''), 'ÇĞİÖŞÜ', 'çğiöşü')),
+      '[[:space:]]+',
+      ' ',
+      'g'
+    )
+  );
+$$;
+
 create or replace function private.is_valid_menu_ai_suggestion(
   suggestion jsonb,
   expected_currency text
@@ -520,8 +536,8 @@ begin
     and (item.branch_id is null or item.branch_id = requested_branch_id)
     and item.deleted_at is null
     and item.id <> coalesce(requested_item_id, '00000000-0000-0000-0000-000000000000')
-    and lower(regexp_replace(trim(item.name), '\s+', ' ', 'g'))
-      = lower(regexp_replace(payload_name, '\s+', ' ', 'g'))
+    and private.normalize_catalog_name(item.name)
+      = private.normalize_catalog_name(payload_name)
   order by item.id
   limit 1;
   if duplicate_id is not null then
@@ -870,7 +886,9 @@ end;
 $$;
 
 revoke execute on function private.is_valid_menu_ai_suggestion(jsonb, text)
-  from public, anon, authenticated;
+from public, anon, authenticated;
+revoke execute on function private.normalize_catalog_name(text)
+from public, anon, authenticated;
 revoke execute on function public.reserve_menu_ai_request(
   uuid,
   uuid,

--- a/supabase/migrations/20260727020000_menu_ai_assistant.sql
+++ b/supabase/migrations/20260727020000_menu_ai_assistant.sql
@@ -1,0 +1,962 @@
+-- Manager-reviewed catalog editing and rate-limited AI menu drafts.
+
+create table public.menu_item_translations (
+  organization_id uuid not null
+    references public.organizations (id) on delete cascade,
+  branch_id uuid,
+  menu_item_id uuid not null,
+  locale text not null check (locale in ('tr', 'bg', 'en')),
+  name text not null check (char_length(trim(name)) between 1 and 160),
+  description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint menu_item_translations_branch_organization_fkey
+    foreign key (organization_id, branch_id)
+    references public.branches (organization_id, id),
+  constraint menu_item_translations_item_organization_fkey
+    foreign key (organization_id, menu_item_id)
+    references public.menu_items (organization_id, id)
+    on delete cascade,
+  primary key (menu_item_id, locale)
+);
+
+create index menu_item_translations_scope_idx
+  on public.menu_item_translations (
+    organization_id,
+    branch_id,
+    locale,
+    menu_item_id
+  );
+
+create table public.menu_ai_requests (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null
+    references public.organizations (id) on delete cascade,
+  branch_id uuid not null,
+  client_request_id uuid not null,
+  created_by uuid not null references auth.users (id),
+  input_text text not null check (char_length(trim(input_text)) between 3 and 500),
+  status text not null default 'processing'
+    check (status in ('processing', 'ready', 'published', 'rejected', 'failed')),
+  model text not null check (char_length(trim(model)) between 1 and 80),
+  suggestion_json jsonb,
+  reviewed_json jsonb,
+  error_code text,
+  input_tokens integer check (input_tokens is null or input_tokens >= 0),
+  output_tokens integer check (output_tokens is null or output_tokens >= 0),
+  latency_ms integer check (latency_ms is null or latency_ms >= 0),
+  published_item_id uuid,
+  version bigint not null default 1 check (version > 0),
+  created_at timestamptz not null default now(),
+  completed_at timestamptz,
+  published_at timestamptz,
+  constraint menu_ai_requests_branch_organization_fkey
+    foreign key (organization_id, branch_id)
+    references public.branches (organization_id, id)
+    on delete cascade,
+  constraint menu_ai_requests_published_item_fkey
+    foreign key (organization_id, published_item_id)
+    references public.menu_items (organization_id, id),
+  constraint menu_ai_requests_state_check
+    check (
+      (status = 'processing' and completed_at is null)
+      or (status <> 'processing' and completed_at is not null)
+    ),
+  unique (organization_id, branch_id, created_by, client_request_id)
+);
+
+create index menu_ai_requests_scope_created_idx
+  on public.menu_ai_requests (organization_id, branch_id, created_at desc);
+create index menu_ai_requests_creator_rate_idx
+  on public.menu_ai_requests (created_by, created_at desc);
+
+insert into public.allergens (code, name)
+values
+  ('GLUTEN', 'Gluten'),
+  ('CRUSTACEANS', 'Crustaceans'),
+  ('EGGS', 'Eggs'),
+  ('FISH', 'Fish'),
+  ('PEANUTS', 'Peanuts'),
+  ('SOY', 'Soy'),
+  ('MILK', 'Milk'),
+  ('NUTS', 'Tree nuts'),
+  ('CELERY', 'Celery'),
+  ('MUSTARD', 'Mustard'),
+  ('SESAME', 'Sesame'),
+  ('SULPHITES', 'Sulphites'),
+  ('LUPIN', 'Lupin'),
+  ('MOLLUSCS', 'Molluscs')
+on conflict (code) do nothing;
+
+alter table public.menu_item_translations enable row level security;
+alter table public.menu_item_translations force row level security;
+alter table public.menu_ai_requests enable row level security;
+alter table public.menu_ai_requests force row level security;
+
+create policy menu_item_translations_member_select
+on public.menu_item_translations
+for select to authenticated
+using ((select private.is_active_member(organization_id, branch_id)));
+
+create policy menu_item_translations_manager_insert
+on public.menu_item_translations
+for insert to authenticated
+with check ((select private.is_manager(organization_id, branch_id)));
+
+create policy menu_item_translations_manager_update
+on public.menu_item_translations
+for update to authenticated
+using ((select private.is_manager(organization_id, branch_id)))
+with check ((select private.is_manager(organization_id, branch_id)));
+
+create policy menu_item_translations_manager_delete
+on public.menu_item_translations
+for delete to authenticated
+using ((select private.is_manager(organization_id, branch_id)));
+
+create policy menu_ai_requests_manager_select
+on public.menu_ai_requests
+for select to authenticated
+using ((select private.is_manager(organization_id, branch_id)));
+
+revoke all on table
+  public.menu_item_translations,
+  public.menu_ai_requests
+from anon, authenticated;
+grant select on table
+  public.menu_item_translations,
+  public.menu_ai_requests
+to authenticated;
+grant insert, update, delete on table public.menu_item_translations
+to authenticated;
+
+create or replace function private.is_valid_menu_ai_suggestion(
+  suggestion jsonb,
+  expected_currency text
+)
+returns boolean
+language plpgsql
+immutable
+set search_path = ''
+as $$
+declare
+  item_json jsonb;
+  entry jsonb;
+begin
+  if jsonb_typeof(suggestion) <> 'object'
+    or suggestion ->> 'schemaVersion' <> '1'
+    or jsonb_typeof(suggestion -> 'item') <> 'object'
+    or jsonb_typeof(suggestion -> 'translations') <> 'array'
+    or jsonb_typeof(suggestion -> 'modifierGroups') <> 'array'
+    or jsonb_typeof(suggestion -> 'allergenSuggestions') <> 'array'
+    or jsonb_typeof(suggestion -> 'warnings') <> 'array'
+    or jsonb_array_length(suggestion -> 'translations') > 3
+    or jsonb_array_length(suggestion -> 'modifierGroups') > 10
+    or jsonb_array_length(suggestion -> 'allergenSuggestions') > 14
+    or jsonb_array_length(suggestion -> 'warnings') > 10 then
+    return false;
+  end if;
+
+  item_json := suggestion -> 'item';
+  if char_length(trim(coalesce(item_json ->> 'name', ''))) not between 1 and 160
+    or char_length(trim(coalesce(item_json ->> 'categoryName', ''))) not between 1 and 120
+    or coalesce(item_json ->> 'currencyCode', '') <> expected_currency
+    or coalesce(item_json ->> 'priceMinor', '') !~ '^[0-9]{1,12}$'
+    or (item_json ->> 'priceMinor')::numeric > 999999999
+    or (
+      item_json -> 'prepTimeMinutes' <> 'null'::jsonb
+      and coalesce(item_json ->> 'prepTimeMinutes', '') !~ '^[0-9]{1,4}$'
+    )
+    or coalesce((item_json ->> 'prepTimeMinutes')::integer, 0) > 1440 then
+    return false;
+  end if;
+
+  for entry in select value from jsonb_array_elements(suggestion -> 'translations')
+  loop
+    if jsonb_typeof(entry) <> 'object'
+      or coalesce(entry ->> 'locale', '') not in ('tr', 'bg', 'en')
+      or char_length(trim(coalesce(entry ->> 'name', ''))) not between 1 and 160 then
+      return false;
+    end if;
+  end loop;
+
+  for entry in select value from jsonb_array_elements(suggestion -> 'allergenSuggestions')
+  loop
+    if jsonb_typeof(entry) <> 'object'
+      or coalesce(entry ->> 'code', '') !~ '^[A-Z0-9_]{1,32}$'
+      or entry ->> 'status' <> 'unknown'
+      or char_length(trim(coalesce(entry ->> 'reason', ''))) not between 1 and 240 then
+      return false;
+    end if;
+  end loop;
+
+  return true;
+exception
+  when others then
+    return false;
+end;
+$$;
+
+create or replace function public.reserve_menu_ai_request(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_client_request_id uuid,
+  requested_input_text text,
+  requested_model text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  existing_request public.menu_ai_requests;
+  organization_plan text;
+  daily_limit integer;
+  request_row public.menu_ai_requests;
+begin
+  if (select auth.uid()) is null then
+    raise exception using errcode = '42501', message = 'authentication_required';
+  end if;
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  if requested_client_request_id is null
+    or char_length(trim(coalesce(requested_input_text, ''))) not between 3 and 500
+    or char_length(trim(coalesce(requested_model, ''))) not between 1 and 80 then
+    raise exception using errcode = '22023', message = 'invalid_menu_ai_request';
+  end if;
+
+  select request.*
+  into existing_request
+  from public.menu_ai_requests as request
+  where request.organization_id = requested_organization_id
+    and request.branch_id = requested_branch_id
+    and request.created_by = (select auth.uid())
+    and request.client_request_id = requested_client_request_id;
+  if existing_request.id is not null then
+    return jsonb_build_object(
+      'id', existing_request.id,
+      'status', existing_request.status,
+      'version', existing_request.version,
+      'replayed', true
+    );
+  end if;
+
+  if (
+    select count(*)
+    from public.menu_ai_requests as request
+    where request.created_by = (select auth.uid())
+      and request.created_at >= now() - interval '10 minutes'
+  ) >= 10 then
+    raise exception using errcode = 'P0001', message = 'menu_ai_burst_limit_reached';
+  end if;
+
+  select organization.plan
+  into organization_plan
+  from public.organizations as organization
+  where organization.id = requested_organization_id
+    and organization.status = 'active';
+  daily_limit := case organization_plan
+    when 'trial' then 20
+    when 'starter' then 50
+    when 'growth' then 200
+    when 'enterprise' then 1000
+    else 0
+  end;
+  if (
+    select count(*)
+    from public.menu_ai_requests as request
+    where request.organization_id = requested_organization_id
+      and request.created_at >= now() - interval '24 hours'
+  ) >= daily_limit then
+    raise exception using errcode = 'P0001', message = 'menu_ai_daily_quota_reached';
+  end if;
+
+  insert into public.menu_ai_requests (
+    organization_id,
+    branch_id,
+    client_request_id,
+    created_by,
+    input_text,
+    model
+  )
+  values (
+    requested_organization_id,
+    requested_branch_id,
+    requested_client_request_id,
+    (select auth.uid()),
+    trim(requested_input_text),
+    trim(requested_model)
+  )
+  returning * into request_row;
+
+  return jsonb_build_object(
+    'id', request_row.id,
+    'status', request_row.status,
+    'version', request_row.version,
+    'replayed', false
+  );
+end;
+$$;
+
+create or replace function public.complete_menu_ai_request(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_request_id uuid,
+  requested_suggestion jsonb,
+  requested_model text,
+  requested_input_tokens integer,
+  requested_output_tokens integer,
+  requested_latency_ms integer
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  branch_currency text;
+  request_row public.menu_ai_requests;
+begin
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  select branch.currency_code
+  into branch_currency
+  from public.branches as branch
+  where branch.organization_id = requested_organization_id
+    and branch.id = requested_branch_id
+    and branch.deleted_at is null;
+  if branch_currency is null
+    or not private.is_valid_menu_ai_suggestion(requested_suggestion, branch_currency)
+    or requested_input_tokens < 0
+    or requested_output_tokens < 0
+    or requested_latency_ms < 0 then
+    raise exception using errcode = '22023', message = 'invalid_menu_ai_suggestion';
+  end if;
+
+  update public.menu_ai_requests as request
+  set
+    status = 'ready',
+    model = trim(requested_model),
+    suggestion_json = requested_suggestion,
+    input_tokens = requested_input_tokens,
+    output_tokens = requested_output_tokens,
+    latency_ms = requested_latency_ms,
+    completed_at = now(),
+    version = request.version + 1
+  where request.organization_id = requested_organization_id
+    and request.branch_id = requested_branch_id
+    and request.id = requested_request_id
+    and request.created_by = (select auth.uid())
+    and request.status = 'processing'
+  returning * into request_row;
+  if request_row.id is null then
+    raise exception using errcode = 'P0001', message = 'menu_ai_request_not_processing';
+  end if;
+
+  return jsonb_build_object(
+    'id', request_row.id,
+    'status', request_row.status,
+    'version', request_row.version,
+    'suggestion', request_row.suggestion_json
+  );
+end;
+$$;
+
+create or replace function public.fail_menu_ai_request(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_request_id uuid,
+  requested_error_code text,
+  requested_latency_ms integer
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  update public.menu_ai_requests as request
+  set
+    status = 'failed',
+    error_code = left(coalesce(requested_error_code, 'unknown_error'), 80),
+    latency_ms = greatest(coalesce(requested_latency_ms, 0), 0),
+    completed_at = now(),
+    version = request.version + 1
+  where request.organization_id = requested_organization_id
+    and request.branch_id = requested_branch_id
+    and request.id = requested_request_id
+    and request.created_by = (select auth.uid())
+    and request.status = 'processing';
+end;
+$$;
+
+create or replace function public.save_catalog_item(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_item_id uuid,
+  requested_expected_version bigint,
+  requested_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  branch_row public.branches;
+  category_row public.menu_categories;
+  item_row public.menu_items;
+  translation jsonb;
+  modifier_group jsonb;
+  modifier_option jsonb;
+  allergen jsonb;
+  created_group_id uuid;
+  duplicate_id uuid;
+  payload_name text := trim(coalesce(requested_payload ->> 'name', ''));
+  payload_category_name text := trim(coalesce(requested_payload ->> 'categoryName', ''));
+  payload_currency text := coalesce(requested_payload ->> 'currencyCode', '');
+  payload_price bigint;
+  payload_prep integer;
+begin
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  select branch.*
+  into branch_row
+  from public.branches as branch
+  where branch.organization_id = requested_organization_id
+    and branch.id = requested_branch_id
+    and branch.status = 'active'
+    and branch.deleted_at is null;
+  if branch_row.id is null then
+    raise exception using errcode = '22023', message = 'catalog_branch_not_found';
+  end if;
+  if jsonb_typeof(requested_payload) <> 'object'
+    or char_length(payload_name) not between 1 and 160
+    or coalesce(requested_payload ->> 'priceMinor', '') !~ '^[0-9]{1,12}$'
+    or payload_currency <> branch_row.currency_code
+    or jsonb_typeof(coalesce(requested_payload -> 'translations', '[]'::jsonb)) <> 'array'
+    or jsonb_typeof(coalesce(requested_payload -> 'modifierGroups', '[]'::jsonb)) <> 'array'
+    or jsonb_typeof(coalesce(requested_payload -> 'confirmedAllergens', '[]'::jsonb)) <> 'array'
+    or jsonb_array_length(coalesce(requested_payload -> 'modifierGroups', '[]'::jsonb)) > 10
+    or jsonb_array_length(coalesce(requested_payload -> 'confirmedAllergens', '[]'::jsonb)) > 14 then
+    raise exception using errcode = '22023', message = 'invalid_catalog_item_payload';
+  end if;
+  payload_price := (requested_payload ->> 'priceMinor')::bigint;
+  if payload_price > 999999999 then
+    raise exception using errcode = '22023', message = 'invalid_catalog_item_price';
+  end if;
+  if requested_payload -> 'prepTimeMinutes' is null
+    or requested_payload -> 'prepTimeMinutes' = 'null'::jsonb then
+    payload_prep := null;
+  elsif coalesce(requested_payload ->> 'prepTimeMinutes', '') ~ '^[0-9]{1,4}$' then
+    payload_prep := (requested_payload ->> 'prepTimeMinutes')::integer;
+  else
+    raise exception using errcode = '22023', message = 'invalid_catalog_prep_time';
+  end if;
+  if payload_prep is not null and payload_prep > 1440 then
+    raise exception using errcode = '22023', message = 'invalid_catalog_prep_time';
+  end if;
+
+  if nullif(requested_payload ->> 'categoryId', '') is not null then
+    select category.*
+    into category_row
+    from public.menu_categories as category
+    where category.organization_id = requested_organization_id
+      and (category.branch_id is null or category.branch_id = requested_branch_id)
+      and category.id = (requested_payload ->> 'categoryId')::uuid
+      and category.deleted_at is null;
+  else
+    if char_length(payload_category_name) not between 1 and 120 then
+      raise exception using errcode = '22023', message = 'catalog_category_required';
+    end if;
+    select category.*
+    into category_row
+    from public.menu_categories as category
+    where category.organization_id = requested_organization_id
+      and (category.branch_id is null or category.branch_id = requested_branch_id)
+      and lower(trim(category.name)) = lower(payload_category_name)
+      and category.deleted_at is null
+    order by (category.branch_id is null), category.id
+    limit 1;
+    if category_row.id is null then
+      insert into public.menu_categories (
+        organization_id,
+        branch_id,
+        name,
+        sort_order,
+        created_by
+      )
+      values (
+        requested_organization_id,
+        requested_branch_id,
+        payload_category_name,
+        (
+          select coalesce(max(category.sort_order), -1) + 1
+          from public.menu_categories as category
+          where category.organization_id = requested_organization_id
+            and category.branch_id = requested_branch_id
+            and category.deleted_at is null
+        ),
+        (select auth.uid())
+      )
+      returning * into category_row;
+    end if;
+  end if;
+  if category_row.id is null then
+    raise exception using errcode = '22023', message = 'catalog_category_not_found';
+  end if;
+
+  select item.id
+  into duplicate_id
+  from public.menu_items as item
+  where item.organization_id = requested_organization_id
+    and (item.branch_id is null or item.branch_id = requested_branch_id)
+    and item.deleted_at is null
+    and item.id <> coalesce(requested_item_id, '00000000-0000-0000-0000-000000000000')
+    and lower(regexp_replace(trim(item.name), '\s+', ' ', 'g'))
+      = lower(regexp_replace(payload_name, '\s+', ' ', 'g'))
+  order by item.id
+  limit 1;
+  if duplicate_id is not null then
+    raise exception using
+      errcode = '23505',
+      message = 'catalog_item_duplicate',
+      detail = jsonb_build_object('existingItemId', duplicate_id)::text;
+  end if;
+
+  if requested_item_id is null then
+    insert into public.menu_items (
+      organization_id,
+      branch_id,
+      category_id,
+      name,
+      description,
+      price_minor,
+      currency_code,
+      tax_rate_basis_points,
+      is_active,
+      is_available,
+      prep_time_minutes,
+      created_by
+    )
+    values (
+      requested_organization_id,
+      requested_branch_id,
+      category_row.id,
+      payload_name,
+      nullif(trim(coalesce(requested_payload ->> 'description', '')), ''),
+      payload_price,
+      branch_row.currency_code,
+      coalesce((requested_payload ->> 'taxRateBasisPoints')::integer, 0),
+      coalesce((requested_payload ->> 'isActive')::boolean, true),
+      coalesce((requested_payload ->> 'isAvailable')::boolean, true),
+      payload_prep,
+      (select auth.uid())
+    )
+    returning * into item_row;
+  else
+    select item.*
+    into item_row
+    from public.menu_items as item
+    where item.organization_id = requested_organization_id
+      and item.branch_id = requested_branch_id
+      and item.id = requested_item_id
+      and item.deleted_at is null
+    for update;
+    if item_row.id is null then
+      raise exception using errcode = 'P0001', message = 'catalog_item_not_found';
+    end if;
+    if requested_expected_version is null or item_row.version <> requested_expected_version then
+      raise exception using
+        errcode = 'P0001',
+        message = 'catalog_item_version_conflict',
+        detail = jsonb_build_object('serverVersion', item_row.version)::text;
+    end if;
+    update public.menu_items as item
+    set
+      category_id = category_row.id,
+      name = payload_name,
+      description = nullif(trim(coalesce(requested_payload ->> 'description', '')), ''),
+      price_minor = payload_price,
+      tax_rate_basis_points =
+        coalesce((requested_payload ->> 'taxRateBasisPoints')::integer, 0),
+      is_active = coalesce((requested_payload ->> 'isActive')::boolean, item.is_active),
+      is_available =
+        coalesce((requested_payload ->> 'isAvailable')::boolean, item.is_available),
+      prep_time_minutes = payload_prep,
+      updated_at = now(),
+      version = item.version + 1
+    where item.id = requested_item_id
+    returning * into item_row;
+
+    update public.modifier_options as option
+    set
+      deleted_at = now(),
+      updated_at = now(),
+      version = option.version + 1
+    where option.organization_id = requested_organization_id
+      and option.branch_id = requested_branch_id
+      and option.modifier_group_id in (
+        select modifier.id
+        from public.modifier_groups as modifier
+        where modifier.organization_id = requested_organization_id
+          and modifier.branch_id = requested_branch_id
+          and modifier.menu_item_id = item_row.id
+          and modifier.deleted_at is null
+      )
+      and option.deleted_at is null;
+    update public.modifier_groups as modifier
+    set
+      deleted_at = now(),
+      updated_at = now(),
+      version = modifier.version + 1
+    where modifier.organization_id = requested_organization_id
+      and modifier.branch_id = requested_branch_id
+      and modifier.menu_item_id = item_row.id
+      and modifier.deleted_at is null;
+  end if;
+
+  delete from public.menu_item_translations as existing_translation
+  where existing_translation.organization_id = requested_organization_id
+    and existing_translation.branch_id = requested_branch_id
+    and existing_translation.menu_item_id = item_row.id;
+  for translation in
+    select value
+    from jsonb_array_elements(coalesce(requested_payload -> 'translations', '[]'::jsonb))
+  loop
+    if coalesce(translation ->> 'locale', '') not in ('tr', 'bg', 'en')
+      or char_length(trim(coalesce(translation ->> 'name', ''))) not between 1 and 160 then
+      raise exception using errcode = '22023', message = 'invalid_catalog_translation';
+    end if;
+    insert into public.menu_item_translations (
+      organization_id,
+      branch_id,
+      menu_item_id,
+      locale,
+      name,
+      description
+    )
+    values (
+      requested_organization_id,
+      requested_branch_id,
+      item_row.id,
+      translation ->> 'locale',
+      trim(translation ->> 'name'),
+      nullif(trim(coalesce(translation ->> 'description', '')), '')
+    );
+  end loop;
+
+  for modifier_group in
+    select value
+    from jsonb_array_elements(coalesce(requested_payload -> 'modifierGroups', '[]'::jsonb))
+  loop
+    if char_length(trim(coalesce(modifier_group ->> 'name', ''))) not between 1 and 120
+      or coalesce(modifier_group ->> 'selectionType', '') not in ('single', 'multiple')
+      or jsonb_typeof(modifier_group -> 'options') <> 'array'
+      or jsonb_array_length(modifier_group -> 'options') > 20 then
+      raise exception using errcode = '22023', message = 'invalid_catalog_modifier_group';
+    end if;
+    insert into public.modifier_groups (
+      organization_id,
+      branch_id,
+      menu_item_id,
+      name,
+      selection_type,
+      minimum_choices,
+      maximum_choices,
+      is_required,
+      sort_order
+    )
+    values (
+      requested_organization_id,
+      requested_branch_id,
+      item_row.id,
+      trim(modifier_group ->> 'name'),
+      modifier_group ->> 'selectionType',
+      coalesce((modifier_group ->> 'minimumChoices')::integer, 0),
+      (modifier_group ->> 'maximumChoices')::integer,
+      coalesce((modifier_group ->> 'isRequired')::boolean, false),
+      coalesce((modifier_group ->> 'sortOrder')::integer, 0)
+    )
+    returning id into created_group_id;
+
+    for modifier_option in
+      select value from jsonb_array_elements(modifier_group -> 'options')
+    loop
+      if char_length(trim(coalesce(modifier_option ->> 'name', ''))) not between 1 and 120
+        or coalesce(modifier_option ->> 'priceDeltaMinor', '') !~ '^-?[0-9]{1,12}$' then
+        raise exception using errcode = '22023', message = 'invalid_catalog_modifier_option';
+      end if;
+      insert into public.modifier_options (
+        organization_id,
+        branch_id,
+        modifier_group_id,
+        name,
+        price_delta_minor,
+        is_default,
+        sort_order
+      )
+      values (
+        requested_organization_id,
+        requested_branch_id,
+        created_group_id,
+        trim(modifier_option ->> 'name'),
+        (modifier_option ->> 'priceDeltaMinor')::bigint,
+        coalesce((modifier_option ->> 'isDefault')::boolean, false),
+        coalesce((modifier_option ->> 'sortOrder')::integer, 0)
+      );
+    end loop;
+  end loop;
+
+  delete from public.menu_item_allergens as existing_allergen
+  where existing_allergen.organization_id = requested_organization_id
+    and existing_allergen.branch_id = requested_branch_id
+    and existing_allergen.menu_item_id = item_row.id;
+  for allergen in
+    select value
+    from jsonb_array_elements(coalesce(requested_payload -> 'confirmedAllergens', '[]'::jsonb))
+  loop
+    if coalesce(allergen ->> 'presence', '') not in (
+      'contains',
+      'may_contain',
+      'free_from'
+    ) then
+      raise exception using errcode = '22023', message = 'invalid_catalog_allergen';
+    end if;
+    insert into public.menu_item_allergens (
+      organization_id,
+      branch_id,
+      menu_item_id,
+      allergen_id,
+      presence,
+      source,
+      confirmed_by,
+      confirmed_at
+    )
+    select
+      requested_organization_id,
+      requested_branch_id,
+      item_row.id,
+      allergen_definition.id,
+      allergen ->> 'presence',
+      'manager',
+      (select auth.uid()),
+      now()
+    from public.allergens as allergen_definition
+    where allergen_definition.code = allergen ->> 'code';
+    if not found then
+      raise exception using errcode = '22023', message = 'catalog_allergen_not_found';
+    end if;
+  end loop;
+
+  return jsonb_build_object(
+    'id', item_row.id,
+    'categoryId', category_row.id,
+    'name', item_row.name,
+    'version', item_row.version,
+    'priceMinor', item_row.price_minor,
+    'currencyCode', item_row.currency_code,
+    'isAvailable', item_row.is_available
+  );
+end;
+$$;
+
+create or replace function public.publish_menu_ai_draft(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_request_id uuid,
+  requested_expected_version bigint,
+  requested_reviewed_payload jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  request_row public.menu_ai_requests;
+  item_result jsonb;
+begin
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  select request.*
+  into request_row
+  from public.menu_ai_requests as request
+  where request.organization_id = requested_organization_id
+    and request.branch_id = requested_branch_id
+    and request.id = requested_request_id
+  for update;
+  if request_row.id is null then
+    raise exception using errcode = 'P0001', message = 'menu_ai_draft_not_found';
+  end if;
+  if request_row.status <> 'ready' then
+    raise exception using errcode = 'P0001', message = 'menu_ai_draft_not_ready';
+  end if;
+  if request_row.version <> requested_expected_version then
+    raise exception using
+      errcode = 'P0001',
+      message = 'menu_ai_draft_version_conflict',
+      detail = jsonb_build_object('serverVersion', request_row.version)::text;
+  end if;
+
+  item_result := public.save_catalog_item(
+    requested_organization_id,
+    requested_branch_id,
+    null,
+    null,
+    requested_reviewed_payload
+  );
+
+  update public.menu_ai_requests as request
+  set
+    status = 'published',
+    reviewed_json = requested_reviewed_payload,
+    published_item_id = (item_result ->> 'id')::uuid,
+    published_at = now(),
+    version = request.version + 1
+  where request.id = request_row.id;
+
+  return jsonb_build_object(
+    'requestId', request_row.id,
+    'status', 'published',
+    'item', item_result
+  );
+end;
+$$;
+
+create or replace function public.bulk_set_menu_item_availability(
+  requested_organization_id uuid,
+  requested_branch_id uuid,
+  requested_item_ids uuid[],
+  requested_is_available boolean
+)
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  affected integer;
+begin
+  if not private.is_manager(requested_organization_id, requested_branch_id) then
+    raise exception using errcode = '42501', message = 'manager_role_required';
+  end if;
+  if requested_item_ids is null
+    or cardinality(requested_item_ids) not between 1 and 100
+    or requested_is_available is null then
+    raise exception using errcode = '22023', message = 'invalid_catalog_bulk_update';
+  end if;
+  update public.menu_items as item
+  set
+    is_available = requested_is_available,
+    updated_at = now(),
+    version = item.version + 1
+  where item.organization_id = requested_organization_id
+    and item.branch_id = requested_branch_id
+    and item.id = any(requested_item_ids)
+    and item.deleted_at is null
+    and item.is_available <> requested_is_available;
+  get diagnostics affected = row_count;
+  return affected;
+end;
+$$;
+
+revoke execute on function private.is_valid_menu_ai_suggestion(jsonb, text)
+  from public, anon, authenticated;
+revoke execute on function public.reserve_menu_ai_request(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  text
+) from public, anon;
+revoke execute on function public.complete_menu_ai_request(
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  text,
+  integer,
+  integer,
+  integer
+) from public, anon;
+revoke execute on function public.fail_menu_ai_request(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  integer
+) from public, anon;
+revoke execute on function public.save_catalog_item(
+  uuid,
+  uuid,
+  uuid,
+  bigint,
+  jsonb
+) from public, anon;
+revoke execute on function public.publish_menu_ai_draft(
+  uuid,
+  uuid,
+  uuid,
+  bigint,
+  jsonb
+) from public, anon;
+revoke execute on function public.bulk_set_menu_item_availability(
+  uuid,
+  uuid,
+  uuid[],
+  boolean
+) from public, anon;
+
+grant execute on function public.reserve_menu_ai_request(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  text
+) to authenticated;
+grant execute on function public.complete_menu_ai_request(
+  uuid,
+  uuid,
+  uuid,
+  jsonb,
+  text,
+  integer,
+  integer,
+  integer
+) to authenticated;
+grant execute on function public.fail_menu_ai_request(
+  uuid,
+  uuid,
+  uuid,
+  text,
+  integer
+) to authenticated;
+grant execute on function public.save_catalog_item(
+  uuid,
+  uuid,
+  uuid,
+  bigint,
+  jsonb
+) to authenticated;
+grant execute on function public.publish_menu_ai_draft(
+  uuid,
+  uuid,
+  uuid,
+  bigint,
+  jsonb
+) to authenticated;
+grant execute on function public.bulk_set_menu_item_availability(
+  uuid,
+  uuid,
+  uuid[],
+  boolean
+) to authenticated;

--- a/supabase/migrations/20260727020000_menu_ai_assistant.sql
+++ b/supabase/migrations/20260727020000_menu_ai_assistant.sql
@@ -138,7 +138,7 @@ set search_path = ''
 as $$
   select lower(
     regexp_replace(
-      trim(translate(coalesce(value, ''), 'ÇĞİÖŞÜ', 'çğiöşü')),
+      trim(translate(coalesce(value, ''), 'ÇĞİIÖŞÜ', 'çğiıöşü')),
       '[[:space:]]+',
       ' ',
       'g'

--- a/supabase/tests/database/005_rapid_order_workspace.test.sql
+++ b/supabase/tests/database/005_rapid_order_workspace.test.sql
@@ -2,7 +2,7 @@ begin;
 
 create extension if not exists pgtap with schema extensions;
 
-select plan(93);
+select plan(111);
 
 insert into auth.users (
   instance_id,
@@ -1753,6 +1753,395 @@ select throws_ok(
   '42501',
   'manager_role_required',
   'waiters cannot access manager reporting'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000001","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+
+select is(
+  public.reserve_menu_ai_request(
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    'c6000000-0000-4000-8000-000000000001',
+    'Patates kızartması - 4 euro, peynirli +1 euro',
+    'gpt-5.6-luna'
+  ) ->> 'status',
+  'processing',
+  'a manager can reserve a rate-limited AI draft without publishing catalog data'
+);
+select is(
+  (
+    public.reserve_menu_ai_request(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      'c6000000-0000-4000-8000-000000000001',
+      'Patates kızartması - 4 euro, peynirli +1 euro',
+      'gpt-5.6-luna'
+    ) ->> 'id'
+  )::uuid,
+  (
+    select id
+    from public.menu_ai_requests
+    where client_request_id = 'c6000000-0000-4000-8000-000000000001'
+  ),
+  'an exact AI request replay returns the original draft reservation'
+);
+select is(
+  (
+    select count(*)
+    from public.menu_ai_requests
+    where client_request_id = 'c6000000-0000-4000-8000-000000000001'
+  ),
+  1::bigint,
+  'an AI retry cannot consume quota twice or duplicate a request'
+);
+select is(
+  public.complete_menu_ai_request(
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    (
+      select id
+      from public.menu_ai_requests
+      where client_request_id = 'c6000000-0000-4000-8000-000000000001'
+    ),
+    jsonb_build_object(
+      'schemaVersion', 1,
+      'item', jsonb_build_object(
+        'name', 'Patates kızartması',
+        'description', 'Çıtır patates',
+        'priceMinor', 400,
+        'currencyCode', 'EUR',
+        'categoryName', 'Atıştırmalık',
+        'prepTimeMinutes', 8
+      ),
+      'translations', jsonb_build_array(
+        jsonb_build_object(
+          'locale', 'tr',
+          'name', 'Patates kızartması',
+          'description', 'Çıtır patates'
+        ),
+        jsonb_build_object(
+          'locale', 'bg',
+          'name', 'Пържени картофи',
+          'description', null
+        ),
+        jsonb_build_object(
+          'locale', 'en',
+          'name', 'French fries',
+          'description', null
+        )
+      ),
+      'modifierGroups', jsonb_build_array(
+        jsonb_build_object(
+          'name', 'Peynir',
+          'selectionType', 'single',
+          'minimumChoices', 0,
+          'maximumChoices', 1,
+          'isRequired', false,
+          'sortOrder', 0,
+          'options', jsonb_build_array(
+            jsonb_build_object(
+              'name', 'Peynirsiz',
+              'priceDeltaMinor', 0,
+              'isDefault', true,
+              'sortOrder', 0
+            ),
+            jsonb_build_object(
+              'name', 'Peynirli',
+              'priceDeltaMinor', 100,
+              'isDefault', false,
+              'sortOrder', 1
+            )
+          )
+        )
+      ),
+      'allergenSuggestions', jsonb_build_array(
+        jsonb_build_object(
+          'code', 'MILK',
+          'status', 'unknown',
+          'reason', 'Peynir seçeneğini reçete veya tedarikçi belgesiyle doğrulayın.'
+        )
+      ),
+      'warnings', jsonb_build_array('Alerjenleri yayınlamadan önce doğrulayın.')
+    ),
+    'gpt-5.6-luna',
+    120,
+    240,
+    800
+  ) ->> 'status',
+  'ready',
+  'only a strict server-validated AI suggestion becomes reviewable'
+);
+select ok(
+  (
+    select bool_and(allergen ->> 'status' = 'unknown')
+    from public.menu_ai_requests as request,
+      jsonb_array_elements(request.suggestion_json -> 'allergenSuggestions') as allergen
+    where request.client_request_id = 'c6000000-0000-4000-8000-000000000001'
+  ),
+  'AI allergen suggestions remain explicitly unknown before manager review'
+);
+select is(
+  public.publish_menu_ai_draft(
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    (
+      select id
+      from public.menu_ai_requests
+      where client_request_id = 'c6000000-0000-4000-8000-000000000001'
+    ),
+    2,
+    jsonb_build_object(
+      'categoryName', 'Atıştırmalık',
+      'name', 'Trüflü patates kızartması',
+      'description', 'Çıtır patates',
+      'priceMinor', 400,
+      'currencyCode', 'EUR',
+      'taxRateBasisPoints', 0,
+      'isActive', true,
+      'isAvailable', true,
+      'prepTimeMinutes', 8,
+      'translations', jsonb_build_array(
+        jsonb_build_object(
+          'locale', 'tr',
+          'name', 'Trüflü patates kızartması',
+          'description', 'Çıtır patates'
+        ),
+        jsonb_build_object(
+          'locale', 'bg',
+          'name', 'Пържени картофи',
+          'description', null
+        ),
+        jsonb_build_object(
+          'locale', 'en',
+          'name', 'French fries',
+          'description', null
+        )
+      ),
+      'modifierGroups', jsonb_build_array(
+        jsonb_build_object(
+          'name', 'Peynir',
+          'selectionType', 'single',
+          'minimumChoices', 0,
+          'maximumChoices', 1,
+          'isRequired', false,
+          'sortOrder', 0,
+          'options', jsonb_build_array(
+            jsonb_build_object(
+              'name', 'Peynirsiz',
+              'priceDeltaMinor', 0,
+              'isDefault', true,
+              'sortOrder', 0
+            ),
+            jsonb_build_object(
+              'name', 'Peynirli',
+              'priceDeltaMinor', 100,
+              'isDefault', false,
+              'sortOrder', 1
+            )
+          )
+        )
+      ),
+      'confirmedAllergens', '[]'::jsonb
+    )
+  ) ->> 'status',
+  'published',
+  'only an explicit manager-reviewed payload publishes the AI draft'
+);
+select is(
+  (
+    select concat_ws('|', item.name, item.price_minor, category.name)
+    from public.menu_items as item
+    join public.menu_categories as category on category.id = item.category_id
+    where item.organization_id = '25000000-0000-4000-8000-000000000001'
+      and item.branch_id = '35000000-0000-4000-8000-000000000001'
+      and item.name = 'Trüflü patates kızartması'
+  ),
+  'Trüflü patates kızartması|400|Atıştırmalık',
+  'publishing creates the reviewed item and category in the active branch'
+);
+select is(
+  (
+    select count(*)
+    from public.modifier_groups as modifier
+    join public.menu_items as item on item.id = modifier.menu_item_id
+    where item.name = 'Trüflü patates kızartması'
+      and item.branch_id = '35000000-0000-4000-8000-000000000001'
+      and modifier.deleted_at is null
+  ),
+  1::bigint,
+  'the reviewed modifier group is published transactionally'
+);
+select is(
+  (
+    select count(*)
+    from public.modifier_options as option
+    join public.modifier_groups as modifier on modifier.id = option.modifier_group_id
+    join public.menu_items as item on item.id = modifier.menu_item_id
+    where item.name = 'Trüflü patates kızartması'
+      and item.branch_id = '35000000-0000-4000-8000-000000000001'
+      and option.deleted_at is null
+  ),
+  2::bigint,
+  'all reviewed modifier options are published transactionally'
+);
+select is(
+  (
+    select count(*)
+    from public.menu_item_translations as translation
+    join public.menu_items as item on item.id = translation.menu_item_id
+    where item.name = 'Trüflü patates kızartması'
+      and item.branch_id = '35000000-0000-4000-8000-000000000001'
+  ),
+  3::bigint,
+  'the reviewed Turkish, Bulgarian, and English translations are stored'
+);
+select is(
+  (
+    select count(*)
+    from public.menu_item_allergens as item_allergen
+    join public.menu_items as item on item.id = item_allergen.menu_item_id
+    where item.name = 'Trüflü patates kızartması'
+      and item.branch_id = '35000000-0000-4000-8000-000000000001'
+  ),
+  0::bigint,
+  'an unconfirmed AI allergen suggestion is never published'
+);
+select is(
+  (
+    select status
+    from public.menu_ai_requests
+    where client_request_id = 'c6000000-0000-4000-8000-000000000001'
+  ),
+  'published',
+  'the AI audit row records the manager publication decision'
+);
+select throws_ok(
+  $$
+    select public.save_catalog_item(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      null,
+      null,
+      jsonb_build_object(
+        'categoryName', 'Atıştırmalık',
+        'name', '  TRÜFLÜ   PATATES KIZARTMASI ',
+        'description', null,
+        'priceMinor', 400,
+        'currencyCode', 'EUR',
+        'translations', '[]'::jsonb,
+        'modifierGroups', '[]'::jsonb,
+        'confirmedAllergens', '[]'::jsonb
+      )
+    )
+  $$,
+  '23505',
+  'catalog_item_duplicate',
+  'normalized duplicate detection prevents accidental repeated menu items'
+);
+select is(
+  (
+    public.save_catalog_item(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      (
+        select id
+        from public.menu_items
+        where name = 'Trüflü patates kızartması'
+          and branch_id = '35000000-0000-4000-8000-000000000001'
+      ),
+      1,
+      jsonb_build_object(
+        'categoryName', 'Atıştırmalık',
+        'name', 'Trüflü patates kızartması',
+        'description', 'Çıtır patates',
+        'priceMinor', 400,
+        'currencyCode', 'EUR',
+        'isActive', true,
+        'isAvailable', true,
+        'prepTimeMinutes', 8,
+        'translations', '[]'::jsonb,
+        'modifierGroups', '[]'::jsonb,
+        'confirmedAllergens', jsonb_build_array(
+          jsonb_build_object('code', 'MILK', 'presence', 'may_contain')
+        )
+      )
+    ) ->> 'version'
+  )::bigint,
+  2::bigint,
+  'manual manager review can update the versioned catalog item'
+);
+select is(
+  (
+    select concat_ws(
+      '|',
+      allergen.code,
+      item_allergen.presence,
+      item_allergen.source,
+      item_allergen.confirmed_by
+    )
+    from public.menu_item_allergens as item_allergen
+    join public.menu_items as item on item.id = item_allergen.menu_item_id
+    join public.allergens as allergen on allergen.id = item_allergen.allergen_id
+    where item.name = 'Trüflü patates kızartması'
+      and item.branch_id = '35000000-0000-4000-8000-000000000001'
+  ),
+  'MILK|may_contain|manager|15000000-0000-4000-8000-000000000001',
+  'only a manager-confirmed allergen receives a definitive presence and source'
+);
+select is(
+  public.bulk_set_menu_item_availability(
+    '25000000-0000-4000-8000-000000000001',
+    '35000000-0000-4000-8000-000000000001',
+    array[
+      (
+        select id
+        from public.menu_items
+        where name = 'Trüflü patates kızartması'
+          and branch_id = '35000000-0000-4000-8000-000000000001'
+      )
+    ],
+    false
+  ),
+  1,
+  'a manager can bulk-update branch menu availability'
+);
+select is(
+  (
+    select is_available
+    from public.menu_items
+    where name = 'Trüflü patates kızartması'
+      and branch_id = '35000000-0000-4000-8000-000000000001'
+  ),
+  false,
+  'sold-out availability is immediately stored in the shared catalog'
+);
+
+reset role;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"15000000-0000-4000-8000-000000000002","role":"authenticated"}',
+  true
+);
+set local role authenticated;
+select throws_ok(
+  $$
+    select public.reserve_menu_ai_request(
+      '25000000-0000-4000-8000-000000000001',
+      '35000000-0000-4000-8000-000000000001',
+      'c6000000-0000-4000-8000-000000000002',
+      'Yetkisiz ürün taslağı',
+      'gpt-5.6-luna'
+    )
+  $$,
+  '42501',
+  'manager_role_required',
+  'waiters cannot generate or publish AI menu drafts'
 );
 
 select * from finish();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
       "@/contexts/*": ["./src/contexts/*"],
       "@/navigation/*": ["./src/navigation/*"]
     }
-  }
+  },
+  "exclude": ["node_modules", "supabase/functions"]
 }


### PR DESCRIPTION
## Outcome
- replaces the legacy menu UI with a responsive manager/waiter menu hub and flexible item editor
- adds category, translation, modifier, availability, duplicate, and bulk-edit workflows
- adds a quota-controlled Supabase Edge Function using strict OpenAI Structured Outputs
- keeps AI output as an auditable draft until a manager reviews and explicitly confirms it
- never promotes AI allergen suggestions beyond unknown without a manager-confirmed source

## Validation
- npm run verify:full
- 40 Jest suites / 182 tests
- 5 Playwright Chromium flows
- 111 pgTAP assertions in the database suite

## Stack
Base: #54

Closes #27